### PR TITLE
fix(risc-iv): reorder register parser so s10/s11 are not shadowed by s1

### DIFF
--- a/src/wrench/Wrench/Isa/RiscIv.hs
+++ b/src/wrench/Wrench/Isa/RiscIv.hs
@@ -191,6 +191,8 @@ register =
         , string "t2" >> return T2
         , string "s0" >> return S0Fp
         , string "fp" >> return S0Fp
+        , string "s10" >> return S10
+        , string "s11" >> return S11
         , string "s1" >> return S1
         , string "a0" >> return A0
         , string "a1" >> return A1
@@ -208,8 +210,6 @@ register =
         , string "s7" >> return S7
         , string "s8" >> return S8
         , string "s9" >> return S9
-        , string "s10" >> return S10
-        , string "s11" >> return S11
         , string "t3" >> return T3
         , string "t4" >> return T4
         , string "t5" >> return T5

--- a/test/Wrench/Isa/RiscIv/Test.hs
+++ b/test/Wrench/Isa/RiscIv/Test.hs
@@ -4,16 +4,25 @@ import Data.Default
 import Relude
 import Relude.Extra
 import Test.Tasty (TestTree, testGroup)
-import Test.Tasty.HUnit (testCase, (@?=))
+import Test.Tasty.HUnit (assertBool, testCase, (@?=))
+import Text.Megaparsec (parse)
 import Wrench.Isa.RiscIv
 import Wrench.Machine.Memory
 import Wrench.Machine.Types
+import Wrench.Translator.Parser.Types (MnemonicParser (..))
+import Wrench.Translator.Types (Ref)
 
 tests :: TestTree
 tests =
     testGroup
         "ISA"
-        [ testCase "Addi: A0(5) + 3 = 8" $ do
+        [ testCase "Parse register s10" $ do
+            assertBool "s10 should parse" $ isRight (translate "add s10, s10, s10")
+        , testCase "Parse register s11" $ do
+            assertBool "s11 should parse" $ isRight (translate "add s11, s11, s11")
+        , testCase "Parse register s1 (not confused with s10/s11)" $ do
+            assertBool "s1 should parse" $ isRight (translate "add s1, s1, s1")
+        , testCase "Addi: A0(5) + 3 = 8" $ do
             runInstruction Addi{rd = A1, rs1 = A0, k = 3} [(A0, 5)] A1 @?= 8
         , testCase "Srl: A0(16) >> A1(2) = 4" $ do
             runInstruction Srl{rd = A2, rs1 = A0, rs2 = A1} [(A0, 16), (A1, 2)] A2 @?= 4
@@ -53,3 +62,9 @@ runInstruction instr initRegs result = do
     let st = initialState 0 (fromList initRegs) instr
         State{regs} = execState instructionStep st
     fromMaybe (error "Register not found") (regs !? result)
+
+translate :: String -> Either String (Isa Int32 (Ref Int32))
+translate code =
+    case parse mnemonic "-" (code <> "\n") of
+        Left err -> Left $ show err
+        Right m -> Right m


### PR DESCRIPTION
## Summary

- `string "s1"` in the `choice` parser matched before `string "s10"`/`string "s11"`, making registers s10 and s11 unparseable
- Moved s10/s11 before s1 in the choice list
- Added parser tests for s10, s11, and s1

## Test plan

- [x] All tests pass (`stack test`)
- [x] New parser tests verify s10, s11, and s1 all parse correctly