### PR TITLE
fix: ISA documentation and implementation
    corrections

### DIFF
--- a/docs/acc32.md
+++ b/docs/acc32.md
@@ -72,12 +72,12 @@ Instruction size: 1 byte for opcode, 4 bytes for absolute operand, 2 bytes for r
 - **Subtract**
     - **Syntax:** `sub <address>`
     - **Description:** Subtract a value from a specific address from the accumulator.
-    - **Operation:** `acc <- acc - mem[<address>]` and set `V` flags.
+    - **Operation:** `acc <- acc - mem[<address>]` and set `C` and `V` flags.
 
 - **Multiply**
     - **Syntax:** `mul <address>`
     - **Description:** Multiply the accumulator by a value from a specific address.
-    - **Operation:** `acc <- acc * mem[<address>]` and set `V` flags.
+    - **Operation:** `acc <- acc * mem[<address>]` and set `C` and `V` flags.
 
 - **Divide**
     - **Syntax:** `div <address>`

--- a/docs/acc32.md
+++ b/docs/acc32.md
@@ -28,9 +28,9 @@ Instruction size: 1 byte for opcode, 4 bytes for absolute operand, 2 bytes for r
 ### Data Movement Instructions
 
 - **Load Immediate**
-    - **Syntax:** `load_imm <address>`
+    - **Syntax:** `load_imm <value>`
     - **Description:** Load an immediate value into the accumulator.
-    - **Operation:** `acc <- <address>`
+    - **Operation:** `acc <- <value>`
 
 - **Load**
     - **Syntax:** `load <offset>`

--- a/docs/f32a.md
+++ b/docs/f32a.md
@@ -41,7 +41,7 @@ Extended Arithmetic Mode (EAM) is a mode that allows us to add with carry bit. S
 
 ### Carry Flag
 
-Most of the instructions drop the carry flag. Exceptions: `add`, `dup`.
+Most of the instructions drop (clear) the carry flag. Specifically, any instruction that pushes to the data stack clears the carry flag as a side effect. Exceptions: `add` (sets carry flag based on overflow), `dup` (preserves carry flag).
 
 ### Data Movement Instructions
 

--- a/docs/m68k.md
+++ b/docs/m68k.md
@@ -46,7 +46,9 @@ Instruction sizes vary depending on the operation mode and addressing modes used
 M68k instructions can operate on data of different sizes:
 
 - **Byte (`.b`):** 8-bit operations
-- **Long (`.l`):** 32-bit operations (default)
+- **Long (`.l`):** 32-bit operations
+
+The size suffix is mandatory and must be explicitly specified for all instructions that support it.
 
 Example: `add.b D0, D1` operates on the least significant byte of D0 and D1.
 
@@ -88,7 +90,7 @@ The M68k ISA supports the following addressing modes:
 
 - **Move**
     - **Syntax:** `move.<size> <source>, <destination>`
-    - **Description:** Move data from the source to the destination.
+    - **Description:** Move data from the source to the destination. Sets N and Z flags based on the result, clears V and C flags.
     - **Operation:** `<destination> <- <source>`
     - **Examples:**
 
@@ -121,7 +123,7 @@ The M68k ISA supports the following addressing modes:
 
 - **Not**
     - **Syntax:** `not.<size> <destination>`
-    - **Description:** Bitwise NOT the destination.
+    - **Description:** Bitwise NOT the destination. Sets N and Z flags based on the result, clears V and C flags.
     - **Operation:** `<destination> <- ~<destination>`
     - **Examples:**
 
@@ -132,7 +134,7 @@ The M68k ISA supports the following addressing modes:
 
 - **And**
     - **Syntax:** `and.<size> <source>, <destination>`
-    - **Description:** Bitwise AND the source with the destination.
+    - **Description:** Bitwise AND the source with the destination. Sets N and Z flags based on the result, clears V and C flags.
     - **Operation:** `<destination> <- <destination> & <source>`
     - **Examples:**
 
@@ -143,7 +145,7 @@ The M68k ISA supports the following addressing modes:
 
 - **Or**
     - **Syntax:** `or.<size> <source>, <destination>`
-    - **Description:** Bitwise OR the source with the destination.
+    - **Description:** Bitwise OR the source with the destination. Sets N and Z flags based on the result, clears V and C flags.
     - **Operation:** `<destination> <- <destination> | <source>`
     - **Examples:**
 
@@ -154,7 +156,7 @@ The M68k ISA supports the following addressing modes:
 
 - **Exclusive Or**
     - **Syntax:** `xor.<size> <source>, <destination>`
-    - **Description:** Bitwise XOR the source with the destination.
+    - **Description:** Bitwise XOR the source with the destination. Sets N and Z flags based on the result, clears V and C flags.
     - **Operation:** `<destination> <- <destination> ^ <source>`
     - **Examples:**
 
