### PR TITLE
Add clc instruction to acc32 docs.

### DIFF
--- a/docs/acc32.md
+++ b/docs/acc32.md
@@ -94,6 +94,11 @@ Instruction size: 1 byte for opcode, 4 bytes for absolute operand, 2 bytes for r
     - **Description:** Clear the overflow flag.
     - **Operation:** `overflow <- 0`
 
+- **Clear Carry**
+    - **Syntax:** `clc`
+    - **Description:** Clear the carry flag.
+    - **Operation:** `carry <- 0`
+
 ### Bitwise Instructions
 
 - **Shift Left**


### PR DESCRIPTION
The docs for acc32 architecture do not specify anything about the clc instruction but it is present in the source code for this ISA and works in version 0.0.4.0.