### PR TITLE
fix(m68k): set carry flag on shift instructions to last bit shifted out

### DIFF
--- a/src/wrench/Wrench/Isa/M68k.hs
+++ b/src/wrench/Wrench/Isa/M68k.hs
@@ -16,7 +16,7 @@ module Wrench.Isa.M68k (
     AddrReg (..),
 ) where
 
-import Data.Bits (complement, shiftL, shiftR, (.&.), (.|.))
+import Data.Bits (complement, shiftL, shiftR, testBit, (.&.), (.|.))
 import Data.Default (Default, def)
 import Data.Text qualified as T
 import Relude
@@ -597,14 +597,14 @@ instance (MachineWord w) => Machine (MachineState (IoMem (Isa w w) w) w) (Isa w 
                         , cFlag = carry
                         }
                 nextPc
-            Asl{mode = Long, src, dst} -> wordCmd2 src dst (\d s -> shiftL d (fromEnum s))
-            Asl{mode = Byte, src, dst} -> byteCmd2 src dst (\d s -> shiftL d (fromEnum s))
-            Asr{mode = Long, src, dst} -> wordCmd2 src dst (\d s -> shiftR d (fromEnum s))
-            Asr{mode = Byte, src, dst} -> byteCmd2 src dst (\d s -> shiftR d (fromEnum s))
-            Lsl{mode = Long, src, dst} -> wordCmd2 src dst lShiftL
-            Lsl{mode = Byte, src, dst} -> byteCmd2 src dst lShiftL
-            Lsr{mode = Long, src, dst} -> wordCmd2 src dst lShiftR
-            Lsr{mode = Byte, src, dst} -> byteCmd2 src dst lShiftR
+            Asl{mode = Long, src, dst} -> wordShift src dst (\d s -> shiftL d (fromEnum s)) (\n -> 32 - n)
+            Asl{mode = Byte, src, dst} -> byteShift src dst (\d s -> shiftL d (fromEnum s)) (\n -> 8 - n)
+            Asr{mode = Long, src, dst} -> wordShift src dst (\d s -> shiftR d (fromEnum s)) (\n -> n - 1)
+            Asr{mode = Byte, src, dst} -> byteShift src dst (\d s -> shiftR d (fromEnum s)) (\n -> n - 1)
+            Lsl{mode = Long, src, dst} -> wordShift src dst lShiftL (\n -> 32 - n)
+            Lsl{mode = Byte, src, dst} -> byteShift src dst lShiftL (\n -> 8 - n)
+            Lsr{mode = Long, src, dst} -> wordShift src dst lShiftR (\n -> n - 1)
+            Lsr{mode = Byte, src, dst} -> byteShift src dst lShiftR (\n -> n - 1)
             Jmp{ref} -> branch ref True
             Bcc{ref} -> get >>= branch ref . not . cFlag
             Bcs{ref} -> get >>= branch ref . cFlag