@@ -231,7 +233,7 @@ The M68k ISA supports the following addressing modes:
 
 - **Arithmetic Shift Left**
     - **Syntax:** `asl.<size> <source>, <destination>`
-    - **Description:** Shift the destination left arithmetically by the count specified in the source.
+    - **Description:** Shift the destination left arithmetically by the count specified in the source. Sets N and Z flags based on the result, C flag is set to the last bit shifted out (0 if shift count is 0), clears V flag.
     - **Operation:** `<destination> <- <destination> << <source>`
     - **Examples:**
 
@@ -243,7 +245,7 @@ The M68k ISA supports the following addressing modes:
 
 - **Arithmetic Shift Right**
     - **Syntax:** `asr.<size> <source>, <destination>`
-    - **Description:** Shift the destination right arithmetically by the count specified in the source.
+    - **Description:** Shift the destination right arithmetically by the count specified in the source. Sets N and Z flags based on the result, C flag is set to the last bit shifted out (0 if shift count is 0), clears V flag.
     - **Operation:** `<destination> <- <destination> >> <source>` (sign-preserving)
     - **Examples:**
 
@@ -255,7 +257,7 @@ The M68k ISA supports the following addressing modes:
 
 - **Logical Shift Left**
     - **Syntax:** `lsl.<size> <source>, <destination>`
-    - **Description:** Shift the destination left logically by the count specified in the source.
+    - **Description:** Shift the destination left logically by the count specified in the source. Sets N and Z flags based on the result, C flag is set to the last bit shifted out (0 if shift count is 0), clears V flag.
     - **Operation:** `<destination> <- <destination> << <source>`
     - **Examples:**
 
@@ -267,7 +269,7 @@ The M68k ISA supports the following addressing modes:
 
 - **Logical Shift Right**
     - **Syntax:** `lsr.<size> <source>, <destination>`
-    - **Description:** Shift the destination right logically by the count specified in the source.
+    - **Description:** Shift the destination right logically by the count specified in the source. Sets N and Z flags based on the result, C flag is set to the last bit shifted out (0 if shift count is 0), clears V flag.
     - **Operation:** `<destination> <- <destination> >> <source>` (zero-fill)
     - **Examples:**
 

--- a/docs/risc-iv.md
+++ b/docs/risc-iv.md
@@ -49,8 +49,8 @@ Instruction size: 4 bytes.
 
 - **Load Upper Immediate**
     - **Syntax:** `lui <rd>, <k>`
-    - **Description:** Load an immediate value shifted left by 12 bits into the destination register.
-    - **Operation:** `rd <- k << 12`
+    - **Description:** Load an immediate value masked to 20 bits and shifted left by 12 bits into the destination register.
+    - **Operation:** `rd <- (k & 0x000FFFFF) << 12`
 
 - **Move**
     - **Syntax:** `mv <rd>, <rs>`
@@ -76,8 +76,8 @@ Instruction size: 4 bytes.
 
 - **Add Immediate**
     - **Syntax:** `addi <rd>, <rs1>, <k>`
-    - **Description:** Add an immediate value to the source register and store the result in the destination register. Only the lower 12 bits of the result are stored (upper 20 bits sets depending on the sign of the immediate value).
-    - **Operation:** `rd <- rs1 + k`
+    - **Description:** Add a 12-bit sign-extended immediate value to the source register and store the result in the destination register. The immediate `k` is truncated to 12 bits and sign-extended to 32 bits before the addition.
+    - **Operation:** `rd <- rs1 + signext(k[11:0])`
 
 - **Add**
     - **Syntax:** `add <rd>, <rs1>, <rs2>`

--- a/docs/risc-iv.md
+++ b/docs/risc-iv.md
@@ -180,13 +180,13 @@ Instruction size: 4 bytes.
 
 - **Branch if Greater Than (Unsigned)**
     - **Syntax:** `bgtu <rs1>, <rs2>, <k>`
-    - **Description:** Jump to the address computed by adding the immediate value to the current program counter if the unsigned value in the first source register is greater than the unsigned value in the second source register.
-    - **Operation:** `if rs1 > rs2 then pc <- pc + k`
+    - **Description:** Jump to the address computed by adding the immediate value to the current program counter if the unsigned interpretation of the first source register is greater than the unsigned interpretation of the second source register.
+    - **Operation:** `if unsigned(rs1) > unsigned(rs2) then pc <- pc + k`
 
 - **Branch if Less Than or Equal (Unsigned)**
     - **Syntax:** `bleu <rs1>, <rs2>, <k>`
