### PR TITLE
feat(acc32): rename branch mnemonics and add bgez

### DIFF
--- a/docs/acc32.md
+++ b/docs/acc32.md
@@ -153,6 +153,11 @@ Instruction size: 1 byte for opcode, 4 bytes for absolute operand, 2 bytes for r
     - **Description:** Jump to a specific address if the accumulator is greater than zero.
     - **Operation:** `if acc > 0 then pc <- <address>`
 
+- **Branch if Greater Than or Equal to Zero**
+    - **Syntax:** `bgez <address>`
+    - **Description:** Jump to a specific address if the accumulator is greater than or equal to zero.
+    - **Operation:** `if acc >= 0 then pc <- <address>`
+
 - **Branch if Less Than Zero**
     - **Syntax:** `bltz <address>`
     - **Description:** Jump to a specific address if the accumulator is less than zero.

--- a/docs/acc32.md
+++ b/docs/acc32.md
@@ -149,12 +149,12 @@ Instruction size: 1 byte for opcode, 4 bytes for absolute operand, 2 bytes for r
     - **Operation:** `if acc != 0 then pc <- <address>`
 
 - **Branch if Greater Than Zero**
-    - **Syntax:** `bgt <address>`
+    - **Syntax:** `bgtz <address>`
     - **Description:** Jump to a specific address if the accumulator is greater than zero.
     - **Operation:** `if acc > 0 then pc <- <address>`
 
 - **Branch if Less Than Zero**
-    - **Syntax:** `ble <address>`
+    - **Syntax:** `bltz <address>`
     - **Description:** Jump to a specific address if the accumulator is less than zero.
     - **Operation:** `if acc < 0 then pc <- <address>`
 

--- a/example/acc32/factorial.s
+++ b/example/acc32/factorial.s
@@ -13,7 +13,7 @@ _start:
     load_acc
     store        n                           ; mem[n] = acc
 
-    ble          not_in_domain
+    bltz         not_in_domain
 
 factorial_begin:
     load         const_1                     ; acc = mem[const_1]

--- a/src/wrench/Wrench/Isa/Acc32.hs
+++ b/src/wrench/Wrench/Isa/Acc32.hs
@@ -110,8 +110,8 @@ instance (MachineWord w) => MnemonicParser (Isa w (Ref w)) where
             , Jmp <$> cmdMnemonic1 "jmp" reference
             , Beqz <$> cmdMnemonic1 "beqz" reference
             , Bnez <$> cmdMnemonic1 "bnez" reference
-            , Bgz <$> cmdMnemonic1 "bgt" reference
-            , Blz <$> cmdMnemonic1 "ble" reference
+            , Bgz <$> cmdMnemonic1 "bgtz" reference
+            , Blz <$> cmdMnemonic1 "bltz" reference
             , Bvs <$> cmdMnemonic1 "bvs" reference
             , Bvc <$> cmdMnemonic1 "bvc" reference
             , Bcs <$> cmdMnemonic1 "bcs" reference

--- a/src/wrench/Wrench/Isa/Acc32.hs
+++ b/src/wrench/Wrench/Isa/Acc32.hs
@@ -69,10 +69,12 @@ data Isa w l
       Beqz l
     | -- | Syntax: @bnez <address>@ Jump to a specific address if the accumulator is not zero.
       Bnez l
-    | -- | Syntax: @bgt <address>@ Jump to a specific address if the accumulator is greater than zero.
+    | -- | Syntax: @bgtz <address>@ Jump to a specific address if the accumulator is greater than zero.
       Bgz l
-    | -- | Syntax: @ble <address>@ Jump to a specific address if the accumulator is less than zero.
+    | -- | Syntax: @bltz <address>@ Jump to a specific address if the accumulator is less than zero.
       Blz l
+    | -- | Syntax: @bgez <address>@ Jump to a specific address if the accumulator is greater than or equal to zero.
+      Bgez l
     | Bvs l
     | Bvc l
     | Bcs l
