### PR TITLE
fix: handle .org correctly inside .data section

### DIFF
--- a/src/wrench/Wrench/Translator/Parser/Misc.hs
+++ b/src/wrench/Wrench/Translator/Parser/Misc.hs
@@ -47,14 +47,10 @@ sectionItems = mapMaybe $ \case
 
 sectionOrg :: [SectionItem i] -> Maybe Int
 sectionOrg items =
-    let orgs =
-            mapMaybe
-                ( \case
-                    Org i -> Just i
-                    _ -> Nothing
-                )
-                items
-     in listToMaybe orgs
+    case [i | Org i <- items] of
+        [] -> Nothing
+        [x] -> Just x
+        (_ : _ : _) -> error "error: multiple .org directives not allowed"
 
 orgDirective :: String -> Parser Int
 orgDirective cstart = do


### PR DESCRIPTION
Previously, multiple .org directives inside a `.data` section were not handled correctly, causing all values to be placed at the first given `.org` position.
This fix ensures that each `.org` directive is correctly handled and values are placed at their intended offsets.

Example:
```asm
.data
param1:     .byte  0xAA
param2:     .byte  0xBB
.org 0x03
param3:     .byte  0xCC
.org 0x05
param4:     .byte  0xDD
```

|            |`0x00`|`0x01`|`0x02`|`0x03`|`0x04`|`0x05`|`0x06`|`0x07`|`0x08`|
|------------|------|------|------|------|------|------|------|------|------|
| Before fix |      |      |      |      |      |`0xAA`|`0xBB`|`0xCC`|`0xDD`|
| After fix  |`0xAA`|`0xBB`|      |`0xCC`|      |`0xDD`|      |      |      |

I also believe a similar fix might be needed for `.text`, but I am not completely certain; if necessary, the PR can be updated to include that.