@@ -682,6 +682,24 @@ instance (MachineWord w) => Machine (MachineState (IoMem (Isa w w) w) w) (Isa w 
                 b <- fetchByte src
                 storeByte dst $ f a b
                 clearVC
+                nextPc
+            wordShift src dst f carryBit = do
+                a <- fetchWord dst
+                b <- fetchWord src
+                let count = fromEnum b
+                    result = f a b
+                    carry = count > 0 && testBit a (carryBit count)
+                storeWord dst result
+                modify $ \st -> st{vFlag = False, cFlag = carry}
+                nextPc
+            byteShift src dst f carryBit = do
+                a <- fetchByte dst
+                b <- fetchByte src
+                let count = fromEnum b
+                    result = f a b
+                    carry = count > 0 && testBit a (carryBit count)
+                storeByte dst result
+                modify $ \st -> st{vFlag = False, cFlag = carry}
                 nextPc
             byteCmd2Ext src dst f = do
                 a <- fetchByte dst

--- a/src/wrench/Wrench/Isa/M68k.hs
+++ b/src/wrench/Wrench/Isa/M68k.hs
@@ -597,14 +597,14 @@ instance (MachineWord w) => Machine (MachineState (IoMem (Isa w w) w) w) (Isa w 
                         , cFlag = carry
                         }
                 nextPc
-            Asl{mode = Long, src, dst} -> wordShift src dst (\d s -> shiftL d (fromEnum s)) (\n -> 32 - n)
-            Asl{mode = Byte, src, dst} -> byteShift src dst (\d s -> shiftL d (fromEnum s)) (\n -> 8 - n)
-            Asr{mode = Long, src, dst} -> wordShift src dst (\d s -> shiftR d (fromEnum s)) (\n -> n - 1)
-            Asr{mode = Byte, src, dst} -> byteShift src dst (\d s -> shiftR d (fromEnum s)) (\n -> n - 1)
-            Lsl{mode = Long, src, dst} -> wordShift src dst lShiftL (\n -> 32 - n)
-            Lsl{mode = Byte, src, dst} -> byteShift src dst lShiftL (\n -> 8 - n)
-            Lsr{mode = Long, src, dst} -> wordShift src dst lShiftR (\n -> n - 1)
-            Lsr{mode = Byte, src, dst} -> byteShift src dst lShiftR (\n -> n - 1)
+            Asl{mode = Long, src, dst} -> wordShift src dst (\d s -> shiftL d (fromEnum s)) (32 -)
+            Asl{mode = Byte, src, dst} -> byteShift src dst (\d s -> shiftL d (fromEnum s)) (8 -)
+            Asr{mode = Long, src, dst} -> wordShift src dst (\d s -> shiftR d (fromEnum s)) (subtract 1)
+            Asr{mode = Byte, src, dst} -> byteShift src dst (\d s -> shiftR d (fromEnum s)) (subtract 1)
+            Lsl{mode = Long, src, dst} -> wordShift src dst lShiftL (32 -)
+            Lsl{mode = Byte, src, dst} -> byteShift src dst lShiftL (8 -)
+            Lsr{mode = Long, src, dst} -> wordShift src dst lShiftR (subtract 1)
+            Lsr{mode = Byte, src, dst} -> byteShift src dst lShiftR (subtract 1)
             Jmp{ref} -> branch ref True
             Bcc{ref} -> get >>= branch ref . not . cFlag
             Bcs{ref} -> get >>= branch ref . cFlag

--- a/test/Wrench/Isa/M68k/Test.hs
+++ b/test/Wrench/Isa/M68k/Test.hs
@@ -307,6 +307,18 @@ tests =
              in do
                     pc @?= 0x1211100F
                     (addrRegs !? A7) @?= Just 0x13
+        , testCase "Shift carry flag" $ do
+            -- LSR: shift right, last bit shifted out is bit 0
+            let State{cFlag} =
+                    simulate "lsr.l D1, D0" st0{dataRegs = insert D1 1 $ insert D0 3 dataRegs0}
+             in cFlag @?= True -- 3 = ...11, shifting right 1, bit 0 = 1
+            let State{cFlag} =
+                    simulate "lsr.l D1, D0" st0{dataRegs = insert D1 1 $ insert D0 2 dataRegs0}
+             in cFlag @?= False -- 2 = ...10, shifting right 1, bit 0 = 0
+            -- ASL: shift left, last bit shifted out is bit 31
+            let State{cFlag} =
+                    simulate "asl.l D1, D0" st0{dataRegs = insert D1 1 $ insert D0 minBound dataRegs0}
+             in cFlag @?= True -- minBound has bit 31 set
         , testCase "LINK and UNLK operations" $ do
             let State{addrRegs, mem} =
                     simulate


### PR DESCRIPTION
## Summary

- M68k shift instructions (ASL, ASR, LSL, LSR) now correctly set the carry flag to the last bit shifted out instead of always clearing it
- Added dedicated `wordShift`/`byteShift` helpers that compute carry from the original value and shift count
- V flag cleared on all shifts per M68k spec

## Test plan

- [x] All tests pass (`stack test`)
- [x] New shift carry flag tests cover LSR carry=1, LSR carry=0, and ASL carry=1