### PR TITLE
fix(risc-iv): discard writes to zero register

### DIFF
--- a/src/wrench/Wrench/Isa/RiscIv.hs
+++ b/src/wrench/Wrench/Isa/RiscIv.hs
@@ -357,6 +357,7 @@ getReg r = do
             raiseInternalError $ "wrong register: " <> show r
             return def
 
+setReg Zero _ = return ()
 setReg r value = modify $ \st@State{regs} -> st{regs = insert r value regs}
 
 getWord addr = do

--- a/test/Wrench/Isa/RiscIv/Test.hs
+++ b/test/Wrench/Isa/RiscIv/Test.hs
@@ -22,6 +22,8 @@ tests =
             assertBool "s11 should parse" $ isRight (translate "add s11, s11, s11")
         , testCase "Parse register s1 (not confused with s10/s11)" $ do
             assertBool "s1 should parse" $ isRight (translate "add s1, s1, s1")
+        , testCase "Zero register is hardwired to 0" $ do
+            runInstruction Addi{rd = Zero, rs1 = Zero, k = 42} [(Zero, 0)] Zero @?= 0
         , testCase "Addi: A0(5) + 3 = 8" $ do
             runInstruction Addi{rd = A1, rs1 = A0, k = 3} [(A0, 5)] A1 @?= 8
         , testCase "Srl: A0(16) >> A1(2) = 4" $ do


### PR DESCRIPTION
## Summary

- In RISC-V, x0 is hardwired to 0 — writes are silently discarded
- Added `setReg Zero _ = return ()` to ignore writes to the zero register
- Added test verifying `addi zero, zero, 42` leaves zero as 0

## Test plan

- [x] All tests pass (`stack test`)