### PR TITLE
Enable Biome linter for static/

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,8 +21,11 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - name: Run Biome
+      - name: Run Biome format
         run: npx @biomejs/biome format static/
+
+      - name: Run Biome lint
+        run: npx @biomejs/biome lint static/
 
   markdown-formatting:
     timeout-minutes: 5

--- a/Makefile
+++ b/Makefile
@@ -138,6 +138,7 @@ lint-fix:
 lint:
 	hlint $(HS_SRC_DIR)
 	ruff check script
+	npx @biomejs/biome lint static/
 
 format-python:
 	ruff format script

--- a/biome.json
+++ b/biome.json
@@ -4,7 +4,13 @@
     "includes": ["static/**"]
   },
   "linter": {
-    "enabled": false
+    "enabled": true,
+    "rules": {
+      "recommended": true,
+      "complexity": {
+        "noImportantStyles": "off"
+      }
+    }
   },
   "formatter": {
     "indentStyle": "space",
@@ -26,6 +32,9 @@
     }
   },
   "html": {
+    "parser": {
+      "interpolation": true
+    },
     "formatter": {
       "enabled": false
     }

--- a/static/assets/utils.js
+++ b/static/assets/utils.js
@@ -96,7 +96,6 @@ export function removeComments(code, commentStarter) {
     // Check for string ending and quotes escape
     if (currentCharacter === insideString && code[currentPosition - 1] !== '\\') {
       insideString = false
-      continue
     }
   }
 

--- a/static/form.html
+++ b/static/form.html
@@ -58,6 +58,7 @@
         >
         <span class="hidden lg:inline text-[var(-c-grey)]">|</span>
         <button
+          type="button"
           id="invert-theme-button"
           class="hover:bg-[var(--c-blue)] text-[var(--c-blue)] hover:text-[var(--c-black)] cursor-pointer"
         >
@@ -158,7 +159,7 @@
 
         <script>
           // Load saved name when page opens
-          window.addEventListener('DOMContentLoaded', function () {
+          window.addEventListener('DOMContentLoaded', () => {
             const savedName = window.localStorage.getItem('author-name')
             if (savedName) {
               document.getElementById('name').value = savedName

--- a/static/result.html
+++ b/static/result.html
@@ -127,6 +127,7 @@
       >
       <span class="hidden lg:inline text-[var(--c-grey)]">|</span>
       <button
+        type="button"
         id="invert-theme-button"
         class="hover:bg-[var(--c-blue)] text-[var(--c-blue)] hover:text-[var(--c-black)] cursor-pointer"
       >
@@ -161,8 +162,7 @@
                 id="comment-text-element"
                 class="bg-[var(--c-dark-grey)] mb-4 p-4 rounded-lg overflow-x-auto"
               >
-{{comment}}</pre
-              >
+{{comment}}</pre>
             </div>
           </div>
 
@@ -171,12 +171,14 @@
               <span class="text-[var(--c-grey)]">/* assembler_code */</span>
               <div class="flex gap-2">
                 <button
+                  type="button"
                   id="hide-comments-button"
                   class="hover:bg-[var(--c-white)] hover:opacity-80 text-[var(--c-white)] hover:text-[var(--c-black)] cursor-pointer"
                 >
                   [hide_comments]
                 </button>
                 <button
+                  type="button"
                   id="copy-assembler-code-button"
                   class="hover:bg-[var(--c-white)] hover:opacity-80 text-[var(--c-white)] hover:text-[var(--c-black)] cursor-pointer"
                 >
@@ -221,6 +223,7 @@
             >
               <span class="text-[var(--c-grey)]">/* simulation_config */</span>
               <button
+                type="button"
                 id="copy-simulation-config-button"
                 class="hover:bg-[var(--c-white)] hover:opacity-80 text-[var(--c-white)] hover:text-[var(--c-black)] cursor-pointer"
               >
@@ -268,8 +271,7 @@
             id="status-text-element"
             class="bg-[var(--c-dark-grey)] mb-4 p-4 rounded-lg overflow-x-auto"
           >
-{{status}}</pre
-          >
+{{status}}</pre>
         </div>
 
         <div
@@ -311,8 +313,7 @@
           id="test-cases-status-element"
           class="bg-[var(--c-dark-grey)] mb-4 p-4 rounded-lg overflow-x-auto"
         >
-{{test_cases_status}}</pre
-        >
+{{test_cases_status}}</pre>
 
         <div
           id="accordion-collapse-test-cases-result"


### PR DESCRIPTION
## Summary

- Turn on Biome's recommended lint rules for `static/` (previously formatter-only) and enable HTML `{{...}}` interpolation parsing
- Wire `biome lint` into `make lint` and the CI `html-formatting` job (renamed step to clarify format vs. lint)
- Apply the resulting fixes:
  - `utils.js`: drop useless `continue`
  - `form.html`: convert `DOMContentLoaded` listener to arrow function
  - `form.html` / `result.html`: add explicit `type="button"` to 5 buttons (`useButtonType` — defaults to `submit` inside `<form>`)
  - `result.html`: collapse multi-line `</pre↵    >` closing tags to single-line `</pre>` so Biome's HTML parser doesn't fail. That surfaced 3 more buttons missing an explicit type.

`complexity/noImportantStyles` is disabled — the `!important` rules in `ascii.css` are intentional overrides for utility-class specificity (accordion expanded-state).

## Test plan

- [ ] `make lint` exits 0
- [ ] CI `html-formatting` job passes (runs both `biome format` and `biome lint`)
- [ ] Visual smoke test in browser: theme toggle, copy buttons, hide-comments button, and accordion expand/collapse still behave normally on `form.html` and `result.html`