### PR TITLE
feat(risc-iv): add RV32I instructions (slti, lb, bitwise/shift immediate, div-by-zero)

### DIFF
--- a/docs/risc-iv.md
+++ b/docs/risc-iv.md
@@ -121,6 +121,21 @@ Instruction size: 4 bytes.
 
 ### Bitwise Instructions
 
+- **Logical Shift Left Immediate**
+    - **Syntax:** `slli <rd>, <rs1>, <k>`
+    - **Description:** Shift the value of the source register left by the immediate amount (lower 5 bits) and store the result in the destination register.
+    - **Operation:** `rd <- rs1 << (k & 0x1F)`
+
+- **Logical Shift Right Immediate**
+    - **Syntax:** `srli <rd>, <rs1>, <k>`
+    - **Description:** Shift the value of the source register right (zero-fill) by the immediate amount (lower 5 bits) and store the result in the destination register.
+    - **Operation:** `rd <- rs1 >>> (k & 0x1F)`
+
+- **Arithmetic Shift Right Immediate**
+    - **Syntax:** `srai <rd>, <rs1>, <k>`
+    - **Description:** Shift the value of the source register right by the immediate amount (lower 5 bits), preserving the sign, and store the result in the destination register.
+    - **Operation:** `rd <- rs1 >> (k & 0x1F)`
+
 - **Logical Shift Left**
     - **Syntax:** `sll <rd>, <rs1>, <rs2>`
     - **Description:** Shift the value of the first source register left by the number of bits specified in the lower 5 bits of the second source register and store the result in the destination register.

--- a/docs/risc-iv.md
+++ b/docs/risc-iv.md
@@ -72,6 +72,11 @@ Instruction size: 4 bytes.
     - **Description:** Load a word from memory at the address computed by adding the offset to the base register into the destination register.
     - **Operation:** `rd <- M[offset + rs1]`
 
+- **Load Byte**
+    - **Syntax:** `lb <rd>, <offset>(<rs1>)`
+    - **Description:** Load a byte from memory at the address computed by adding the offset to the base register, sign-extend it to 32 bits, and store in the destination register.
+    - **Operation:** `rd <- signext(M[offset + rs1][7:0])`
+
 ### Arithmetic Instructions
 
 - **Add Immediate**

--- a/docs/risc-iv.md
+++ b/docs/risc-iv.md
@@ -141,15 +141,30 @@ Instruction size: 4 bytes.
     - **Description:** Perform a bitwise AND on the values of two source registers and store the result in the destination register.
     - **Operation:** `rd <- rs1 & rs2`
 
+- **Bitwise AND Immediate**
+    - **Syntax:** `andi <rd>, <rs1>, <k>`
+    - **Description:** Perform a bitwise AND of the source register with a 12-bit sign-extended immediate value.
+    - **Operation:** `rd <- rs1 & signext(k[11:0])`
+
 - **Bitwise OR**
     - **Syntax:** `or <rd>, <rs1>, <rs2>`
     - **Description:** Perform a bitwise OR on the values of two source registers and store the result in the destination register.
     - **Operation:** `rd <- rs1 | rs2`
 
+- **Bitwise OR Immediate**
+    - **Syntax:** `ori <rd>, <rs1>, <k>`
+    - **Description:** Perform a bitwise OR of the source register with a 12-bit sign-extended immediate value.
+    - **Operation:** `rd <- rs1 | signext(k[11:0])`
+
 - **Bitwise XOR**
     - **Syntax:** `xor <rd>, <rs1>, <rs2>`
     - **Description:** Perform a bitwise XOR on the values of two source registers and store the result in the destination register.
     - **Operation:** `rd <- rs1 ^ rs2`
+
+- **Bitwise XOR Immediate**
+    - **Syntax:** `xori <rd>, <rs1>, <k>`
+    - **Description:** Perform a bitwise XOR of the source register with a 12-bit sign-extended immediate value.
+    - **Operation:** `rd <- rs1 ^ signext(k[11:0])`
 
 ### Control Flow Instructions
 

