### PR TITLE
fix(m68k): compute carry flag on subtraction (subExt)

### DIFF
--- a/src/wrench/Wrench/Machine/Types.hs
+++ b/src/wrench/Wrench/Machine/Types.hs
@@ -122,7 +122,7 @@ subExt :: (MachineWord w) => w -> w -> Ext w
 subExt x y =
     let result = x - y
         overflow = ((x > 0 && y < 0 && result < 0) || (x < 0 && y > 0 && result > 0))
-        carry = False
+        carry = fromSign x < fromSign y
      in Ext{value = result, overflow, carry}
 
 mulExt :: (MachineWord w) => w -> w -> Ext w

--- a/test/Wrench/Isa/M68k/Test.hs
+++ b/test/Wrench/Isa/M68k/Test.hs
@@ -35,27 +35,30 @@ tests =
             let State{dataRegs} = simulate "mul.b D1, D0" st0{dataRegs = insert D1 10 $ insert D0 10 dataRegs0}
              in (dataRegs !? D0) @?= Just 100
         , testCase "Compare operations" $ do
-            let State{dataRegs, zFlag, nFlag} =
+            let State{dataRegs, zFlag, nFlag, cFlag} =
                     simulate "cmp.l D1, D0" st0{dataRegs = insert D1 5 $ insert D0 5 dataRegs0}
              in do
                     (dataRegs !? D0) @?= Just 5
                     (dataRegs !? D1) @?= Just 5
                     zFlag @?= True
                     nFlag @?= False
-            let State{dataRegs, zFlag, nFlag} =
+                    cFlag @?= False
+            let State{dataRegs, zFlag, nFlag, cFlag} =
                     simulate "cmp.l D1, D0" st0{dataRegs = insert D1 10 $ insert D0 5 dataRegs0}
              in do
                     (dataRegs !? D0) @?= Just 5
                     (dataRegs !? D1) @?= Just 10
                     zFlag @?= False
                     nFlag @?= True
-            let State{dataRegs, zFlag, nFlag} =
+                    cFlag @?= True
+            let State{dataRegs, zFlag, nFlag, cFlag} =
                     simulate "cmp.l D1, D0" st0{dataRegs = insert D1 3 $ insert D0 5 dataRegs0}
              in do
                     (dataRegs !? D0) @?= Just 5
                     (dataRegs !? D1) @?= Just 3
                     zFlag @?= False
                     nFlag @?= False
+                    cFlag @?= False
             let State{dataRegs, zFlag} =
                     simulate "cmp.b D1, D0" st0{dataRegs = insert D1 0x100 $ insert D0 0 dataRegs0}
              in do

--- a/test/Wrench/Machine/Types/Test.hs
+++ b/test/Wrench/Machine/Types/Test.hs
@@ -25,6 +25,12 @@ tests =
             subExt (minBound :: Int32) 1 @?= Ext{value = maxBound, overflow = True, carry = False}
         , testCase "subExt: minBound - maxBound = 1, overflow, carry" $ do
             subExt (minBound :: Int32) maxBound @?= Ext{value = 1, overflow = True, carry = False}
+        , testCase "subExt: 0 - 1 = -1, no overflow, carry (borrow)" $ do
+            subExt (0 :: Int32) 1 @?= Ext{value = -1, overflow = False, carry = True}
+        , testCase "subExt: 1 - 2 = -1, no overflow, carry (borrow)" $ do
+            subExt (1 :: Int32) 2 @?= Ext{value = -1, overflow = False, carry = True}
+        , testCase "subExt: 5 - 3 = 2, no overflow, no carry" $ do
+            subExt (5 :: Int32) 3 @?= Ext{value = 2, overflow = False, carry = False}
         , testCase "mulExt: 2 * 3 = 6, no overflow, no carry" $ do
             mulExt (2 :: Int32) 3 @?= Ext{value = 6, overflow = False, carry = False}
         , testCase "mulExt: maxBound * 2 = -2, overflow, carry" $ do


### PR DESCRIPTION
## Summary

- `subExt` always returned `carry = False`, breaking `bcc`/`bcs` branches after `CMP` and `SUB` instructions
- Now computes unsigned borrow: `carry = fromSign x < fromSign y`
- Added `subExt` unit tests for borrow and no-borrow cases
- Added `cFlag` assertions to existing M68k CMP tests

## Test plan

- [x] All tests pass (`stack test`)
- [x] `make test-examples` clean