### PR TITLE
Reorder operations in f32a.md documentation

### DIFF
--- a/docs/f32a.md
+++ b/docs/f32a.md
@@ -130,9 +130,10 @@ Most of the instructions drop the carry flag. Exceptions: `add`, `dup`.
         2. `if A[31] then S[0] <- 1`
         3. `A <- A << 1`
         4. `T <- T << 1`
-        5. `if S >= mem[B] then T[0] <- 1`
-        6. `if S >= mem[B] then S <- S - mem[B]`
-    - [**Python example**](https://github.com/Chousik/wrench/blob/master/example/step-by-step-div.py)
+        5. `if S >= mem[B] then`
+            - `S <- S - mem[B]`
+            - `T[0] <- 1`
+    - [**Python example**](https://github.com/ryukzak/wrench/blob/master/example/step-by-step-div.py)
 
 - **Left Shift**
     - **Syntax:** `2*`


### PR DESCRIPTION
The issue:
If S >= mem[B] is met, mem[B] is subtracted from S. After this subtraction, S is guaranteed to be less than mem[B]. Therefore, the condition (if S >= mem[B]) will never evaluate to true, meaning the quotient bit (T[0] <- 1) would never be set.

The Fix:
Swap the subtraction step and the setting step of T[0]. The check for S >= mem[B] and the setting of the T[0] bit must be done while S has not yet changed before the subtraction.