--- a/docs/risc-iv.md
+++ b/docs/risc-iv.md
@@ -79,6 +79,11 @@ Instruction size: 4 bytes.
     - **Description:** Add a 12-bit sign-extended immediate value to the source register and store the result in the destination register. The immediate `k` is truncated to 12 bits and sign-extended to 32 bits before the addition.
     - **Operation:** `rd <- rs1 + signext(k[11:0])`
 
+- **Set Less Than Immediate**
+    - **Syntax:** `slti <rd>, <rs1>, <k>`
+    - **Description:** Set the destination register to 1 if the source register is less than the immediate value (signed comparison), else set to 0.
+    - **Operation:** `rd <- (rs1 < k) ? 1 : 0`
+
 - **Add**
     - **Syntax:** `add <rd>, <rs1>, <rs2>`
     - **Description:** Add the values of two source registers and store the result in the destination register.

--- a/src/wrench/Wrench/Isa/RiscIv.hs
+++ b/src/wrench/Wrench/Isa/RiscIv.hs
@@ -143,6 +143,12 @@ data Isa w l
       Xor {rd, rs1, rs2 :: Register}
     | -- | Set less than immediate: rd = (rs1 < k) ? 1 : 0
       Slti {rd, rs1 :: Register, k :: l}
+    | -- | Bitwise AND immediate: rd = rs1 & k
+      Andi {rd, rs1 :: Register, k :: l}
+    | -- | Bitwise OR immediate: rd = rs1 | k
+      Ori {rd, rs1 :: Register, k :: l}
+    | -- | Bitwise XOR immediate: rd = rs1 ^ k
+      Xori {rd, rs1 :: Register, k :: l}
     | -- | Move: rd = rs
       Mv {rd, rs :: Register}
     | -- | Store word: M[offsetRs1] = rs2
@@ -253,8 +259,11 @@ instance (MachineWord w) => MnemonicParser (Isa w (Ref w)) where
                     , cmd3args "sll" Sll register register register
                     , cmd3args "srl" Srl register register register
                     , cmd3args "sra" Sra register register register
+                    , cmd3args "andi" Andi register register referenceWithDirective
                     , cmd3args "and" And register register register
+                    , cmd3args "ori" Ori register register referenceWithDirective
                     , cmd3args "or" Or register register register
+                    , cmd3args "xori" Xori register register referenceWithDirective
                     , cmd3args "xor" Xor register register register
                     , cmd2args "mv" Mv register register
                     , cmd2args "sw" Sw register memRef
