### PR TITLE
feat(is_prime): add testcase for incorrect optimization

### DIFF
--- a/script/testcases/mathematics.py
+++ b/script/testcases/mathematics.py
@@ -197,6 +197,7 @@ is_prime_ref = is_prime
 TEST_CASES["is_prime"] = TestCase(
     simple=is_prime,
     cases=[
+        Word2Word(2, 1),
         Word2Word(5, 1),
         Word2Word(4, 0),
         Word2Word(7, 1),


### PR DESCRIPTION
Some optimizations for large inputs skip even numbers by starting iteration from 3, which can lead to incorrect handling of the prime number 2. New test ensures that 2 is correctly treated as a prime.