### PR TITLE
fix(m68k): clear V and C flags on MOVE, NOT, AND, OR, XOR

### DIFF
--- a/src/wrench/Wrench/Isa/M68k.hs
+++ b/src/wrench/Wrench/Isa/M68k.hs
@@ -647,14 +647,17 @@ instance (MachineWord w) => Machine (MachineState (IoMem (Isa w w) w) w) (Isa w 
         where
             branch addr True = setPc $ fromEnum addr
             branch _addr False = nextPc
+            clearVC = modify $ \st -> st{vFlag = False, cFlag = False}
             wordCmd1 src dst f = do
                 a <- fetchWord src
                 storeWord dst $ f a
+                clearVC
                 nextPc
             wordCmd2 src dst f = do
                 a <- fetchWord dst
                 b <- fetchWord src
                 storeWord dst $ f a b
+                clearVC
                 nextPc
             wordCmd2Ext src dst f = do
                 a <- fetchWord dst
@@ -672,11 +675,13 @@ instance (MachineWord w) => Machine (MachineState (IoMem (Isa w w) w) w) (Isa w 
             byteCmd1 src dst f = do
                 a <- fetchByte src
                 storeByte dst $ f a
+                clearVC
                 nextPc
             byteCmd2 src dst f = do
                 a <- fetchByte dst
                 b <- fetchByte src
                 storeByte dst $ f a b
+                clearVC
                 nextPc
             byteCmd2Ext src dst f = do
                 a <- fetchByte dst

--- a/test/Wrench/Isa/M68k/Test.hs
+++ b/test/Wrench/Isa/M68k/Test.hs
@@ -65,6 +65,40 @@ tests =
                     (dataRegs !? D0) @?= Just 0
                     (dataRegs !? D1) @?= Just 0x100
                     zFlag @?= True
+        , testCase "Logic ops clear V and C flags" $ do
+            let State{vFlag, cFlag} =
+                    simulate
+                        "and.l D1, D0"
+                        st0
+                            { dataRegs = insert D1 0xFF $ insert D0 0xFF dataRegs0
+                            , vFlag = True
+                            , cFlag = True
+                            }
+             in do
+                    vFlag @?= False
+                    cFlag @?= False
+            let State{vFlag, cFlag} =
+                    simulate
+                        "move.l D1, D0"
+                        st0
+                            { dataRegs = insert D1 1 dataRegs0
+                            , vFlag = True
+                            , cFlag = True
+                            }
+             in do
+                    vFlag @?= False
+                    cFlag @?= False
+            let State{vFlag, cFlag} =
+                    simulate
+                        "not.l D0"
+                        st0
+                            { dataRegs = insert D0 0 dataRegs0
+                            , vFlag = True
+                            , cFlag = True
+                            }
+             in do
+                    vFlag @?= False
+                    cFlag @?= False
         , testCase "Translator" $ do
             translate "movea.l D0, A0" @?= Right (MoveA Long (DirectDataReg D0) (DirectAddrReg A0))
             translate "move.l 12, D0" @?= Right (Move Long (Immediate $ ValueR id 12) (DirectDataReg D0))


### PR DESCRIPTION
## Summary

- Per M68k spec, MOVE, NOT, AND, OR, XOR set N/Z based on result and clear V and C
- Added `clearVC` after `storeWord`/`storeByte` in `wordCmd1`, `wordCmd2`, `byteCmd1`, `byteCmd2`
- Added tests verifying V/C are cleared after AND, MOVE, and NOT when previously set

## Test plan

- [x] All tests pass (`stack test`)