### PR TITLE
feat(vliw-iv): add lb instruction (load byte)

### DIFF
--- a/docs/vliw-iv.md
+++ b/docs/vliw-iv.md
@@ -154,6 +154,11 @@ add rd, rs1, rs2 / addi rd, rs1, k / lw rd, offset(rs1) / beq rs1, rs2, k
     - **Description:** Load a word from memory at the address computed by adding the offset to the base register into the destination register.
     - **Operation:** `rd <- M[offset + rs1]`
 
+- **Load Byte**
+    - **Syntax:** `lb <rd>, <offset>(<rs1>)`
+    - **Description:** Load a byte from memory at the address computed by adding the offset to the base register, sign-extend it to 32 bits, and store in the destination register.
+    - **Operation:** `rd <- signext(M[offset + rs1][7:0])`
+
 - **Store Word**
     - **Syntax:** `sw <rs2>, <offset>(<rs1>)`
     - **Description:** Store the value from the source register into memory at the address computed by adding the offset to the base register.
@@ -163,8 +168,6 @@ add rd, rs1, rs2 / addi rd, rs1, k / lw rd, offset(rs1) / beq rs1, rs2, k
     - **Syntax:** `sb <rs2>, <offset>(<rs1>)`
     - **Description:** Store the lower 8 bits of the value from the source register into memory at the address computed by adding the offset to the base register.
     - **Operation:** `M[offset + rs1] <- rs2 & 0xFF`
-
-> **Note:** There is no `lb` (load byte) instruction. Byte-level reads can be performed by loading a word with `lw` and using ALU operations to extract the desired byte.
 
 - **NOP**
     - **Syntax:** `nop`

--- a/src/wrench/Wrench/Isa/VliwIv.hs
+++ b/src/wrench/Wrench/Isa/VliwIv.hs
@@ -117,6 +117,7 @@ instance (Default w) => Default (HashMap Register w) where
 
 data MemoryOp w l
     = Lw {lwRd :: Register, lwOffsetRs1 :: MemRef w}
+    | Lb {lbRd :: Register, lbOffsetRs1 :: MemRef w}
     | Sw {swRs2 :: Register, swOffsetRs1 :: MemRef w}
     | Sb {sbRs2 :: Register, sbOffsetRs1 :: MemRef w}
     | NopM
@@ -227,6 +228,7 @@ parseMemOp :: (MachineWord w) => Parser (MemoryOp w (Ref w))
 parseMemOp =
     choice
         [ cmd2args "lw" Lw register memRef
+        , cmd2args "lb" Lb register memRef
         , cmd2args "sw" Sw register memRef
         , cmd2args "sb" Sb register memRef
         , string "nop" >> return NopM
@@ -289,6 +291,7 @@ instance (MachineWord w) => MnemonicParser (Isa w (Ref w)) where
 instance DerefMnemonic (MemoryOp w) w where
     derefMnemonic _ _ NopM = NopM
     derefMnemonic _ _ (Lw lwRd lwOffsetRs1) = Lw lwRd lwOffsetRs1
+    derefMnemonic _ _ (Lb lbRd lbOffsetRs1) = Lb lbRd lbOffsetRs1
     derefMnemonic _ _ (Sw swRs2 swOffsetRs1) = Sw swRs2 swOffsetRs1
     derefMnemonic _ _ (Sb sbRs2 sbOffsetRs1) = Sb sbRs2 sbOffsetRs1
 
@@ -417,6 +420,16 @@ setWord addr w = do
             put st{mem = mem'}
         Left err -> raiseInternalError $ "memory access error: " <> err
 
+getByte addr = do
+    st@State{mem} <- get
+    case readByte mem addr of
+        Right (mem', b) -> do
+            put st{mem = mem'}
+            return b
+        Left err -> do
+            raiseInternalError $ "memory access error: " <> err
+            return 0
+
 setByte addr byte = do
     st@State{mem} <- get
     case writeByte mem addr byte of
@@ -501,6 +514,10 @@ instance (MachineWord w) => Machine (MachineState (IoMem (Isa w w) w) w) (Isa w 
                 rs1' <- getReg mrReg
                 w <- getWord $ fromEnum (mrOffset + rs1')
                 return $ Just (lwRd, w)
+            computeMem (Lb lbRd (MemRef mrOffset mrReg)) = do
+                rs1' <- getReg mrReg
+                b <- getByte $ fromEnum (mrOffset + rs1')
+                return $ Just (lbRd, fromIntegral (fromIntegral b :: Int8))
             computeMem (Sw swRs2 (MemRef mrOffset mrReg)) = do
                 rs2' <- getReg swRs2
                 mrReg' <- getReg mrReg

--- a/test/Wrench/Isa/VliwIv/Test.hs
+++ b/test/Wrench/Isa/VliwIv/Test.hs
@@ -74,6 +74,24 @@ tests =
             case readByte mem 20 of
                 Right (_, b) -> b @?= 0x78
                 Left err -> assertFailure $ "Memory read failed: " <> toString err
+        , testCase "Memory operations: Lb (positive byte)" $ do
+            let st1 = withRegs [(A0, 0)]
+                mem1 = either error id $ do
+                    writeByte (mem st1) 20 0x41
+                State{regs} = simulate "nop / nop / lb a1, 20(a0) / nop" st1{mem = mem1}
+             in (regs !? A1) @?= Just 0x41
+        , testCase "Memory operations: Lb (sign extension for negative byte)" $ do
+            let st1 = withRegs [(A0, 0)]
+                mem1 = either error id $ do
+                    writeByte (mem st1) 20 0x80
+                State{regs} = simulate "nop / nop / lb a1, 20(a0) / nop" st1{mem = mem1}
+             in (regs !? A1) @?= Just (-128)
+        , testCase "Memory operations: Lb with offset (sign extension from 0xFF)" $ do
+            let st1 = withRegs [(A0, 0)]
+                mem1 = either error id $ do
+                    writeByte (mem st1) 25 0xFF
+                State{regs} = simulate "nop / nop / lb a1, 25(a0) / nop" st1{mem = mem1}
+             in (regs !? A1) @?= Just (-1)
         , testCase "Control flow: J (jump)" $ do
             let State{pc} =
                     simulate


### PR DESCRIPTION
## Summary
- Add `lb` (load byte, sign-extended) to the memory slot, complementing existing `sb`
- Especially valuable in VLIW where the memory slot is a bottleneck

## Test plan
- [x] Unit tests for lb (positive byte, sign-extension of 0x80, sign-extension of 0xFF)
- [x] All 492 tests pass