### PR TITLE
feat(f32a): allow bare numeric literals without lit keyword

### DIFF
--- a/docs/f32a.md
+++ b/docs/f32a.md
@@ -46,8 +46,8 @@ Most of the instructions drop (clear) the carry flag. Specifically, any instruct
 ### Data Movement Instructions
 
 - **Literal**
-    - **Syntax:** `lit <value>`
-    - **Description:** Push an immediate value onto the data stack.
+    - **Syntax:** `<value>` or `lit <value>`
+    - **Description:** Push an immediate value onto the data stack. The `lit` keyword is optional — a bare number, hex value (`0xFF`), or character literal (`'A'`) is sufficient.
     - **Operation:** `dataStack.push(<value>)`
 
 - **Fetch from Address**

--- a/example/f32a/factorial.s
+++ b/example/f32a/factorial.s
@@ -24,7 +24,7 @@ swap:
     \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\
 
 multiply:
-    lit 31 >r                \ for R = 31
+    31 >r                \ for R = 31
 multiply_do:
     +*                       \ mres-high:acc-old:n:[]; mres-low in a
     next multiply_do
@@ -34,7 +34,7 @@ multiply_do:
     \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\
 
 factorial:
-    lit 1 swap               \ n:acc:[]
+    1 swap               \ n:acc:[]
 factorial_while:
     dup                      \ n:n:acc:[]
     if factorial_finish      \ n:acc:[]
@@ -42,12 +42,12 @@ factorial_while:
     dup a!                   \ n:acc:[]
 
     swap                     \ acc:n:[]
-    lit 0                    \ 0:acc:n:[]
+    0                        \ 0:acc:n:[]
 
     multiply
 
     swap                     \ n:acc
-    lit -1 +                 \ n-1:acc
+    -1 +                 \ n-1:acc
 
     factorial_while ;
 

--- a/example/f32a/hello.s
+++ b/example/f32a/hello.s
@@ -10,17 +10,17 @@ _start:
 
     lit buf a!               \ a for buf address
 
-    lit 12                   \ hardcoded counter on T
+    12\ hardcoded counter on T
 
 while:
     dup
     if end
 
-    @+ lit 255 and
+    @+ 255 and
 
     !b
 
-    lit -1 +
+    -1 +
     while ;
 
 end:

--- a/src/wrench/Wrench/Isa/F32a.hs
+++ b/src/wrench/Wrench/Isa/F32a.hs
@@ -13,8 +13,9 @@ import Data.Bits (Bits (..), clearBit, complement, setBit, shiftL, shiftR, testB
 import Data.Default (def)
 import Data.Text qualified as T
 import Relude
-import Text.Megaparsec (choice, try)
-import Text.Megaparsec.Char (hspace, hspace1, string)
+import Relude.Unsafe qualified as Unsafe
+import Text.Megaparsec (anySingleBut, choice, try)
+import Text.Megaparsec.Char (char, hspace, hspace1, string)
 import Wrench.Machine.Memory
 import Wrench.Machine.Types
 import Wrench.Report
@@ -133,11 +134,32 @@ instance (MachineWord w) => MnemonicParser (Isa w (Ref w)) where
                 hspace1
                 void $ string ";"
                 return $ Jump label
+            , Lit <$> bareLiteral
             , try $ do
                 label <- reference
                 hspace1 <|> eol' "\\"
                 return $ Call label
             ]
+
+bareLiteral :: (MachineWord w) => Parser (Ref w)
+bareLiteral = try $ do
+    hspace
+    ref <-
+        choice
+            [ do
+                void $ char '\''
+                c <- anySingleBut '\''
+                void $ char '\''
+                return $ ValueR id $ fromIntegral $ ord c
+            , hexNum <&> ValueR id . Unsafe.read
+            , do
+                n <- num
+                guard (not $ null n)
+                guard (n /= "-")
+                return $ ValueR id $ Unsafe.read n
+            ]
+    hspace1 <|> eol' "\\"
+    return ref
 
 cmdMnemonic0 :: String -> Parser ()
 cmdMnemonic0 mnemonic = try $ do

