### PR TITLE
feat(m68k): add neg, clr instructions and handle div-by-zero

### DIFF
--- a/docs/acc32.md
+++ b/docs/acc32.md
@@ -72,12 +72,12 @@ Instruction size: 1 byte for opcode, 4 bytes for absolute operand, 2 bytes for r
 - **Subtract**
     - **Syntax:** `sub <address>`
     - **Description:** Subtract a value from a specific address from the accumulator.
-    - **Operation:** `acc <- acc - mem[<address>]` and set `V` flags.
+    - **Operation:** `acc <- acc - mem[<address>]` and set `C` and `V` flags.
 
 - **Multiply**
     - **Syntax:** `mul <address>`
     - **Description:** Multiply the accumulator by a value from a specific address.
-    - **Operation:** `acc <- acc * mem[<address>]` and set `V` flags.
+    - **Operation:** `acc <- acc * mem[<address>]` and set `C` and `V` flags.
 
 - **Divide**
     - **Syntax:** `div <address>`

--- a/docs/acc32.md
+++ b/docs/acc32.md
@@ -28,9 +28,9 @@ Instruction size: 1 byte for opcode, 4 bytes for absolute operand, 2 bytes for r
 ### Data Movement Instructions
 
 - **Load Immediate**
-    - **Syntax:** `load_imm <address>`
+    - **Syntax:** `load_imm <value>`
     - **Description:** Load an immediate value into the accumulator.
-    - **Operation:** `acc <- <address>`
+    - **Operation:** `acc <- <value>`
 
 - **Load**
     - **Syntax:** `load <offset>`

--- a/docs/f32a.md
+++ b/docs/f32a.md
@@ -41,7 +41,7 @@ Extended Arithmetic Mode (EAM) is a mode that allows us to add with carry bit. S
 
 ### Carry Flag
 
-Most of the instructions drop the carry flag. Exceptions: `add`, `dup`.
+Most of the instructions drop (clear) the carry flag. Specifically, any instruction that pushes to the data stack clears the carry flag as a side effect. Exceptions: `add` (sets carry flag based on overflow), `dup` (preserves carry flag).
 
 ### Data Movement Instructions
 

--- a/docs/m68k.md
+++ b/docs/m68k.md
@@ -121,6 +121,17 @@ The M68k ISA supports the following addressing modes:
 
 ### Logical Instructions
 
+- **Clear**
+    - **Syntax:** `clr.<size> <destination>`
+    - **Description:** Clear the destination to zero. Sets Z flag, clears N, V, and C flags.
+    - **Operation:** `<destination> <- 0`
+    - **Examples:**
+
+      ```assembly
+      clr.l D0            ; D0 <- 0 (32-bit)
+      clr.b D0            ; Clear lowest byte of D0
+      ```
+
 - **Negate**
     - **Syntax:** `neg.<size> <destination>`
     - **Description:** Negate the destination (compute 0 - destination). Sets N, Z, V, and C flags based on the result.

--- a/docs/m68k.md
+++ b/docs/m68k.md
@@ -121,6 +121,17 @@ The M68k ISA supports the following addressing modes:
 
 ### Logical Instructions
 
+- **Negate**
+    - **Syntax:** `neg.<size> <destination>`
+    - **Description:** Negate the destination (compute 0 - destination). Sets N, Z, V, and C flags based on the result.
+    - **Operation:** `<destination> <- 0 - <destination>`
+    - **Examples:**
+
+      ```assembly
+      neg.l D0            ; D0 <- -D0 (32-bit)
+      neg.b D0            ; Negate lowest byte of D0
+      ```
+
 - **Not**
     - **Syntax:** `not.<size> <destination>`
     - **Description:** Bitwise NOT the destination. Sets N and Z flags based on the result, clears V and C flags.

--- a/docs/m68k.md
+++ b/docs/m68k.md
@@ -46,7 +46,9 @@ Instruction sizes vary depending on the operation mode and addressing modes used
 M68k instructions can operate on data of different sizes:
 
 - **Byte (`.b`):** 8-bit operations
