### PR TITLE
fix(risc-iv): mask shift amounts to lower 5 bits per RISC-V spec

### DIFF
--- a/src/wrench/Wrench/Isa/RiscIv.hs
+++ b/src/wrench/Wrench/Isa/RiscIv.hs
@@ -443,9 +443,9 @@ instance (MachineWord w) => Machine (MachineState (IoMem (Isa w w) w) w) (Isa w 
                     )
             Div{rd, rs1, rs2} -> rOperation rs1 rs2 rd id id div
             Rem{rd, rs1, rs2} -> rOperation rs1 rs2 rd id id rem
-            Sll{rd, rs1, rs2} -> rOperation rs1 rs2 rd id id (\r1 r2 -> r1 `shiftL` fromEnum r2)
-            Srl{rd, rs1, rs2} -> rOperation rs1 rs2 rd id id lShiftR
-            Sra{rd, rs1, rs2} -> rOperation rs1 rs2 rd id id (\r1 r2 -> r1 `shiftR` fromEnum r2)
+            Sll{rd, rs1, rs2} -> rOperation rs1 rs2 rd id id (\r1 r2 -> r1 `shiftL` (fromEnum r2 .&. 0x1F))
+            Srl{rd, rs1, rs2} -> rOperation rs1 rs2 rd id id (\r1 r2 -> lShiftR r1 (r2 .&. 0x1F))
+            Sra{rd, rs1, rs2} -> rOperation rs1 rs2 rd id id (\r1 r2 -> r1 `shiftR` (fromEnum r2 .&. 0x1F))
             And{rd, rs1, rs2} -> rOperation rs1 rs2 rd id id (.&.)
             Or{rd, rs1, rs2} -> rOperation rs1 rs2 rd id id (.|.)
             Xor{rd, rs1, rs2} -> rOperation rs1 rs2 rd id id xor

--- a/test/Wrench/Isa/RiscIv/Test.hs
+++ b/test/Wrench/Isa/RiscIv/Test.hs
@@ -26,6 +26,8 @@ tests =
             runInstruction Addi{rd = Zero, rs1 = Zero, k = 42} [(Zero, 0)] Zero @?= 0
         , testCase "Addi: A0(5) + 3 = 8" $ do
             runInstruction Addi{rd = A1, rs1 = A0, k = 3} [(A0, 5)] A1 @?= 8
+        , testCase "Sll masks shift amount to 5 bits" $ do
+            runInstruction Sll{rd = A2, rs1 = A0, rs2 = A1} [(A0, 1), (A1, 33)] A2 @?= 2
         , testCase "Srl: A0(16) >> A1(2) = 4" $ do
             runInstruction Srl{rd = A2, rs1 = A0, rs2 = A1} [(A0, 16), (A1, 2)] A2 @?= 4
         , testCase "Sll: A0(3) << A1(2) = 12" $ do


### PR DESCRIPTION
## Summary

- RISC-V spec requires shift amounts masked to lower 5 bits (for RV32)
- Applied `.&. 0x1F` to shift amounts in SLL, SRL, SRA
- Added test: `sll` with shift amount 33 produces same result as shift by 1

## Test plan

- [x] All tests pass (`stack test`)