--- a/test/Wrench/Isa/F32a/Test.hs
+++ b/test/Wrench/Isa/F32a/Test.hs
@@ -28,6 +28,21 @@ tests =
         , testCase "Drop removes top" $ do
             let State{dataStack} = simulate "drop" st0{dataStack = [1, 2, 3]}
              in dataStack @?= [2, 3]
+        , testCase "Bare decimal literal pushes to stack" $ do
+            let State{dataStack} = simulate "42" st0
+             in dataStack @?= [42]
+        , testCase "Bare hex literal pushes to stack" $ do
+            let State{dataStack} = simulate "0xFF" st0
+             in dataStack @?= [255]
+        , testCase "Bare negative literal pushes to stack" $ do
+            let State{dataStack} = simulate "-1" st0
+             in dataStack @?= [-1]
+        , testCase "Bare char literal pushes to stack" $ do
+            let State{dataStack} = simulate "'A'" st0
+             in dataStack @?= [65]
+        , testCase "lit keyword still works" $ do
+            let State{dataStack} = simulate "lit 42" st0
+             in dataStack @?= [42]
         ]
     where
         memInit = Mem 256 $ fromList $ map (\a -> (fromEnum a, Value a)) [0 .. 255]

--- a/test/golden/f32a/carry.s
+++ b/test/golden/f32a/carry.s
@@ -1,17 +1,17 @@
     .text
 
 _start:
-    lit 2
-    lit 0xFFFF_FFFE lit 1 +
-    lit 1 + +
+    2
+    0xFFFF_FFFE 1 +
+    1 + +
 
     drop
 
-    lit 1 eam
+    1 eam
 
-    lit 2
-    lit 0xFFFF_FFFE lit 1 +
-    lit 1 + +
+    2
+    0xFFFF_FFFE 1 +
+    1 + +
 
     drop
 

--- a/test/golden/f32a/div.s
+++ b/test/golden/f32a/div.s
@@ -14,9 +14,9 @@ _start:
     !b                       \ [B] <- divisor
 
     a!                       \ A <- dividend
-    lit 0 lit 0              \ quotient:remainder:[]
+    0 0              \ quotient:remainder:[]
 
-    lit 31 >r                \ for R = 31
+    31 >r                \ for R = 31
 multiply_begin:
     +/                       \ mres-high:acc-old:n:[]
     \ mres-low in a

--- a/test/golden/f32a/factorial.s
+++ b/test/golden/f32a/factorial.s
@@ -28,21 +28,21 @@ continue:
     \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\
 
 handler_negative:
-    lit -1
+    -1
     @p output_addr a! !
     halt
 
     \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\
 
 handler_overflow:
-    lit -858993460
+    -858993460
     @p output_addr a! !
     halt
 
     \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\
 
 multiply:
-    lit 31 >r                \ for R = 31
+    31 >r                \ for R = 31
 multiply_do:
     +*                       \ mres-high:acc-old:n:[]
     \ mres-low in a
@@ -54,7 +54,7 @@ multiply_do:
     \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\
 
 divide:
-    lit 31 >r                \ for R = 31
+    31 >r                \ for R = 31
 divide_do:
     +/
 
@@ -64,7 +64,7 @@ divide_do:
     \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\
 
 factorial:
-    lit 1 over >r >r drop r> r>  \ n:acc:[]
+    1 over >r >r drop r> r>  \ n:acc:[]
 factorial_while:
     dup                      \ n:n:acc:[]
     if factorial_finish      \ n:acc:[]
@@ -75,13 +75,13 @@ factorial_while:
     dup !p tmp_prev
 
 continue_factorial:
-    lit 0                    \ 0:acc:n:[]
+    0                        \ 0:acc:n:[]
 
     multiply                 \ acc:n:[]
 
     a! !b                    \ []
     a @b                     \ n:acc:[]
