### PR TITLE
rle_compress fix and potential directions for improving it

### DIFF
--- a/script/testcases/complex.py
+++ b/script/testcases/complex.py
@@ -572,6 +572,7 @@ def rle_compress(input):
     - "aaaaaaaaaa" -> "9a1a" (splits runs > 9)
 
     - Buffer size for the compressed message -- `0x40`, starts from `0x00`.
+    - Buffer size for the input message -- `0x40`, starts from `0x40`.
     - End of input -- new line.
 
     Python example args:

--- a/variants.md
+++ b/variants.md
@@ -646,6 +646,7 @@ def rle_compress(input):
     - "aaaaaaaaaa" -> "9a1a" (splits runs > 9)
 
     - Buffer size for the compressed message -- `0x40`, starts from `0x00`.
+    - Buffer size for the input message -- `0x40`, starts from `0x40`.
     - End of input -- new line.
 
     Python example args:


### PR DESCRIPTION
Исправил описание к варианту rle_compress

Кстати, вообще не идёт никакой проверки на память, по сему могу предложить либо добавить проверку, либо убрать информацию о начале буфера. Он судя по python коду нужен