-- **Long (`.l`):** 32-bit operations (default)
+- **Long (`.l`):** 32-bit operations
+
+The size suffix is mandatory and must be explicitly specified for all instructions that support it.
 
 Example: `add.b D0, D1` operates on the least significant byte of D0 and D1.
 
@@ -88,7 +90,7 @@ The M68k ISA supports the following addressing modes:
 
 - **Move**
     - **Syntax:** `move.<size> <source>, <destination>`
-    - **Description:** Move data from the source to the destination.
+    - **Description:** Move data from the source to the destination. Sets N and Z flags based on the result, clears V and C flags.
     - **Operation:** `<destination> <- <source>`
     - **Examples:**
 
@@ -121,7 +123,7 @@ The M68k ISA supports the following addressing modes:
 
 - **Not**
     - **Syntax:** `not.<size> <destination>`
-    - **Description:** Bitwise NOT the destination.
+    - **Description:** Bitwise NOT the destination. Sets N and Z flags based on the result, clears V and C flags.
     - **Operation:** `<destination> <- ~<destination>`
     - **Examples:**
 
@@ -132,7 +134,7 @@ The M68k ISA supports the following addressing modes:
 
 - **And**
     - **Syntax:** `and.<size> <source>, <destination>`
-    - **Description:** Bitwise AND the source with the destination.
+    - **Description:** Bitwise AND the source with the destination. Sets N and Z flags based on the result, clears V and C flags.
     - **Operation:** `<destination> <- <destination> & <source>`
     - **Examples:**
 
@@ -143,7 +145,7 @@ The M68k ISA supports the following addressing modes:
 
 - **Or**
     - **Syntax:** `or.<size> <source>, <destination>`
-    - **Description:** Bitwise OR the source with the destination.
+    - **Description:** Bitwise OR the source with the destination. Sets N and Z flags based on the result, clears V and C flags.
     - **Operation:** `<destination> <- <destination> | <source>`
     - **Examples:**
 
@@ -154,7 +156,7 @@ The M68k ISA supports the following addressing modes:
 
 - **Exclusive Or**
     - **Syntax:** `xor.<size> <source>, <destination>`
-    - **Description:** Bitwise XOR the source with the destination.
+    - **Description:** Bitwise XOR the source with the destination. Sets N and Z flags based on the result, clears V and C flags.
     - **Operation:** `<destination> <- <destination> ^ <source>`
     - **Examples:**
 
@@ -231,7 +233,7 @@ The M68k ISA supports the following addressing modes:
 
 - **Arithmetic Shift Left**
     - **Syntax:** `asl.<size> <source>, <destination>`
-    - **Description:** Shift the destination left arithmetically by the count specified in the source.
+    - **Description:** Shift the destination left arithmetically by the count specified in the source. Sets N and Z flags based on the result, C flag is set to the last bit shifted out (0 if shift count is 0), clears V flag.
     - **Operation:** `<destination> <- <destination> << <source>`
     - **Examples:**
 
@@ -243,7 +245,7 @@ The M68k ISA supports the following addressing modes:
 
 - **Arithmetic Shift Right**
     - **Syntax:** `asr.<size> <source>, <destination>`
-    - **Description:** Shift the destination right arithmetically by the count specified in the source.
+    - **Description:** Shift the destination right arithmetically by the count specified in the source. Sets N and Z flags based on the result, C flag is set to the last bit shifted out (0 if shift count is 0), clears V flag.
     - **Operation:** `<destination> <- <destination> >> <source>` (sign-preserving)
     - **Examples:**
 
@@ -255,7 +257,7 @@ The M68k ISA supports the following addressing modes:
 
 - **Logical Shift Left**
     - **Syntax:** `lsl.<size> <source>, <destination>`
-    - **Description:** Shift the destination left logically by the count specified in the source.
+    - **Description:** Shift the destination left logically by the count specified in the source. Sets N and Z flags based on the result, C flag is set to the last bit shifted out (0 if shift count is 0), clears V flag.
     - **Operation:** `<destination> <- <destination> << <source>`
     - **Examples:**
 
