### PR TITLE
Fix limits for brainfuck_interpreter

### DIFF
--- a/script/testcases/complex.py
+++ b/script/testcases/complex.py
@@ -539,7 +539,7 @@ TEST_CASES["brainfuck_interpreter"] = TestCase(
             "+++++[>+++++[>++<-]<-]>>.\n",
             "2",
             "",
-            limit=5000,
+            limit=7000,
         ),
         String2String(
             "+++++[>+++++<-]>[\n",


### PR DESCRIPTION
Increased the limits for m68k brainfuck_interpreter test 17, which were not enough
author: Мельник Фёдор Александрович