-    - **Description:** Jump to the address computed by adding the immediate value to the current program counter if the unsigned value in the first source register is less than or equal to the unsigned value in the second source register.
-    - **Operation:** `if rs1 <= rs2 then pc <- pc + k`
+    - **Description:** Jump to the address computed by adding the immediate value to the current program counter if the unsigned interpretation of the first source register is less than or equal to the unsigned interpretation of the second source register.
+    - **Operation:** `if unsigned(rs1) <= unsigned(rs2) then pc <- pc + k`
 
 - **Branch if Equal**
     - **Syntax:** `beq <rs1>, <rs2>, <k>`

--- a/docs/vliw-iv.md
+++ b/docs/vliw-iv.md
@@ -108,18 +108,18 @@ add rd, rs1, rs2 / addi rd, rs1, k / lw rd, offset(rs1) / beq rs1, rs2, k
 
 - **Logical Shift Left**
     - **Syntax:** `sll <rd>, <rs1>, <rs2>`
-    - **Description:** Shift the value of the first source register left by the number of bits specified in the second source register and store the result in the destination register.
-    - **Operation:** `rd <- rs1 << rs2`
+    - **Description:** Shift the value of the first source register left by the number of bits specified in the lower 5 bits of the second source register and store the result in the destination register.
+    - **Operation:** `rd <- rs1 << (rs2 & 0x1F)`
 
 - **Logical Shift Right**
     - **Syntax:** `srl <rd>, <rs1>, <rs2>`
-    - **Description:** Shift the value of the first source register right by the number of bits specified in the second source register and store the result in the destination register.
-    - **Operation:** `rd <- rs1 >> rs2`
+    - **Description:** Shift the value of the first source register right (zero-fill) by the number of bits specified in the lower 5 bits of the second source register and store the result in the destination register.
+    - **Operation:** `rd <- rs1 >>> (rs2 & 0x1F)`
 
 - **Arithmetic Shift Right**
     - **Syntax:** `sra <rd>, <rs1>, <rs2>`
-    - **Description:** Shift the value of the first source register right by the number of bits specified in the second source register, preserving the sign, and store the result in the destination register.
-    - **Operation:** `rd <- rs1 >> rs2`
+    - **Description:** Shift the value of the first source register right by the number of bits specified in the lower 5 bits of the second source register, preserving the sign, and store the result in the destination register.
+    - **Operation:** `rd <- rs1 >> (rs2 & 0x1F)`
 
 - **Bitwise AND**
     - **Syntax:** `and <rd>, <rs1>, <rs2>`

--- a/docs/vliw-iv.md
+++ b/docs/vliw-iv.md
@@ -53,7 +53,9 @@ Instruction size: 11 bytes (90-bit bundle).
 [SLOT 3]   control: 14 bits   <opcode:4><offset or offset+register:10>
 ```
 
-Each instruction is a bundle with 4 slots: Slot 0 (ALU1), Slot 1 (ALU2), Slot 2 (Memory), Slot 3 (Control). Operations in slots execute in parallel. Unused slots are NOP (no operation). Assembly syntax uses `/` to separate slots:
+Each instruction is a bundle with 4 slots: Slot 0 (ALU1), Slot 1 (ALU2), Slot 2 (Memory), Slot 3 (Control). Operations in slots execute in parallel. Unused slots are NOP (no operation). Assembly syntax uses `/` to separate slots.
+
+**Execution model:** All source operands are read first, then all results are written back simultaneously. The order of register writes from ALU1, ALU2, and Memory slots is non-deterministic — if multiple slots write to the same register, the result is undefined. The control slot always executes last. The compiler/assembler must ensure that parallel operations in the same bundle are independent (no write-write or read-write conflicts across slots).
 
 ```assembly
 add rd, rs1, rs2 / addi rd, rs1, k / lw rd, offset(rs1) / beq rs1, rs2, k

--- a/docs/vliw-iv.md
+++ b/docs/vliw-iv.md
@@ -63,8 +63,8 @@ add rd, rs1, rs2 / addi rd, rs1, k / lw rd, offset(rs1) / beq rs1, rs2, k
 
 - **Load Upper Immediate**
     - **Syntax:** `lui <rd>, <k>`
-    - **Description:** Load an immediate value shifted left by 12 bits into the destination register.
-    - **Operation:** `rd <- k << 12`
+    - **Description:** Load an immediate value masked to 20 bits and shifted left by 12 bits into the destination register.
+    - **Operation:** `rd <- (k & 0x000FFFFF) << 12`
 
 - **Move**
     - **Syntax:** `mv <rd>, <rs>`
@@ -73,8 +73,8 @@ add rd, rs1, rs2 / addi rd, rs1, k / lw rd, offset(rs1) / beq rs1, rs2, k
 
 - **Add Immediate**
     - **Syntax:** `addi <rd>, <rs1>, <k>`
