### PR TITLE
feat: add vliw task - palindrome cstr

### DIFF
--- a/script/testcases/vliw.py
+++ b/script/testcases/vliw.py
@@ -107,6 +107,62 @@ TEST_CASES["djb2_hash"] = TestCase(
 ###########################################################
 
 
+def palindrome_cstr(xs):
+    """Input: stream of chars forming c string style.
+
+    Need to check whether the input string is a palindrome
+    (reads the same forwards and backwards).
+
+    Returns: 1 if the string is a palindrome, 0 otherwise.
+    """
+    it = 0
+    chars = []
+    while ord(xs[it]) > 0:
+        chars.append(xs[it])
+        it += 1
+
+    left = 0
+    right = len(chars) - 1
+    while left < right:
+        if chars[left] != chars[right]:
+            return 0
+        left += 1
+        right -= 1
+    return 1
+
+
+TEST_CASES["palindrome_cstr"] = TestCase(
+    simple=palindrome_cstr,
+    cases=[
+        CharSequence2Word("\0", 1),
+        CharSequence2Word("a\0", 1),
+        CharSequence2Word("aba\0", 1),
+        CharSequence2Word("abba\0", 1),
+        CharSequence2Word("racecar\0", 1),
+        CharSequence2Word("abc\0", 0),
+        CharSequence2Word("hello\0", 0),
+    ],
+    reference=palindrome_cstr,
+    reference_cases=[
+        CharSequence2Word("ab\0", 0),
+        CharSequence2Word("aa\0", 1),
+        CharSequence2Word("abcba\0", 1),
+        CharSequence2Word("abcde\0", 0),
+        CharSequence2Word("level\0", 1),
+        CharSequence2Word("noon\0", 1),
+        CharSequence2Word("Aba\0", 0),
+        CharSequence2Word("12321\0", 1),
+        CharSequence2Word(" \0", 1),
+        CharSequence2Word("ab a\0", 0),
+    ],
+    is_variant=True,
+    category="VLIW",
+)
+
+
+###########################################################
+
+
 def determinant_3x3(*xs):
     """Input: 3x3 matrix in format a_10, a_20, a_30, a_11, ...
 

--- a/variants.md
+++ b/variants.md
@@ -106,6 +106,7 @@ Variants:
     - [djb2_hash](#djb2_hash)
     - [fnv32_1_hash](#fnv32_1_hash)
     - [fnv32_1a_hash](#fnv32_1a_hash)
+    - [palindrome_cstr](#palindrome_cstr)
 - _Examples_
     - [dup](#dup)
     - [factorial](#factorial)
@@ -1642,6 +1643,42 @@ def fnv32_1a_hash(xs):
 assert fnv32_1a_hash('a\0') == 3826002220
 assert fnv32_1a_hash('abc\0') == 440920331
 assert fnv32_1a_hash('Computers are awesome!\0') == 4243580747
+```
+
+### `palindrome_cstr`
+
+```python
+def palindrome_cstr(xs):
+    """Input: stream of chars forming c string style.
+
+    Need to check whether the input string is a palindrome
+    (reads the same forwards and backwards).
+
+    Returns: 1 if the string is a palindrome, 0 otherwise.
+    """
+    it = 0
+    chars = []
+    while ord(xs[it]) > 0:
+        chars.append(xs[it])
+        it += 1
+
+    left = 0
+    right = len(chars) - 1
+    while left < right:
+        if chars[left] != chars[right]:
+            return 0
+        left += 1
+        right -= 1
+    return 1
+
+
+assert palindrome_cstr('\0') == 1
+assert palindrome_cstr('a\0') == 1
+assert palindrome_cstr('aba\0') == 1
+assert palindrome_cstr('abba\0') == 1
+assert palindrome_cstr('racecar\0') == 1
+assert palindrome_cstr('abc\0') == 0
+assert palindrome_cstr('hello\0') == 0
 ```
 
 ## _Examples_


### PR DESCRIPTION
Add `palindrome_cstr` as a new VLIW variant task: given a null-terminated string, determine whether it is a palindrome and output `1` or `0`.

The task is a good fit for VLIW because the two-pointer loop allows both pointer updates and a conditional branch to be packed into a single bundle, showcasing real instruction-level parallelism.