### PR TITLE
Fixed typo in f32a ISA doc

### DIFF
--- a/docs/f32a.md
+++ b/docs/f32a.md
@@ -199,10 +199,10 @@ Most of the instructions drop the carry flag. Exceptions: `add`, `dup`.
 
 - **R-Pop**
     - **Syntax:** `r>`
-    - **Description:** Move the top value of the return stack to the data stack.
-    - **Operation:** `dataStack.push(returnStack.pop())`
+    - **Description:** Move the top value of the data stack to the return stack.
+    - **Operation:** `returnStack.push(dataStack.pop())`
 
 - **R-Push**
     - **Syntax:** `>r`
-    - **Description:** Move the top value of the data stack to the return stack.
-    - **Operation:** `returnStack.push(dataStack.pop())`
+    - **Description:** Move the top value of the return stack to the data stack.
+    - **Operation:** `dataStack.push(returnStack.pop())`

--- a/docs/f32a.md
+++ b/docs/f32a.md
@@ -197,12 +197,12 @@ Most of the instructions drop the carry flag. Exceptions: `add`, `dup`.
 
 ### Register Manipulation Instructions
 
-- **R-Pop**
+- **R-Push**
     - **Syntax:** `r>`
     - **Description:** Move the top value of the data stack to the return stack.
     - **Operation:** `returnStack.push(dataStack.pop())`
 
-- **R-Push**
+- **R-Pop**
     - **Syntax:** `>r`
     - **Description:** Move the top value of the return stack to the data stack.
     - **Operation:** `dataStack.push(returnStack.pop())`


### PR DESCRIPTION
This PR fixes the typo provided in the created issue [(link)](https://github.com/ryukzak/wrench/issues/46).