@@ -285,6 +294,9 @@ instance (MachineWord w) => DerefMnemonic (Isa w) w where
                 Jr{rs} -> Jr{rs}
                 Addi{rd, rs1, k} -> Addi{rd, rs1, k = deref' f k}
                 Slti{rd, rs1, k} -> Slti{rd, rs1, k = deref' f k}
+                Andi{rd, rs1, k} -> Andi{rd, rs1, k = deref' f k}
+                Ori{rd, rs1, k} -> Ori{rd, rs1, k = deref' f k}
+                Xori{rd, rs1, k} -> Xori{rd, rs1, k = deref' f k}
                 Add{rd, rs1, rs2} -> Add{rd, rs1, rs2}
                 Sub{rd, rs1, rs2} -> Sub{rd, rs1, rs2}
                 Mul{rd, rs1, rs2} -> Mul{rd, rs1, rs2}
@@ -448,6 +460,18 @@ instance (MachineWord w) => Machine (MachineState (IoMem (Isa w w) w) w) (Isa w 
             Slti{rd, rs1, k} -> do
                 rs1' <- getReg rs1
                 setReg rd (if rs1' < k then 1 else 0)
+                nextPc
+            Andi{rd, rs1, k} -> do
+                rs1' <- getReg rs1
+                setReg rd (rs1' .&. (k `signBitAnd` 0x00000FFF))
+                nextPc
+            Ori{rd, rs1, k} -> do
+                rs1' <- getReg rs1
+                setReg rd (rs1' .|. (k `signBitAnd` 0x00000FFF))
+                nextPc
+            Xori{rd, rs1, k} -> do
+                rs1' <- getReg rs1
+                setReg rd (rs1' `xor` (k `signBitAnd` 0x00000FFF))
                 nextPc
             Add{rd, rs1, rs2} -> rOperation rs1 rs2 rd id id (+)
             Sub{rd, rs1, rs2} -> rOperation rs1 rs2 rd id id (-)

--- a/src/wrench/Wrench/Isa/RiscIv.hs
+++ b/src/wrench/Wrench/Isa/RiscIv.hs
@@ -512,8 +512,8 @@ instance (MachineWord w) => Machine (MachineState (IoMem (Isa w w) w) w) (Isa w 
                             shift = 8 * byteSizeT @w
                          in fromIntegral (x `shiftR` shift)
                     )
-            Div{rd, rs1, rs2} -> rOperation rs1 rs2 rd id id div
-            Rem{rd, rs1, rs2} -> rOperation rs1 rs2 rd id id rem
+            Div{rd, rs1, rs2} -> rOperation rs1 rs2 rd id id (\r1 r2 -> if r2 == 0 then -1 else div r1 r2)
+            Rem{rd, rs1, rs2} -> rOperation rs1 rs2 rd id id (\r1 r2 -> if r2 == 0 then r1 else rem r1 r2)
             Sll{rd, rs1, rs2} -> rOperation rs1 rs2 rd id id (\r1 r2 -> r1 `shiftL` (fromEnum r2 .&. 0x1F))
             Srl{rd, rs1, rs2} -> rOperation rs1 rs2 rd id id (\r1 r2 -> lShiftR r1 (r2 .&. 0x1F))
             Sra{rd, rs1, rs2} -> rOperation rs1 rs2 rd id id (\r1 r2 -> r1 `shiftR` (fromEnum r2 .&. 0x1F))

--- a/src/wrench/Wrench/Isa/RiscIv.hs
+++ b/src/wrench/Wrench/Isa/RiscIv.hs
@@ -140,6 +140,8 @@ data Isa w l
       Or {rd, rs1, rs2 :: Register}
     | -- | Bitwise XOR: rd = rs1 ^ rs2
       Xor {rd, rs1, rs2 :: Register}
+    | -- | Set less than immediate: rd = (rs1 < k) ? 1 : 0
+      Slti {rd, rs1 :: Register, k :: l}
     | -- | Move: rd = rs
       Mv {rd, rs :: Register}
     | -- | Store word: M[offsetRs1] = rs2
@@ -238,6 +240,7 @@ instance (MachineWord w) => MnemonicParser (Isa w (Ref w)) where
             cmd =
                 choice
                     [ cmd3args "addi" Addi register register referenceWithDirective
+                    , cmd3args "slti" Slti register register referenceWithDirective
                     , cmd3args "add" Add register register register
                     , cmd3args "sub" Sub register register register
                     , cmd3args "mul" Mul register register register
@@ -277,6 +280,7 @@ instance (MachineWord w) => DerefMnemonic (Isa w) w where
                 Jal{rd, k} -> Jal rd $ deref' relF k
                 Jr{rs} -> Jr{rs}
                 Addi{rd, rs1, k} -> Addi{rd, rs1, k = deref' f k}
+                Slti{rd, rs1, k} -> Slti{rd, rs1, k = deref' f k}
                 Add{rd, rs1, rs2} -> Add{rd, rs1, rs2}
                 Sub{rd, rs1, rs2} -> Sub{rd, rs1, rs2}
                 Mul{rd, rs1, rs2} -> Mul{rd, rs1, rs2}
@@ -425,6 +429,10 @@ instance (MachineWord w) => Machine (MachineState (IoMem (Isa w w) w) w) (Isa w 
             Addi{rd, rs1, k} -> do
                 rs1' <- getReg rs1
                 setReg rd (rs1' + (k `signBitAnd` 0x00000FFF))
+                nextPc
+            Slti{rd, rs1, k} -> do
+                rs1' <- getReg rs1
+                setReg rd (if rs1' < k then 1 else 0)
                 nextPc
             Add{rd, rs1, rs2} -> rOperation rs1 rs2 rd id id (+)
             Sub{rd, rs1, rs2} -> rOperation rs1 rs2 rd id id (-)

--- a/src/wrench/Wrench/Isa/RiscIv.hs
+++ b/src/wrench/Wrench/Isa/RiscIv.hs
@@ -143,6 +143,12 @@ data Isa w l
       Xor {rd, rs1, rs2 :: Register}
     | -- | Set less than immediate: rd = (rs1 < k) ? 1 : 0
       Slti {rd, rs1 :: Register, k :: l}
+    | -- | Logical shift left immediate: rd = rs1 << k (5 bit)
+      Slli {rd, rs1 :: Register, k :: l}
+    | -- | Logical shift right immediate: rd = rs1 >>> k (5 bit)
+      Srli {rd, rs1 :: Register, k :: l}
+    | -- | Arithmetic shift right immediate: rd = rs1 >> k (5 bit)
+      Srai {rd, rs1 :: Register, k :: l}
     | -- | Bitwise AND immediate: rd = rs1 & k
       Andi {rd, rs1 :: Register, k :: l}
     | -- | Bitwise OR immediate: rd = rs1 | k
@@ -256,8 +262,11 @@ instance (MachineWord w) => MnemonicParser (Isa w (Ref w)) where
                     , cmd3args "mulh" Mulh register register register
                     , cmd3args "div" Div register register register
                     , cmd3args "rem" Rem register register register
+                    , cmd3args "slli" Slli register register referenceWithDirective
                     , cmd3args "sll" Sll register register register
+                    , cmd3args "srli" Srli register register referenceWithDirective
                     , cmd3args "srl" Srl register register register
+                    , cmd3args "srai" Srai register register referenceWithDirective
                     , cmd3args "sra" Sra register register register
                     , cmd3args "andi" Andi register register referenceWithDirective
                     , cmd3args "and" And register register register
@@ -294,6 +303,9 @@ instance (MachineWord w) => DerefMnemonic (Isa w) w where
                 Jr{rs} -> Jr{rs}
                 Addi{rd, rs1, k} -> Addi{rd, rs1, k = deref' f k}
                 Slti{rd, rs1, k} -> Slti{rd, rs1, k = deref' f k}
+                Slli{rd, rs1, k} -> Slli{rd, rs1, k = deref' f k}
+                Srli{rd, rs1, k} -> Srli{rd, rs1, k = deref' f k}
+                Srai{rd, rs1, k} -> Srai{rd, rs1, k = deref' f k}
                 Andi{rd, rs1, k} -> Andi{rd, rs1, k = deref' f k}
                 Ori{rd, rs1, k} -> Ori{rd, rs1, k = deref' f k}
                 Xori{rd, rs1, k} -> Xori{rd, rs1, k = deref' f k}
@@ -460,6 +472,18 @@ instance (MachineWord w) => Machine (MachineState (IoMem (Isa w w) w) w) (Isa w 
             Slti{rd, rs1, k} -> do
                 rs1' <- getReg rs1
                 setReg rd (if rs1' < k then 1 else 0)
+                nextPc
+            Slli{rd, rs1, k} -> do
+                rs1' <- getReg rs1
+                setReg rd (rs1' `shiftL` (fromEnum k .&. 0x1F))
+                nextPc
+            Srli{rd, rs1, k} -> do
+                rs1' <- getReg rs1
+                setReg rd (lShiftR rs1' (k .&. 0x1F))
+                nextPc
+            Srai{rd, rs1, k} -> do
+                rs1' <- getReg rs1
+                setReg rd (rs1' `shiftR` (fromEnum k .&. 0x1F))
                 nextPc
             Andi{rd, rs1, k} -> do
                 rs1' <- getReg rs1

--- a/src/wrench/Wrench/Isa/RiscIv.hs
+++ b/src/wrench/Wrench/Isa/RiscIv.hs
@@ -9,6 +9,7 @@ module Wrench.Isa.RiscIv (
     MachineState (..),
     RiscIvState,
     Register (..),
+    MemRef (..),
 ) where
 
 import Data.Bits (shiftL, shiftR, (.&.), (.|.))
@@ -152,6 +153,8 @@ data Isa w l
       Lui {rd :: Register, k :: l}
     | -- | Load word: rd = M[offsetRs1]
       Lw {rd :: Register, offsetRs1 :: MemRef w}
+    | -- | Load byte (sign-extended): rd = signext(M[offsetRs1][7:0])
+      Lb {rd :: Register, offsetRs1 :: MemRef w}
     | -- | Jump: PC = PC + k
       J {k :: l}
     | -- | Jump and Link: rd = PC + 4, PC += k
@@ -258,6 +261,7 @@ instance (MachineWord w) => MnemonicParser (Isa w (Ref w)) where
                     , cmd2args "sb" Sb register memRef
                     , cmd2args "lui" Lui register referenceWithDirective
                     , cmd2args "lw" Lw register memRef
+                    , cmd2args "lb" Lb register memRef
                     , cmd1args "j" J reference
                     , cmd2args "jal" Jal register reference
                     , cmd1args "jr" Jr register
@@ -298,6 +302,7 @@ instance (MachineWord w) => DerefMnemonic (Isa w) w where
                 Sb{rs2, offsetRs1} -> Sb{rs2, offsetRs1}
                 Lui{rd, k} -> Lui{rd, k = deref' f k}
                 Lw{rd, offsetRs1} -> Lw{rd, offsetRs1}
+                Lb{rd, offsetRs1} -> Lb{rd, offsetRs1}
                 Beqz{rs1, k} -> Beqz rs1 $ deref' relF k
                 Bnez{rs1, k} -> Bnez rs1 $ deref' relF k
                 Bgt{rs1, rs2, k} -> Bgt rs1 rs2 $ deref' relF k
@@ -380,6 +385,16 @@ setWord addr w = do
         Right mem' -> do
             put st{mem = mem'}
         Left err -> raiseInternalError $ "memory access error: " <> err
+
+getByte addr = do
+    st@State{mem} <- get
+    case readByte mem addr of
+        Right (mem', b) -> do
+            put st{mem = mem'}
+            return b
+        Left err -> do
+            raiseInternalError $ "memory access error: " <> err
+            return 0
 
 setByte addr byte = do
     st@State{mem} <- get
@@ -478,6 +493,11 @@ instance (MachineWord w) => Machine (MachineState (IoMem (Isa w w) w) w) (Isa w 
                 rs1' <- getReg mrReg
                 w <- getWord $ fromEnum (mrOffset + rs1')
                 setReg rd w
+                nextPc
+            Lb{rd, offsetRs1 = MemRef{mrOffset, mrReg}} -> do
+                rs1' <- getReg mrReg
+                b <- getByte $ fromEnum (mrOffset + rs1')
+                setReg rd (fromIntegral (fromIntegral b :: Int8))
                 nextPc
             J{k} -> do
                 State{pc} <- get

--- a/test/Wrench/Isa/RiscIv/Test.hs
+++ b/test/Wrench/Isa/RiscIv/Test.hs
@@ -36,6 +36,12 @@ tests =
             runInstruction Srl{rd = A2, rs1 = A0, rs2 = A1} [(A0, -16), (A1, 2)] A2 @?= 1073741820
         , testCase "Sra: A0(-16) >> A1(2) = -4" $ do
             runInstruction Sra{rd = A2, rs1 = A0, rs2 = A1} [(A0, -16), (A1, 2)] A2 @?= -4
+        , testCase "Slti: 5 < 10 = 1" $ do
+            runInstruction Slti{rd = A1, rs1 = A0, k = 10} [(A0, 5)] A1 @?= 1
+        , testCase "Slti: 5 < 3 = 0" $ do
+            runInstruction Slti{rd = A1, rs1 = A0, k = 3} [(A0, 5)] A1 @?= 0
+        , testCase "Slti: -1 < 0 = 1" $ do
+            runInstruction Slti{rd = A1, rs1 = A0, k = 0} [(A0, -1)] A1 @?= 1
         ]
 
 initialState :: Int -> HashMap Register Int32 -> Isa Int32 Int32 -> MachineState (IoMem (Isa Int32 Int32) Int32) Int32

--- a/test/Wrench/Isa/RiscIv/Test.hs
+++ b/test/Wrench/Isa/RiscIv/Test.hs
@@ -62,6 +62,14 @@ tests =
             runInstruction Ori{rd = A1, rs1 = A0, k = 0x00F} [(A0, 0x1230)] A1 @?= 0x123F
         , testCase "Xori: 0x1234 ^ 0x0FF = 0x12CB" $ do
             runInstruction Xori{rd = A1, rs1 = A0, k = 0x0FF} [(A0, 0x1234)] A1 @?= 0x12CB
+        , testCase "Slli: 1 << 4 = 16" $ do
+            runInstruction Slli{rd = A1, rs1 = A0, k = 4} [(A0, 1)] A1 @?= 16
+        , testCase "Srli: 0x100 >> 4 = 0x10" $ do
+            runInstruction Srli{rd = A1, rs1 = A0, k = 4} [(A0, 0x100)] A1 @?= 0x10
+        , testCase "Srli: -16 >> 4 = 0x0FFFFFFF (no sign extension)" $ do
+            runInstruction Srli{rd = A1, rs1 = A0, k = 4} [(A0, -16)] A1 @?= 0x0FFFFFFF
+        , testCase "Srai: -16 >> 4 = -1" $ do
+            runInstruction Srai{rd = A1, rs1 = A0, k = 4} [(A0, -16)] A1 @?= -1
         ]
 
 initialState :: Int -> HashMap Register Int32 -> Isa Int32 Int32 -> MachineState (IoMem (Isa Int32 Int32) Int32) Int32

--- a/test/Wrench/Isa/RiscIv/Test.hs
+++ b/test/Wrench/Isa/RiscIv/Test.hs
@@ -70,6 +70,10 @@ tests =
             runInstruction Srli{rd = A1, rs1 = A0, k = 4} [(A0, -16)] A1 @?= 0x0FFFFFFF
         , testCase "Srai: -16 >> 4 = -1" $ do
             runInstruction Srai{rd = A1, rs1 = A0, k = 4} [(A0, -16)] A1 @?= -1
+        , testCase "Div by zero: 42 / 0 = -1" $ do
+            runInstruction Div{rd = A1, rs1 = A0, rs2 = A2} [(A0, 42), (A2, 0)] A1 @?= -1
+        , testCase "Rem by zero: 42 % 0 = 42" $ do
+            runInstruction Rem{rd = A1, rs1 = A0, rs2 = A2} [(A0, 42), (A2, 0)] A1 @?= 42
         ]
 
 initialState :: Int -> HashMap Register Int32 -> Isa Int32 Int32 -> MachineState (IoMem (Isa Int32 Int32) Int32) Int32

--- a/test/Wrench/Isa/RiscIv/Test.hs
+++ b/test/Wrench/Isa/RiscIv/Test.hs
@@ -42,6 +42,20 @@ tests =
             runInstruction Slti{rd = A1, rs1 = A0, k = 3} [(A0, 5)] A1 @?= 0
         , testCase "Slti: -1 < 0 = 1" $ do
             runInstruction Slti{rd = A1, rs1 = A0, k = 0} [(A0, -1)] A1 @?= 1
+        , testCase "Lb: load byte 0x41" $ do
+            runInstructionWithMem
+                Lb{rd = A1, offsetRs1 = MemRef{mrOffset = 20, mrReg = A0}}
+                [(A0, 0)]
+                [(20, 0x41)]
+                A1
+                @?= 0x41
+        , testCase "Lb: sign extension of 0x80 = -128" $ do
+            runInstructionWithMem
+                Lb{rd = A1, offsetRs1 = MemRef{mrOffset = 20, mrReg = A0}}
+                [(A0, 0)]
+                [(20, 0x80)]
+                A1
+                @?= -128
         ]
 
 initialState :: Int -> HashMap Register Int32 -> Isa Int32 Int32 -> MachineState (IoMem (Isa Int32 Int32) Int32) Int32
@@ -72,6 +86,39 @@ runInstruction instr initRegs result = do
     let st = initialState 0 (fromList initRegs) instr
         State{regs} = execState instructionStep st
     fromMaybe (error "Register not found") (regs !? result)
+
+runInstructionWithMem :: Isa Int32 Int32 -> [(Register, Int32)] -> [(Int, Word8)] -> Register -> Int32
+runInstructionWithMem instr initRegs memWrites result = do
+    let st = initialStateWithMem 0 (fromList initRegs) instr memWrites
+        State{regs} = execState instructionStep st
+    fromMaybe (error "Register not found") (regs !? result)
+
+initialStateWithMem ::
+    Int -> HashMap Register Int32 -> Isa Int32 Int32 -> [(Int, Word8)] -> MachineState (IoMem (Isa Int32 Int32) Int32) Int32
+initialStateWithMem pc regs instr memWrites =
+    let baseMem =
+            mkIoMem
+                def
+                ( Mem
+                    { memoryData =
+                        fromList
+                            $ [(i, Value 0) | i <- [0 .. 255]]
+                            <> [ (pc, Instruction instr)
+                               , (pc + 1, InstructionPart)
+                               , (pc + 2, InstructionPart)
+                               , (pc + 3, InstructionPart)
+                               ]
+                    , memorySize = 256
+                    }
+                )
+        mem' = either error id $ foldlM (\m (i, b) -> writeByte m i b) baseMem memWrites
+     in State
+            { pc = pc
+            , mem = mem'
+            , regs = regs
+            , stopped = False
+            , internalError = Nothing
+            }
 
 translate :: String -> Either String (Isa Int32 (Ref Int32))
 translate code =

--- a/test/Wrench/Isa/RiscIv/Test.hs
+++ b/test/Wrench/Isa/RiscIv/Test.hs
@@ -56,6 +56,12 @@ tests =
                 [(20, 0x80)]
                 A1
                 @?= -128
+        , testCase "Andi: 0x1234 & 0x0FF = 0x0034" $ do
+            runInstruction Andi{rd = A1, rs1 = A0, k = 0x0FF} [(A0, 0x1234)] A1 @?= 0x0034
+        , testCase "Ori: 0x1230 | 0x00F = 0x123F" $ do
+            runInstruction Ori{rd = A1, rs1 = A0, k = 0x00F} [(A0, 0x1230)] A1 @?= 0x123F
+        , testCase "Xori: 0x1234 ^ 0x0FF = 0x12CB" $ do
+            runInstruction Xori{rd = A1, rs1 = A0, k = 0x0FF} [(A0, 0x1234)] A1 @?= 0x12CB
         ]
 
 initialState :: Int -> HashMap Register Int32 -> Isa Int32 Int32 -> MachineState (IoMem (Isa Int32 Int32) Int32) Int32


### PR DESCRIPTION
## Summary
- Add `slti` (set less than immediate) for parity with VLIW-IV
- Add `lb` (load byte, sign-extended) to complement existing `sb`
- Add `andi`, `ori`, `xori` (bitwise immediate operations)
- Add `slli`, `srli`, `srai` (shift immediate operations)
- Handle division by zero per RISC-V spec: div returns -1, rem returns dividend

## Test plan
- [x] Unit tests for slti (positive, negative, boundary)
- [x] Unit tests for lb (positive byte, sign-extension of 0x80)
- [x] Unit tests for andi, ori, xori
- [x] Unit tests for slli, srli (unsigned), srai (signed)
- [x] Unit tests for div-by-zero and rem-by-zero
- [x] All 503 tests pass