-    lit 0 lit 0              \ 0:0:n:acc:[]
+    0 0              \ 0:0:n:acc:[]
     divide                   \ quot:rem:n:acc:[]
     over >r >r drop r> r>    \ rem:quot:n:acc:[]
     if continue_factorial2
@@ -90,13 +90,13 @@ continue_factorial:
 continue_factorial2:
     @p tmp_prev              \ prev_acc:quot:n:acc[]
 
-    inv lit 1 + +            \ quot-prev_acc:n:acc[]
+    inv 1 + +            \ quot-prev_acc:n:acc[]
 
     if continue_factorial3
     handler_overflow
 
 continue_factorial3:
-    lit -1 +                 \ n-1:acc
+    -1 +                 \ n-1:acc
     factorial_while ;
 
 factorial_finish:

--- a/test/golden/f32a/get_put_char.s
+++ b/test/golden/f32a/get_put_char.s
@@ -11,19 +11,19 @@ _start:
 
     @
 
-    dup lit 'X' is_equal
+    dup 'X' is_equal
     if minus1
 
-    dup lit 'Y' is_equal
+    dup 'Y' is_equal
     if cccccccc
 
     !b halt
 
 is_equal:
-    inv lit 1 + + ;
+    inv 1 + + ;
 
 minus1:
-    lit -1 !b halt
+    -1 !b halt
 
 cccccccc:
-    lit 0xCCCCCCCC !b halt
+    0xCCCCCCCC !b halt

--- a/test/golden/f32a/hello.s
+++ b/test/golden/f32a/hello.s
@@ -10,17 +10,17 @@ _start:
 
     lit buf a!               \ a for buf address
 
-    lit 14                   \ hardcoded counter on T
+    14                   \ hardcoded counter on T
 
 while:
     dup
     if end
 
-    @+ lit 255 and
+    @+ 255 and
 
     !b
 
-    lit -1 +
+    -1 +
     while ;
 
 end:

--- a/test/golden/f32a/jmp_and_call.s
+++ b/test/golden/f32a/jmp_and_call.s
@@ -1,8 +1,8 @@
     .text
 
 _start:
-    lit 25
-    lit 25
+    25
+    25
     next_call halt_jmp ;
 
 next_call:

--- a/test/performance/program.s
+++ b/test/performance/program.s
@@ -10,31 +10,31 @@ _start:
   @p aaa a! @  ccc  @p bbb a! !  ooo
 
 ccc:
-  dup -if ddd  drop lit -1  ;
+  dup -if ddd  drop -1  ;
 
 ddd:
   dup if mmm
 
-  dup lit -1 +
+  dup -1 +
   if hhh
 
 eee:
-  @p d !b  dup a! lit 0 lit 0  fff  inv lit 1 + @b + -if lll  if hhh  @p d lit 1 + !p d  eee ;
+  @p d !b  dup a! 0 0  fff  inv 1 + @b + -if lll  if hhh  @p d 1 + !p d  eee ;
 
 fff:
-  lit 31 >r
+  31 >r
 ggg:
   +/  next ggg  ;
 
 hhh:
-  drop lit 0  ;
+  drop 0  ;
 kkk:
-  drop lit 1  ;
+  drop 1  ;
 
 lll:
   if hhh  kkk  ;
 
 mmm:
-  drop lit -1  ;
+  drop -1  ;
 ooo:
   halt


### PR DESCRIPTION
## Summary
- Numbers, hex values (`0xFF`), and character literals (`'A'`) can now be written directly in F32a assembly to push them onto the stack
- The `lit` keyword remains supported for backward compatibility and is still required for label references (`lit buf`)
- All examples and tests updated to use the new shorter syntax

Before:
```
lit 42
lit 0xFF
lit 'A'
lit -1 +
```

After:
```
42
0xFF
'A'
-1 +
```

## Test plan
- [x] Unit tests for bare decimal, hex, negative, and char literals
- [x] Unit test verifying `lit` keyword still works
- [x] All examples and golden tests updated and passing
- [x] All 494 tests pass