-    - **Description:** Add an immediate value to the source register and store the result in the destination register.
-    - **Operation:** `rd <- rs1 + k`
+    - **Description:** Add a 12-bit sign-extended immediate value to the source register and store the result in the destination register. The immediate `k` is truncated to 12 bits and sign-extended to 32 bits before the addition.
+    - **Operation:** `rd <- rs1 + signext(k[11:0])`
 
 - **Add**
     - **Syntax:** `add <rd>, <rs1>, <rs2>`

--- a/docs/vliw-iv.md
+++ b/docs/vliw-iv.md
@@ -6,7 +6,7 @@ The VLIW ISA is a simple register-based instruction set inspired by VLIW (Very L
 
 The VLIW architecture is a 32-bit VLIW (Very Long Instruction Word) architecture inspired by RISC-V and classic VLIW designs. It features:
 
-- 32 general-purpose registers (including one hardwired zero register)
+- 32 general-purpose registers (including one hardwired zero register — writes to `Zero` are silently ignored)
 - Fixed-length 11-byte (90-bit) instruction bundles, divided into 4 slots for parallel execution
 - Load-store architecture (memory access only through specific instructions in dedicated slots)
 - Simple addressing modes

--- a/docs/vliw-iv.md
+++ b/docs/vliw-iv.md
@@ -207,13 +207,13 @@ add rd, rs1, rs2 / addi rd, rs1, k / lw rd, offset(rs1) / beq rs1, rs2, k
 
 - **Branch if Greater Than (Unsigned)**
     - **Syntax:** `bgtu <rs1>, <rs2>, <k>`
-    - **Description:** Jump to the address computed by adding the immediate value to the current program counter if the unsigned value in the first source register is greater than the unsigned value in the second source register.
-    - **Operation:** `if rs1 > rs2 then pc <- pc + k`
+    - **Description:** Jump to the address computed by adding the immediate value to the current program counter if the unsigned interpretation of the first source register is greater than the unsigned interpretation of the second source register.
+    - **Operation:** `if unsigned(rs1) > unsigned(rs2) then pc <- pc + k`
 
 - **Branch if Less Than or Equal (Unsigned)**
     - **Syntax:** `bleu <rs1>, <rs2>, <k>`
-    - **Description:** Jump to the address computed by adding the immediate value to the current program counter if the unsigned value in the first source register is less than or equal to the unsigned value in the second source register.
-    - **Operation:** `if rs1 <= rs2 then pc <- pc + k`
+    - **Description:** Jump to the address computed by adding the immediate value to the current program counter if the unsigned interpretation of the first source register is less than or equal to the unsigned interpretation of the second source register.
+    - **Operation:** `if unsigned(rs1) <= unsigned(rs2) then pc <- pc + k`
 
 - **Branch if Equal**
     - **Syntax:** `beq <rs1>, <rs2>, <k>`

--- a/docs/vliw-iv.md
+++ b/docs/vliw-iv.md
@@ -164,6 +164,8 @@ add rd, rs1, rs2 / addi rd, rs1, k / lw rd, offset(rs1) / beq rs1, rs2, k
     - **Description:** Store the lower 8 bits of the value from the source register into memory at the address computed by adding the offset to the base register.
     - **Operation:** `M[offset + rs1] <- rs2 & 0xFF`
 
+> **Note:** There is no `lb` (load byte) instruction. Byte-level reads can be performed by loading a word with `lw` and using ALU operations to extract the desired byte.
+
 - **NOP**
     - **Syntax:** `nop`
     - **Description:** No operation.

--- a/src/wrench/Wrench/Isa/VliwIv.hs
+++ b/src/wrench/Wrench/Isa/VliwIv.hs
@@ -397,6 +397,7 @@ getReg r = do
             raiseInternalError $ "wrong register: " <> show r
             return def
 
+setReg Zero _ = return ()
 setReg r value = modify $ \st@State{regs} -> st{regs = insert r value regs}
 
 getWord addr = do


### PR DESCRIPTION
## Summary
- **docs(acc32):** fix sub/mul flag documentation (both set C and V, not just V), fix load_imm parameter name
- **fix(vliw-iv):** ignore writes to Zero register (was writable despite being documented as hardwired zero)
- **docs(risc-iv,vliw-iv):** document immediate masking for addi (12-bit sign-extended) and lui (20-bit masked), document shift 5-bit masking, clarify unsigned comparison in
bgtu/bleu, document Zero register write behavior
- **docs(m68k):** document flag behavior for move/not/and/or/xor/shift operations, clarify mandatory size suffix
- **docs(vliw-iv):** document parallel execution non-deterministic write order, note absence of lb instruction
- **docs(f32a):** clarify carry flag behavior (dataPush clears carry)

## Test plan
- [x] All 489 tests pass (`stack test`)
- [ ] Review documentation changes for accuracy
EOF