@@ -267,7 +269,7 @@ The M68k ISA supports the following addressing modes:
 
 - **Logical Shift Right**
     - **Syntax:** `lsr.<size> <source>, <destination>`
-    - **Description:** Shift the destination right logically by the count specified in the source.
+    - **Description:** Shift the destination right logically by the count specified in the source. Sets N and Z flags based on the result, C flag is set to the last bit shifted out (0 if shift count is 0), clears V flag.
     - **Operation:** `<destination> <- <destination> >> <source>` (zero-fill)
     - **Examples:**
 

--- a/docs/risc-iv.md
+++ b/docs/risc-iv.md
@@ -49,8 +49,8 @@ Instruction size: 4 bytes.
 
 - **Load Upper Immediate**
     - **Syntax:** `lui <rd>, <k>`
-    - **Description:** Load an immediate value shifted left by 12 bits into the destination register.
-    - **Operation:** `rd <- k << 12`
+    - **Description:** Load an immediate value masked to 20 bits and shifted left by 12 bits into the destination register.
+    - **Operation:** `rd <- (k & 0x000FFFFF) << 12`
 
 - **Move**
     - **Syntax:** `mv <rd>, <rs>`
@@ -76,8 +76,8 @@ Instruction size: 4 bytes.
 
 - **Add Immediate**
     - **Syntax:** `addi <rd>, <rs1>, <k>`
-    - **Description:** Add an immediate value to the source register and store the result in the destination register. Only the lower 12 bits of the result are stored (upper 20 bits sets depending on the sign of the immediate value).
-    - **Operation:** `rd <- rs1 + k`
+    - **Description:** Add a 12-bit sign-extended immediate value to the source register and store the result in the destination register. The immediate `k` is truncated to 12 bits and sign-extended to 32 bits before the addition.
+    - **Operation:** `rd <- rs1 + signext(k[11:0])`
 
 - **Add**
     - **Syntax:** `add <rd>, <rs1>, <rs2>`

--- a/docs/risc-iv.md
+++ b/docs/risc-iv.md
@@ -180,13 +180,13 @@ Instruction size: 4 bytes.
 
 - **Branch if Greater Than (Unsigned)**
     - **Syntax:** `bgtu <rs1>, <rs2>, <k>`
-    - **Description:** Jump to the address computed by adding the immediate value to the current program counter if the unsigned value in the first source register is greater than the unsigned value in the second source register.
-    - **Operation:** `if rs1 > rs2 then pc <- pc + k`
+    - **Description:** Jump to the address computed by adding the immediate value to the current program counter if the unsigned interpretation of the first source register is greater than the unsigned interpretation of the second source register.
+    - **Operation:** `if unsigned(rs1) > unsigned(rs2) then pc <- pc + k`
 
 - **Branch if Less Than or Equal (Unsigned)**
     - **Syntax:** `bleu <rs1>, <rs2>, <k>`
-    - **Description:** Jump to the address computed by adding the immediate value to the current program counter if the unsigned value in the first source register is less than or equal to the unsigned value in the second source register.
-    - **Operation:** `if rs1 <= rs2 then pc <- pc + k`
+    - **Description:** Jump to the address computed by adding the immediate value to the current program counter if the unsigned interpretation of the first source register is less than or equal to the unsigned interpretation of the second source register.
+    - **Operation:** `if unsigned(rs1) <= unsigned(rs2) then pc <- pc + k`
 
 - **Branch if Equal**
     - **Syntax:** `beq <rs1>, <rs2>, <k>`

--- a/docs/vliw-iv.md
+++ b/docs/vliw-iv.md
@@ -108,18 +108,18 @@ add rd, rs1, rs2 / addi rd, rs1, k / lw rd, offset(rs1) / beq rs1, rs2, k
 
 - **Logical Shift Left**
     - **Syntax:** `sll <rd>, <rs1>, <rs2>`