@@ -111,6 +113,7 @@ instance (MachineWord w) => MnemonicParser (Isa w (Ref w)) where
             , Beqz <$> cmdMnemonic1 "beqz" reference
             , Bnez <$> cmdMnemonic1 "bnez" reference
             , Bgz <$> cmdMnemonic1 "bgtz" reference
+            , Bgez <$> cmdMnemonic1 "bgez" reference
             , Blz <$> cmdMnemonic1 "bltz" reference
             , Bvs <$> cmdMnemonic1 "bvs" reference
             , Bvc <$> cmdMnemonic1 "bvc" reference
@@ -164,6 +167,7 @@ instance (MachineWord w) => DerefMnemonic (Isa w) w where
                 Beqz l -> Beqz (deref' f l)
                 Bnez l -> Bnez (deref' f l)
                 Bgz l -> Bgz (deref' f l)
+                Bgez l -> Bgez (deref' f l)
                 Blz l -> Blz (deref' f l)
                 Bvs l -> Bvs (deref' f l)
                 Bvc l -> Bvc (deref' f l)
@@ -181,6 +185,7 @@ instance ByteSize (Isa w l) where
     byteSize Beqz{} = 5
     byteSize Bnez{} = 5
     byteSize Bgz{} = 5
+    byteSize Bgez{} = 5
     byteSize Blz{} = 5
     byteSize Bvs{} = 5
     byteSize Bvc{} = 5
@@ -319,6 +324,7 @@ instance (MachineWord w) => Machine (MachineState (IoMem (Isa w w) w) w) (Isa w 
             Beqz a -> condJmp (== 0) a
             Bnez a -> condJmp (/= 0) a
             Bgz a -> condJmp (> 0) a
+            Bgez a -> condJmp (>= 0) a
             Blz a -> condJmp (< 0) a
             Bvs a -> getOverflowFlag >>= \overflow -> if overflow then setPc (fromEnum a) else nextPc
             Bvc a -> getOverflowFlag >>= \overflow -> if not overflow then setPc (fromEnum a) else nextPc

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -10,6 +10,7 @@ import Text.Pretty.Simple (pShowNoColor)
 import Wrench.Config
 import Wrench.Isa.Acc32 (Acc32State)
 import Wrench.Isa.Acc32 qualified as Acc32
+import Wrench.Isa.Acc32.Test qualified
 import Wrench.Isa.F32a (F32aState)
 import Wrench.Isa.F32a qualified as F32a
 import Wrench.Isa.F32a.Test qualified
@@ -128,7 +129,8 @@ tests =
             ]
         , testGroup
             "Acc32"
-            [ testGroup
+            [ Wrench.Isa.Acc32.Test.tests
+            , testGroup
                 "Translator"
                 [ goldenTranslate Acc32 "test/golden/acc32/logical_not.s"
                 , goldenTranslate Acc32 "test/golden/acc32/hello.s"

--- a/test/Wrench/Isa/Acc32/Test.hs
+++ b/test/Wrench/Isa/Acc32/Test.hs
@@ -24,6 +24,12 @@ tests =
             runBranch (Blz 100) 0 @?= 10
         , testCase "bltz not taken (acc > 0)" $ do
             runBranch (Blz 100) 5 @?= 10
+        , testCase "bgez taken (acc == 0)" $ do
+            runBranch (Bgez 100) 0 @?= 100
+        , testCase "bgez taken (acc > 0)" $ do
+            runBranch (Bgez 100) 5 @?= 100
+        , testCase "bgez not taken (acc < 0)" $ do
+            runBranch (Bgez 100) (-1) @?= 10
         ]
 
 -- | Build an initial state with a LoadImm at address 0 (5 bytes) followed by

--- a/test/Wrench/Isa/Acc32/Test.hs
+++ b/test/Wrench/Isa/Acc32/Test.hs
@@ -1,0 +1,54 @@
+module Wrench.Isa.Acc32.Test (tests) where
+
+import Data.Default
+import Relude
+import Test.Tasty (TestTree, testGroup)
+import Test.Tasty.HUnit (testCase, (@?=))
+import Wrench.Isa.Acc32
+import Wrench.Machine.Memory
+import Wrench.Machine.Types
+
+tests :: TestTree
+tests =
+    testGroup
+        "ISA"
+        [ testCase "bgtz taken (acc > 0)" $ do
+            runBranch (Bgz 100) 5 @?= 100
+        , testCase "bgtz not taken (acc == 0)" $ do
+            runBranch (Bgz 100) 0 @?= 10
+        , testCase "bgtz not taken (acc < 0)" $ do
+            runBranch (Bgz 100) (-1) @?= 10
+        , testCase "bltz taken (acc < 0)" $ do
+            runBranch (Blz 100) (-1) @?= 100
+        , testCase "bltz not taken (acc == 0)" $ do
+            runBranch (Blz 100) 0 @?= 10
+        , testCase "bltz not taken (acc > 0)" $ do
+            runBranch (Blz 100) 5 @?= 10
+        ]
+
+-- | Build an initial state with a LoadImm at address 0 (5 bytes) followed by
+-- the branch instruction at address 5 (5 bytes). After two instructionStep
+-- calls, the acc is set and the branch is evaluated.
+mkState :: Isa Int32 Int32 -> Int32 -> Acc32State Int32
+mkState branchInstr accVal =
+    let loadInstr = LoadImm accVal
+        mem =
+            mkIoMem
+                def
+                ( Mem
+                    { memoryData =
+                        fromList $
+                            [(0, Instruction loadInstr)]
+                                <> [(i, InstructionPart) | i <- [1 .. 4]]
+                                <> [(5, Instruction branchInstr)]
+                                <> [(i, InstructionPart) | i <- [6 .. 9]]
+                    , memorySize = 10
+                    }
+                )
+     in initState 0 mem []
+
+runBranch :: Isa Int32 Int32 -> Int32 -> Int
+runBranch instr accVal =
+    let st = mkState instr accVal
+        st' = execState (instructionStep >> instructionStep) st
+     in programCounter st'

--- a/test/golden/acc32/all.s
+++ b/test/golden/acc32/all.s
@@ -97,10 +97,10 @@ _start:
     bnez         jump_target                 ; if acc != 0, jump to jump_target
 
     load_imm     0x02                        ; acc <- 0x02
-    bgt          jump_target                 ; if acc > 0, jump to jump_target
+    bgtz         jump_target                 ; if acc > 0, jump to jump_target
 
     load_imm     0xFF                        ; acc <- 0xFF
-    ble          jump_target                 ; if acc < 0, jump to jump_target
+    bltz         jump_target                 ; if acc < 0, jump to jump_target
 
 jump_target:
     ; Halt the machine

--- a/test/golden/acc32/factorial.s
+++ b/test/golden/acc32/factorial.s
@@ -13,7 +13,7 @@ _start:
     load_acc
     store        n                           ; mem[n] = acc
 
-    ble          not_in_domain
+    bltz         not_in_domain
 
 factorial_begin:
     load         const_1                     ; acc = mem[const_1]


### PR DESCRIPTION
## Summary
- Rename `bgt`/`ble` → `bgtz`/`bltz` to match MIPS/RISC-V conventions and avoid confusion (old mnemonics implied two-operand comparison)
- Add `bgez` instruction (branch if accumulator >= 0) to complete the zero-comparison branch set

## Test plan
- [x] Unit tests for bgtz taken/not-taken
- [x] Unit tests for bltz taken/not-taken
- [x] Unit tests for bgez taken/not-taken (acc=0, acc>0, acc<0)
- [x] Updated example and golden test assembly files
- [x] All 498 tests pass