### PR TITLE
feat: show wrench version on report page with mismatch warning

### DIFF
--- a/src/wrench-serv/Main.hs
+++ b/src/wrench-serv/Main.hs
@@ -239,7 +239,8 @@ getReport conf@Config{cStoragePath} cookie guid = do
 versionWarning :: Text -> Text
 versionWarning reportVer
     | reportVer == wrenchVersion = ""
-    | otherwise = " <span class=\"text-[var(--c-orange)]\">[WARNING: current wrench version is " <> escapeHtml wrenchVersion <> "]</span>"
+    | otherwise =
+        " <span class=\"text-[var(--c-orange)]\">[WARNING: current wrench version is " <> escapeHtml wrenchVersion <> "]</span>"
 
 redirectToForm :: Handler (Headers '[Header "Location" Text] NoContent)
 redirectToForm = throwError $ err301{errHeaders = [("Location", "/submit-form")]}

--- a/src/wrench-serv/Main.hs
+++ b/src/wrench-serv/Main.hs
@@ -207,6 +207,8 @@ getReport conf@Config{cStoragePath} cookie guid = do
                 , ("{{comment}}", escapeHtml commentContent)
                 , ("{{status}}", escapeHtml status)
                 , ("{{test_cases_status}}", escapeHtml testCaseStatus)
+                , ("{{report_wrench_version}}", escapeHtml reportWrenchVersion)
+                , ("{{version_warning}}", versionWarning reportWrenchVersion)
                 ]
 
     let renderTemplate =
@@ -233,6 +235,11 @@ getReport conf@Config{cStoragePath} cookie guid = do
                 }
     liftIO $ trackEvent conf event
     return $ addHeader (trackCookie track) $ toHtmlRaw renderTemplate
+
+versionWarning :: Text -> Text
+versionWarning reportVer
+    | reportVer == wrenchVersion = ""
+    | otherwise = " <span class=\"text-[var(--c-orange)]\">[WARNING: current wrench version is " <> escapeHtml wrenchVersion <> "]</span>"
 
 redirectToForm :: Handler (Headers '[Header "Location" Text] NoContent)
 redirectToForm = throwError $ err301{errHeaders = [("Location", "/submit-form")]}

--- a/static/result.html
+++ b/static/result.html
@@ -138,15 +138,12 @@
       <div class="flex-1 mt-6 min-w-[300px] max-w-[50%]">
         <div>
           <div>
-            <!-- prettier-ignore -->
             <p class="text-[var(--c-grey)] text-left">
             /* variant: {{variant}} */
           </p>
-            <!-- prettier-ignore -->
             <p class="text-[var(--c-grey)] text-left">
             /* author: {{name}} */
           </p>
-            <!-- prettier-ignore -->
             <p class="mb-6 text-[var(--c-grey)] text-left">
             /* wrench: {{report_wrench_version}} */{{version_warning}}
           </p>

--- a/static/result.html
+++ b/static/result.html
@@ -143,8 +143,12 @@
             /* variant: {{variant}} */
           </p>
             <!-- prettier-ignore -->
-            <p class="mb-6 text-[var(--c-grey)] text-left">
+            <p class="text-[var(--c-grey)] text-left">
             /* author: {{name}} */
+          </p>
+            <!-- prettier-ignore -->
+            <p class="mb-6 text-[var(--c-grey)] text-left">
+            /* wrench: {{report_wrench_version}} */{{version_warning}}
           </p>
           </div>
           <div>


### PR DESCRIPTION
## Summary

- Display the wrench version used for simulation on the report page (next to variant and author)
- Show an orange warning when the report's version differs from the current server version

Closes #103

## Test plan

- [x] All tests pass (`stack test`)