-    - **Description:** Shift the value of the first source register left by the number of bits specified in the second source register and store the result in the destination register.
-    - **Operation:** `rd <- rs1 << rs2`
+    - **Description:** Shift the value of the first source register left by the number of bits specified in the lower 5 bits of the second source register and store the result in the destination register.
+    - **Operation:** `rd <- rs1 << (rs2 & 0x1F)`
 
 - **Logical Shift Right**
     - **Syntax:** `srl <rd>, <rs1>, <rs2>`
-    - **Description:** Shift the value of the first source register right by the number of bits specified in the second source register and store the result in the destination register.
-    - **Operation:** `rd <- rs1 >> rs2`
+    - **Description:** Shift the value of the first source register right (zero-fill) by the number of bits specified in the lower 5 bits of the second source register and store the result in the destination register.
+    - **Operation:** `rd <- rs1 >>> (rs2 & 0x1F)`
 
 - **Arithmetic Shift Right**
     - **Syntax:** `sra <rd>, <rs1>, <rs2>`
-    - **Description:** Shift the value of the first source register right by the number of bits specified in the second source register, preserving the sign, and store the result in the destination register.
-    - **Operation:** `rd <- rs1 >> rs2`
+    - **Description:** Shift the value of the first source register right by the number of bits specified in the lower 5 bits of the second source register, preserving the sign, and store the result in the destination register.
+    - **Operation:** `rd <- rs1 >> (rs2 & 0x1F)`
 
 - **Bitwise AND**
     - **Syntax:** `and <rd>, <rs1>, <rs2>`

--- a/docs/vliw-iv.md
+++ b/docs/vliw-iv.md
@@ -53,7 +53,9 @@ Instruction size: 11 bytes (90-bit bundle).
 [SLOT 3]   control: 14 bits   <opcode:4><offset or offset+register:10>
 ```
 
-Each instruction is a bundle with 4 slots: Slot 0 (ALU1), Slot 1 (ALU2), Slot 2 (Memory), Slot 3 (Control). Operations in slots execute in parallel. Unused slots are NOP (no operation). Assembly syntax uses `/` to separate slots:
+Each instruction is a bundle with 4 slots: Slot 0 (ALU1), Slot 1 (ALU2), Slot 2 (Memory), Slot 3 (Control). Operations in slots execute in parallel. Unused slots are NOP (no operation). Assembly syntax uses `/` to separate slots.
+
+**Execution model:** All source operands are read first, then all results are written back simultaneously. The order of register writes from ALU1, ALU2, and Memory slots is non-deterministic — if multiple slots write to the same register, the result is undefined. The control slot always executes last. The compiler/assembler must ensure that parallel operations in the same bundle are independent (no write-write or read-write conflicts across slots).
 
 ```assembly
 add rd, rs1, rs2 / addi rd, rs1, k / lw rd, offset(rs1) / beq rs1, rs2, k

--- a/docs/vliw-iv.md
+++ b/docs/vliw-iv.md
@@ -63,8 +63,8 @@ add rd, rs1, rs2 / addi rd, rs1, k / lw rd, offset(rs1) / beq rs1, rs2, k
 
 - **Load Upper Immediate**
     - **Syntax:** `lui <rd>, <k>`
-    - **Description:** Load an immediate value shifted left by 12 bits into the destination register.
-    - **Operation:** `rd <- k << 12`
+    - **Description:** Load an immediate value masked to 20 bits and shifted left by 12 bits into the destination register.
+    - **Operation:** `rd <- (k & 0x000FFFFF) << 12`
 
 - **Move**
     - **Syntax:** `mv <rd>, <rs>`
@@ -73,8 +73,8 @@ add rd, rs1, rs2 / addi rd, rs1, k / lw rd, offset(rs1) / beq rs1, rs2, k
 
 - **Add Immediate**
     - **Syntax:** `addi <rd>, <rs1>, <k>`
-    - **Description:** Add an immediate value to the source register and store the result in the destination register.
-    - **Operation:** `rd <- rs1 + k`
+    - **Description:** Add a 12-bit sign-extended immediate value to the source register and store the result in the destination register. The immediate `k` is truncated to 12 bits and sign-extended to 32 bits before the addition.
+    - **Operation:** `rd <- rs1 + signext(k[11:0])`
 
 - **Add**
     - **Syntax:** `add <rd>, <rs1>, <rs2>`

--- a/docs/vliw-iv.md
+++ b/docs/vliw-iv.md
@@ -6,7 +6,7 @@ The VLIW ISA is a simple register-based instruction set inspired by VLIW (Very L
 
 The VLIW architecture is a 32-bit VLIW (Very Long Instruction Word) architecture inspired by RISC-V and classic VLIW designs. It features:
 
-- 32 general-purpose registers (including one hardwired zero register)
+- 32 general-purpose registers (including one hardwired zero register — writes to `Zero` are silently ignored)
 - Fixed-length 11-byte (90-bit) instruction bundles, divided into 4 slots for parallel execution
 - Load-store architecture (memory access only through specific instructions in dedicated slots)
 - Simple addressing modes

--- a/docs/vliw-iv.md
+++ b/docs/vliw-iv.md
@@ -207,13 +207,13 @@ add rd, rs1, rs2 / addi rd, rs1, k / lw rd, offset(rs1) / beq rs1, rs2, k
 
 - **Branch if Greater Than (Unsigned)**
     - **Syntax:** `bgtu <rs1>, <rs2>, <k>`
-    - **Description:** Jump to the address computed by adding the immediate value to the current program counter if the unsigned value in the first source register is greater than the unsigned value in the second source register.
-    - **Operation:** `if rs1 > rs2 then pc <- pc + k`
+    - **Description:** Jump to the address computed by adding the immediate value to the current program counter if the unsigned interpretation of the first source register is greater than the unsigned interpretation of the second source register.
+    - **Operation:** `if unsigned(rs1) > unsigned(rs2) then pc <- pc + k`
 
 - **Branch if Less Than or Equal (Unsigned)**
     - **Syntax:** `bleu <rs1>, <rs2>, <k>`
-    - **Description:** Jump to the address computed by adding the immediate value to the current program counter if the unsigned value in the first source register is less than or equal to the unsigned value in the second source register.
-    - **Operation:** `if rs1 <= rs2 then pc <- pc + k`
+    - **Description:** Jump to the address computed by adding the immediate value to the current program counter if the unsigned interpretation of the first source register is less than or equal to the unsigned interpretation of the second source register.
+    - **Operation:** `if unsigned(rs1) <= unsigned(rs2) then pc <- pc + k`
 
 - **Branch if Equal**
     - **Syntax:** `beq <rs1>, <rs2>, <k>`

--- a/docs/vliw-iv.md
+++ b/docs/vliw-iv.md
@@ -164,6 +164,8 @@ add rd, rs1, rs2 / addi rd, rs1, k / lw rd, offset(rs1) / beq rs1, rs2, k
     - **Description:** Store the lower 8 bits of the value from the source register into memory at the address computed by adding the offset to the base register.
     - **Operation:** `M[offset + rs1] <- rs2 & 0xFF`
 
+> **Note:** There is no `lb` (load byte) instruction. Byte-level reads can be performed by loading a word with `lw` and using ALU operations to extract the desired byte.
+
 - **NOP**
     - **Syntax:** `nop`
     - **Description:** No operation.

--- a/src/wrench/Wrench/Isa/M68k.hs
+++ b/src/wrench/Wrench/Isa/M68k.hs
@@ -599,8 +599,16 @@ instance (MachineWord w) => Machine (MachineState (IoMem (Isa w w) w) w) (Isa w 
             Sub{mode = Byte, src, dst} -> byteCmd2Ext src dst subExt
             Mul{mode = Long, src, dst} -> wordCmd2Ext src dst mulExt
             Mul{mode = Byte, src, dst} -> byteCmd2Ext src dst mulExt
-            Div{mode = Long, src, dst} -> wordCmd2 src dst div
-            Div{mode = Byte, src, dst} -> byteCmd2 src dst div
+            Div{mode = Long, src, dst} -> do
+                b <- fetchWord src
+                if b == 0
+                    then raiseInternalError "division by zero"
+                    else wordCmd2 src dst div
+            Div{mode = Byte, src, dst} -> do
+                b <- fetchByte src
+                if b == 0
+                    then raiseInternalError "division by zero"
+                    else byteCmd2 src dst div
             Cmp{mode = Long, src, dst} -> do
                 a <- fetchWord dst
                 b <- fetchWord src

--- a/src/wrench/Wrench/Isa/M68k.hs
+++ b/src/wrench/Wrench/Isa/M68k.hs
@@ -78,6 +78,7 @@ data Isa w l
     = Move {mode :: Mode, src, dst :: Argument w l}
     | MoveA {mode :: Mode, src, dst :: Argument w l}
     | Not {mode :: Mode, dst :: Argument w l}
+    | Neg {mode :: Mode, dst :: Argument w l}
     | And {mode :: Mode, src, dst :: Argument w l}
     | Or {mode :: Mode, src, dst :: Argument w l}
     | Xor {mode :: Mode, src, dst :: Argument w l}
@@ -119,6 +120,7 @@ instance (MachineWord w) => MnemonicParser (Isa w (Ref w)) where
             [ cmd2args "move" Move (longMode <|> byteMode) src dst
             , cmd2args "movea" MoveA longMode src addrRegister
             , cmd1args "not" Not (longMode <|> byteMode) dst
+            , cmd1args "neg" Neg (longMode <|> byteMode) dst
             , cmd2args "and" And (longMode <|> byteMode) src dst
             , cmd2args "or" Or (longMode <|> byteMode) src dst
             , cmd2args "xor" Xor (longMode <|> byteMode) src dst
@@ -281,6 +283,7 @@ instance DerefMnemonic (Isa w) w where
                 Move{mode, src, dst} -> Move mode (derefArg src) (derefArg dst)
                 MoveA{mode, src, dst} -> MoveA mode (derefArg src) (derefArg dst)
                 Not{mode, dst} -> Not mode (derefArg dst)
+                Neg{mode, dst} -> Neg mode (derefArg dst)
                 And{mode, src, dst} -> And mode (derefArg src) (derefArg dst)
                 Or{mode, src, dst} -> Or mode (derefArg src) (derefArg dst)
                 Xor{mode, src, dst} -> Xor mode (derefArg src) (derefArg dst)
@@ -324,6 +327,7 @@ instance (ByteSizeT w) => ByteSize (Isa w l) where
     byteSize (Move _mode src dst) = 2 + byteSize src + byteSize dst
     byteSize (MoveA _mode src dst) = 2 + byteSize src + byteSize dst
     byteSize (Not _mode dst) = 2 + byteSize dst
+    byteSize (Neg _mode dst) = 2 + byteSize dst
     byteSize (And _mode src dst) = 2 + byteSize src + byteSize dst
     byteSize (Or _mode src dst) = 2 + byteSize src + byteSize dst
     byteSize (Xor _mode src dst) = 2 + byteSize src + byteSize dst
@@ -559,6 +563,18 @@ instance (MachineWord w) => Machine (MachineState (IoMem (Isa w w) w) w) (Isa w 
             MoveA{mode = Byte} -> error "not implemented"
             Not{mode = Long, dst} -> wordCmd1 dst dst complement
             Not{mode = Byte, dst} -> byteCmd1 dst dst complement
+            Neg{mode = Long, dst} -> do
+                a <- fetchWord dst
+                let Ext{value, carry, overflow} = subExt 0 a
+                storeWord dst value
+                modify $ \st -> st{nFlag = value < 0, zFlag = value == 0, vFlag = overflow, cFlag = carry}
+                nextPc
+            Neg{mode = Byte, dst} -> do
+                a <- fetchByte dst
+                let Ext{value, carry, overflow} = subExt 0 a
+                storeByte dst value
+                modify $ \st -> st{nFlag = value < 0, zFlag = value == 0, vFlag = overflow, cFlag = carry}
+                nextPc
             And{mode = Long, src, dst} -> wordCmd2 src dst (.&.)
             And{mode = Byte, src, dst} -> byteCmd2 src dst (.&.)
             Or{mode = Long, src, dst} -> wordCmd2 src dst (.|.)

--- a/src/wrench/Wrench/Isa/M68k.hs
+++ b/src/wrench/Wrench/Isa/M68k.hs
@@ -79,6 +79,7 @@ data Isa w l
     | MoveA {mode :: Mode, src, dst :: Argument w l}
     | Not {mode :: Mode, dst :: Argument w l}
     | Neg {mode :: Mode, dst :: Argument w l}
+    | Clr {mode :: Mode, dst :: Argument w l}
     | And {mode :: Mode, src, dst :: Argument w l}
     | Or {mode :: Mode, src, dst :: Argument w l}
     | Xor {mode :: Mode, src, dst :: Argument w l}
@@ -121,6 +122,7 @@ instance (MachineWord w) => MnemonicParser (Isa w (Ref w)) where
             , cmd2args "movea" MoveA longMode src addrRegister
             , cmd1args "not" Not (longMode <|> byteMode) dst
             , cmd1args "neg" Neg (longMode <|> byteMode) dst
+            , cmd1args "clr" Clr (longMode <|> byteMode) dst
             , cmd2args "and" And (longMode <|> byteMode) src dst
             , cmd2args "or" Or (longMode <|> byteMode) src dst
             , cmd2args "xor" Xor (longMode <|> byteMode) src dst
@@ -284,6 +286,7 @@ instance DerefMnemonic (Isa w) w where
                 MoveA{mode, src, dst} -> MoveA mode (derefArg src) (derefArg dst)
                 Not{mode, dst} -> Not mode (derefArg dst)
                 Neg{mode, dst} -> Neg mode (derefArg dst)
+                Clr{mode, dst} -> Clr mode (derefArg dst)
                 And{mode, src, dst} -> And mode (derefArg src) (derefArg dst)
                 Or{mode, src, dst} -> Or mode (derefArg src) (derefArg dst)
                 Xor{mode, src, dst} -> Xor mode (derefArg src) (derefArg dst)
@@ -328,6 +331,7 @@ instance (ByteSizeT w) => ByteSize (Isa w l) where
     byteSize (MoveA _mode src dst) = 2 + byteSize src + byteSize dst
     byteSize (Not _mode dst) = 2 + byteSize dst
     byteSize (Neg _mode dst) = 2 + byteSize dst
+    byteSize (Clr _mode dst) = 2 + byteSize dst
     byteSize (And _mode src dst) = 2 + byteSize src + byteSize dst
     byteSize (Or _mode src dst) = 2 + byteSize src + byteSize dst
     byteSize (Xor _mode src dst) = 2 + byteSize src + byteSize dst
@@ -563,6 +567,14 @@ instance (MachineWord w) => Machine (MachineState (IoMem (Isa w w) w) w) (Isa w 
             MoveA{mode = Byte} -> error "not implemented"
             Not{mode = Long, dst} -> wordCmd1 dst dst complement
             Not{mode = Byte, dst} -> byteCmd1 dst dst complement
+            Clr{mode = Long, dst} -> do
+                storeWord dst 0
+                modify $ \st -> st{nFlag = False, zFlag = True, vFlag = False, cFlag = False}
+                nextPc
+            Clr{mode = Byte, dst} -> do
+                storeByte dst 0
+                modify $ \st -> st{nFlag = False, zFlag = True, vFlag = False, cFlag = False}
+                nextPc
             Neg{mode = Long, dst} -> do
                 a <- fetchWord dst
                 let Ext{value, carry, overflow} = subExt 0 a

--- a/src/wrench/Wrench/Isa/VliwIv.hs
+++ b/src/wrench/Wrench/Isa/VliwIv.hs
@@ -397,6 +397,7 @@ getReg r = do
             raiseInternalError $ "wrong register: " <> show r
             return def
 
+setReg Zero _ = return ()
 setReg r value = modify $ \st@State{regs} -> st{regs = insert r value regs}
 
 getWord addr = do

--- a/test/Wrench/Isa/M68k/Test.hs
+++ b/test/Wrench/Isa/M68k/Test.hs
@@ -344,6 +344,13 @@ tests =
              in do
                     (dataRegs !? D0) @?= Just 0x00
                     zFlag @?= True
+        , testCase "Division by zero" $ do
+            let State{internalError} =
+                    simulate "div.l D1, D0" st0{dataRegs = insert D1 0 $ insert D0 10 dataRegs0}
+             in internalError @?= Just "division by zero"
+            let State{internalError} =
+                    simulate "div.b D1, D0" st0{dataRegs = insert D1 0 $ insert D0 10 dataRegs0}
+             in internalError @?= Just "division by zero"
         , testCase "LINK and UNLK operations" $ do
             let State{addrRegs, mem} =
                     simulate

--- a/test/Wrench/Isa/M68k/Test.hs
+++ b/test/Wrench/Isa/M68k/Test.hs
@@ -319,6 +319,19 @@ tests =
             let State{cFlag} =
                     simulate "asl.l D1, D0" st0{dataRegs = insert D1 1 $ insert D0 minBound dataRegs0}
              in cFlag @?= True -- minBound has bit 31 set
+        , testCase "Negate operations" $ do
+            let State{dataRegs, nFlag} = simulate "neg.l D0" st0{dataRegs = insert D0 5 dataRegs0}
+             in do
+                    (dataRegs !? D0) @?= Just (-5)
+                    nFlag @?= True
+            let State{dataRegs, zFlag} = simulate "neg.l D0" st0{dataRegs = insert D0 0 dataRegs0}
+             in do
+                    (dataRegs !? D0) @?= Just 0
+                    zFlag @?= True
+            let State{dataRegs, nFlag} = simulate "neg.b D0" st0{dataRegs = insert D0 3 dataRegs0}
+             in do
+                    (dataRegs !? D0) @?= Just (-3)
+                    nFlag @?= True
         , testCase "LINK and UNLK operations" $ do
             let State{addrRegs, mem} =
                     simulate

--- a/test/Wrench/Isa/M68k/Test.hs
+++ b/test/Wrench/Isa/M68k/Test.hs
@@ -332,6 +332,18 @@ tests =
              in do
                     (dataRegs !? D0) @?= Just (-3)
                     nFlag @?= True
+        , testCase "Clear operations" $ do
+            let State{dataRegs, zFlag, nFlag, vFlag, cFlag} = simulate "clr.l D0" st0{dataRegs = insert D0 42 dataRegs0}
+             in do
+                    (dataRegs !? D0) @?= Just 0
+                    zFlag @?= True
+                    nFlag @?= False
+                    vFlag @?= False
+                    cFlag @?= False
+            let State{dataRegs, zFlag} = simulate "clr.b D0" st0{dataRegs = insert D0 0xFF dataRegs0}
+             in do
+                    (dataRegs !? D0) @?= Just 0x00
+                    zFlag @?= True
         , testCase "LINK and UNLK operations" $ do
             let State{addrRegs, mem} =
                     simulate


### PR DESCRIPTION
## Summary
- Add `neg.<size>` instruction (negate: 0 - destination, sets all flags)
- Add `clr.<size>` instruction (clear to zero, sets Z=1, clears N/V/C)
- Handle division by zero gracefully with `raiseInternalError` instead of Haskell runtime crash

## Test plan
- [x] Unit tests for neg.l, neg.b (positive, zero inputs, flag checks)
- [x] Unit tests for clr.l, clr.b (flag checks)
- [x] Unit tests for div.l and div.b with zero divisor
- [x] All 496 tests pass