### PR TITLE
Add simulation stats block to CLI output (#83)

### DIFF
--- a/src/wrench/Wrench/Isa/F32a.hs
+++ b/src/wrench/Wrench/Isa/F32a.hs
@@ -239,6 +239,7 @@ data MachineState mem w = State
     , extendedArithmeticMode :: Bool
     , carryFlag :: Bool
     , internalError :: Maybe Text
+    , depthStats :: DepthStatsAcc
     }
     deriving (Show)
 
@@ -255,6 +256,7 @@ instance (MachineWord w) => InitState (IoMem (Isa w w) w) (MachineState (IoMem (
             , extendedArithmeticMode = False
             , carryFlag = False
             , internalError = Nothing
+            , depthStats = emptyDepthStatsAcc
             }
 
 setP :: forall w. Int -> State (MachineState (IoMem (Isa w w) w) w) ()
@@ -344,8 +346,9 @@ instance (MachineWord w) => StateInterspector (MachineState (IoMem (Isa w w) w) 
     programCounter State{p} = p
     memoryDump State{ram} = ram
     ioStreams State{ram = IoMem{mIoStreams}} = mIoStreams
-    stackInfo State{dataStack, returnStack} =
-        ListStack{dDepth = length dataStack, rDepth = length returnStack}
+    recordStats st@State{dataStack, returnStack, depthStats} =
+        st{depthStats = recordDepth (length dataStack) (length returnStack) depthStats}
+    machineStats State{depthStats} = renderDepthStats (byteSizeT @w) depthStats
     reprState labels st v
         | Just v' <- defaultView labels st v = v'
     reprState labels st@State{a, b, dataStack, returnStack, extendedArithmeticMode, carryFlag} v =

--- a/src/wrench/Wrench/Isa/F32a.hs
+++ b/src/wrench/Wrench/Isa/F32a.hs
@@ -344,6 +344,8 @@ instance (MachineWord w) => StateInterspector (MachineState (IoMem (Isa w w) w) 
     programCounter State{p} = p
     memoryDump State{ram} = ram
     ioStreams State{ram = IoMem{mIoStreams}} = mIoStreams
+    stackInfo State{dataStack, returnStack} =
+        ListStack{dDepth = length dataStack, rDepth = length returnStack}
     reprState labels st v
         | Just v' <- defaultView labels st v = v'
     reprState labels st@State{a, b, dataStack, returnStack, extendedArithmeticMode, carryFlag} v =

--- a/src/wrench/Wrench/Isa/M68k.hs
+++ b/src/wrench/Wrench/Isa/M68k.hs
@@ -410,6 +410,10 @@ instance (MachineWord w) => StateInterspector (MachineState (IoMem (Isa w w) w) 
     programCounter State{pc} = pc
     memoryDump State{mem} = mem
     ioStreams State{mem = IoMem{mIoStreams}} = mIoStreams
+    stackInfo State{addrRegs} =
+        case addrRegs !? A7 of
+            Just s | s /= def -> SpStack{sp = s, spInitialised = True}
+            _ -> SpStack{sp = def, spInitialised = False}
     reprState labels st v
         | Just v' <- defaultView labels st v = v'
     reprState labels st@State{addrRegs, dataRegs, nFlag, zFlag, vFlag, cFlag} v =

--- a/src/wrench/Wrench/Isa/M68k.hs
+++ b/src/wrench/Wrench/Isa/M68k.hs
@@ -373,6 +373,7 @@ data MachineState mem w = State
     , stopped :: Bool
     , internalError :: Maybe Text
     , nFlag, zFlag, vFlag, cFlag :: Bool
+    , spStats :: SpStatsAcc w
     }
     deriving (Show)
 
@@ -404,16 +405,16 @@ instance (MachineWord w) => InitState (IoMem (Isa w w) w) (MachineState (IoMem (
             , zFlag = True
             , vFlag = False
             , cFlag = False
+            , spStats = emptySpStatsAcc
             }
 
 instance (MachineWord w) => StateInterspector (MachineState (IoMem (Isa w w) w) w) (IoMem (Isa w w) w) (Isa w w) w where
     programCounter State{pc} = pc
     memoryDump State{mem} = mem
     ioStreams State{mem = IoMem{mIoStreams}} = mIoStreams
-    stackInfo State{addrRegs} =
-        case addrRegs !? A7 of
-            Just s | s /= def -> SpStack{sp = s, spInitialised = True}
-            _ -> SpStack{sp = def, spInitialised = False}
+    recordStats st@State{addrRegs, spStats} =
+        st{spStats = recordSp (mfilter (/= def) (addrRegs !? A7)) spStats}
+    machineStats State{spStats} = renderSpStats spStats
     reprState labels st v
         | Just v' <- defaultView labels st v = v'
     reprState labels st@State{addrRegs, dataRegs, nFlag, zFlag, vFlag, cFlag} v =

--- a/src/wrench/Wrench/Isa/RiscIv.hs
+++ b/src/wrench/Wrench/Isa/RiscIv.hs
@@ -26,6 +26,7 @@ import Wrench.Machine.Types (
     InitState (..),
     IoMem (..),
     Machine (..),
+    StackInfo (..),
     StateInterspector (..),
     fromSign,
     halted,
@@ -441,6 +442,10 @@ instance (MachineWord w) => StateInterspector (MachineState (IoMem (Isa w w) w) 
     programCounter State{pc} = pc
     memoryDump State{mem} = mem
     ioStreams State{mem = IoMem{mIoStreams}} = mIoStreams
+    stackInfo State{regs} =
+        case regs !? Sp of
+            Just s | s /= def -> SpStack{sp = s, spInitialised = True}
+            _ -> SpStack{sp = def, spInitialised = False}
     reprState labels st v
         | Just v' <- defaultView labels st v = v'
     reprState labels st@State{regs} v =

--- a/src/wrench/Wrench/Isa/RiscIv.hs
+++ b/src/wrench/Wrench/Isa/RiscIv.hs
@@ -26,11 +26,14 @@ import Wrench.Machine.Types (
     InitState (..),
     IoMem (..),
     Machine (..),
-    StackInfo (..),
+    SpStatsAcc,
     StateInterspector (..),
+    emptySpStatsAcc,
     fromSign,
     halted,
     lShiftR,
+    recordSp,
+    renderSpStats,
     signBitAnd,
  )
 import Wrench.Report
@@ -369,6 +372,7 @@ data MachineState mem w = State
     , regs :: HashMap Register w
     , stopped :: Bool
     , internalError :: Maybe Text
+    , spStats :: SpStatsAcc w
     }
     deriving (Show)
 
@@ -436,16 +440,16 @@ instance (MachineWord w) => InitState (IoMem (Isa w w) w) (MachineState (IoMem (
             , regs = def
             , stopped = False
             , internalError = Nothing
+            , spStats = emptySpStatsAcc
             }
 
 instance (MachineWord w) => StateInterspector (MachineState (IoMem (Isa w w) w) w) (IoMem (Isa w w) w) (Isa w w) w where
     programCounter State{pc} = pc
     memoryDump State{mem} = mem
     ioStreams State{mem = IoMem{mIoStreams}} = mIoStreams
-    stackInfo State{regs} =
-        case regs !? Sp of
-            Just s | s /= def -> SpStack{sp = s, spInitialised = True}
-            _ -> SpStack{sp = def, spInitialised = False}
+    recordStats st@State{regs, spStats} =
+        st{spStats = recordSp (mfilter (/= def) (regs !? Sp)) spStats}
+    machineStats State{spStats} = renderSpStats spStats
     reprState labels st v
         | Just v' <- defaultView labels st v = v'
     reprState labels st@State{regs} v =

--- a/src/wrench/Wrench/Isa/VliwIv.hs
+++ b/src/wrench/Wrench/Isa/VliwIv.hs
@@ -25,11 +25,14 @@ import Wrench.Machine.Types (
     InitState (..),
     IoMem (..),
     Machine (..),
-    StackInfo (..),
+    SpStatsAcc,
     StateInterspector (..),
+    emptySpStatsAcc,
     fromSign,
     halted,
     lShiftR,
+    recordSp,
+    renderSpStats,
     signBitAnd,
  )
 import Wrench.Report
@@ -372,6 +375,7 @@ data MachineState mem w = State
     , stopped :: Bool
     , internalError :: Maybe Text
     , randoms :: [Int]
+    , spStats :: SpStatsAcc w
     }
     deriving (Show)
 
@@ -447,16 +451,16 @@ instance (MachineWord w) => InitState (IoMem (Isa w w) w) (MachineState (IoMem (
             , stopped = False
             , internalError = Nothing
             , randoms = randomStream
+            , spStats = emptySpStatsAcc
             }
 
 instance (MachineWord w) => StateInterspector (MachineState (IoMem (Isa w w) w) w) (IoMem (Isa w w) w) (Isa w w) w where
     programCounter State{pc} = pc
     memoryDump State{mem} = mem
     ioStreams State{mem = IoMem{mIoStreams}} = mIoStreams
-    stackInfo State{regs} =
-        case regs !? Sp of
-            Just s | s /= def -> SpStack{sp = s, spInitialised = True}
-            _ -> SpStack{sp = def, spInitialised = False}
+    recordStats st@State{regs, spStats} =
+        st{spStats = recordSp (mfilter (/= def) (regs !? Sp)) spStats}
+    machineStats State{spStats} = renderSpStats spStats
     reprState labels st v
         | Just v' <- defaultView labels st v = v'
     reprState labels st@State{regs} v =

--- a/src/wrench/Wrench/Isa/VliwIv.hs
+++ b/src/wrench/Wrench/Isa/VliwIv.hs
@@ -25,6 +25,7 @@ import Wrench.Machine.Types (
     InitState (..),
     IoMem (..),
     Machine (..),
+    StackInfo (..),
     StateInterspector (..),
     fromSign,
     halted,
@@ -452,6 +453,10 @@ instance (MachineWord w) => StateInterspector (MachineState (IoMem (Isa w w) w) 
     programCounter State{pc} = pc
     memoryDump State{mem} = mem
     ioStreams State{mem = IoMem{mIoStreams}} = mIoStreams
+    stackInfo State{regs} =
+        case regs !? Sp of
+            Just s | s /= def -> SpStack{sp = s, spInitialised = True}
+            _ -> SpStack{sp = def, spInitialised = False}
     reprState labels st v
         | Just v' <- defaultView labels st v = v'
     reprState labels st@State{regs} v =

--- a/src/wrench/Wrench/Machine.hs
+++ b/src/wrench/Wrench/Machine.hs
@@ -1,12 +1,70 @@
 {-# OPTIONS_GHC -Wno-missing-signatures #-}
 
-module Wrench.Machine (powerOn) where
+module Wrench.Machine (
+    powerOn,
+    RuntimeStats (..),
+    StackStats (..),
+) where
 
 import Relude
 import Relude.Extra
 import Wrench.Machine.Types
 
-data Simulation st isa = Simulation
+-- | Stats accumulated while simulating, classified by stack architecture.
+--
+-- For SP-based stacks the "top" is taken as the SP value observed just before
+-- the first decrease — this skips over the multi-step initialisation sequence
+-- (e.g. RiscIv's @lui sp, 0 ; addi sp, sp, _@ or M68k's
+-- @movea.l label, A7 ; movea.l (A7), A7@) where intermediate SP values are
+-- transient address-of-label rather than the true stack top.
+data StackStats w
+    = StackStatsNone
+    | StackStatsSp
+        { ssLastSp :: !(Maybe w)
+        -- ^ last observed SP value (for trend detection)
+        , ssTopSp :: !(Maybe w)
+        -- ^ "settled" top — the value just before the first decrease
+        , ssMinSp :: !(Maybe w)
+        -- ^ minimum SP observed after the first decrease
+        }
+    | StackStatsList
+        { ssMaxDDepth :: !Int
+        , ssMaxRDepth :: !Int
+        }
+    deriving (Show)
+
+data RuntimeStats w = RuntimeStats
+    { rsInstructions :: !Int
+    , rsStack :: !(StackStats w)
+    }
+    deriving (Show)
+
+initStackStats :: StackInfo w -> StackStats w
+initStackStats NoStack = StackStatsNone
+initStackStats SpStack{} = StackStatsSp{ssLastSp = Nothing, ssTopSp = Nothing, ssMinSp = Nothing}
+initStackStats ListStack{} = StackStatsList{ssMaxDDepth = 0, ssMaxRDepth = 0}
+
+mergeStack :: (Ord w) => StackInfo w -> StackStats w -> StackStats w
+mergeStack NoStack acc = acc
+mergeStack SpStack{spInitialised = False} acc = acc
+mergeStack SpStack{sp, spInitialised = True} acc =
+    case acc of
+        StackStatsSp{ssLastSp = Nothing} ->
+            StackStatsSp{ssLastSp = Just sp, ssTopSp = Just sp, ssMinSp = Nothing}
+        StackStatsSp{ssLastSp = Just prev, ssMinSp = Nothing} ->
+            if sp < prev
+                then StackStatsSp{ssLastSp = Just sp, ssTopSp = Just prev, ssMinSp = Just sp}
+                else StackStatsSp{ssLastSp = Just sp, ssTopSp = Just sp, ssMinSp = Nothing}
+        StackStatsSp{ssTopSp, ssMinSp = Just lo} ->
+            StackStatsSp{ssLastSp = Just sp, ssTopSp, ssMinSp = Just (min lo sp)}
+        _ -> acc
+mergeStack ListStack{dDepth, rDepth} acc =
+    case acc of
+        StackStatsList{ssMaxDDepth, ssMaxRDepth} ->
+            StackStatsList{ssMaxDDepth = max ssMaxDDepth dDepth, ssMaxRDepth = max ssMaxRDepth rDepth}
+        _ -> acc
+
+data Simulation st isa w = Simulation
     { log :: [Trace st isa]
     , machineState :: st
     , pc2label :: HashMap Int String
@@ -15,43 +73,46 @@ data Simulation st isa = Simulation
     , stateRecordCount :: Int
     , stateRecordLimits :: Int
     , takePartOnStateRecordLimit :: Int
+    , stackStats :: StackStats w
     }
 
-tellState :: st -> State (Simulation st isa) ()
+tellState :: (StateInterspector st m isa w, Ord w) => st -> State (Simulation st isa w) ()
 tellState machineState = modify
-    $ \sim@Simulation{log, stateRecordCount, stateRecordLimits, takePartOnStateRecordLimit} ->
-        if stateRecordCount >= stateRecordLimits
-            then
-                let n = (stateRecordLimits `div` takePartOnStateRecordLimit)
-                    rest = drop n log
-                    rest' =
-                        filter
-                            ( \case
-                                TState _ -> False
-                                _ -> True
-                            )
-                            rest
-                    dropped = length rest - length rest'
-                    warn = "Dropped " <> show dropped <> " states"
-                 in sim
-                        { log = take n log <> rest' <> [TWarn warn]
-                        , stateRecordCount = stateRecordCount - dropped
+    $ \sim@Simulation{log, stateRecordCount, stateRecordLimits, takePartOnStateRecordLimit, stackStats} ->
+        let stackStats' = mergeStack (stackInfo machineState) stackStats
+            sim' = sim{stackStats = stackStats'}
+         in if stateRecordCount >= stateRecordLimits
+                then
+                    let n = (stateRecordLimits `div` takePartOnStateRecordLimit)
+                        rest = drop n log
+                        rest' =
+                            filter
+                                ( \case
+                                    TState _ -> False
+                                    _ -> True
+                                )
+                                rest
+                        dropped = length rest - length rest'
+                        warn = "Dropped " <> show dropped <> " states"
+                     in sim'
+                            { log = take n log <> rest' <> [TWarn warn]
+                            , stateRecordCount = stateRecordCount - dropped
+                            }
+                else
+                    sim'
+                        { log = TState machineState : log
+                        , stateRecordCount = stateRecordCount + 1
                         }
-            else
-                sim
-                    { log = TState machineState : log
-                    , stateRecordCount = stateRecordCount + 1
-                    }
 
 tellError msg = modify $ \sim@Simulation{log} ->
     sim{log = TError msg : log}
 
-simulate :: (Machine st isa w) => Simulation st isa -> [Trace st isa]
+simulate :: (Machine st isa w, StateInterspector st m isa w, Ord w) => Simulation st isa w -> ([Trace st isa], RuntimeStats w)
 simulate sim =
-    let Simulation{log} = execState simulate' sim
-     in reverse log
+    let Simulation{log, instructionCount, stackStats} = execState simulate' sim
+     in (reverse log, RuntimeStats{rsInstructions = instructionCount, rsStack = stackStats})
 
-simulateInstructionStep :: (Machine st isa w) => State (Simulation st isa) ()
+simulateInstructionStep :: (Machine st isa w) => State (Simulation st isa w) ()
 simulateInstructionStep =
     modify $ \sim@Simulation{machineState, instructionCount} ->
         sim
@@ -59,7 +120,7 @@ simulateInstructionStep =
             , instructionCount = instructionCount + 1
             }
 
-simulate' :: (Machine st isa w) => State (Simulation st isa) ()
+simulate' :: (Machine st isa w, StateInterspector st m isa w, Ord w) => State (Simulation st isa w) ()
 simulate' = do
     Simulation{machineState, instructionCount, instructionLimits} <- get
     if instructionCount >= instructionLimits
@@ -73,14 +134,15 @@ simulate' = do
             Left err -> tellError err
 
 powerOn ::
-    (Machine st isa w, MachineWord w) =>
+    (Machine st isa w, MachineWord w, StateInterspector st m isa w) =>
     Int
     -> Int
     -> HashMap String w
     -> st
-    -> Either Text [Trace st isa]
+    -> Either Text ([Trace st isa], RuntimeStats w)
 powerOn instructionLimits stateRecordLimits labels machineInitState = do
     let pc2label = fromList $ map (\(a, b) -> (fromEnum b, a)) $ toPairs labels
+        initialStack = initStackStats (stackInfo machineInitState)
     Right
         $ simulate
             Simulation
@@ -92,4 +154,5 @@ powerOn instructionLimits stateRecordLimits labels machineInitState = do
                 , stateRecordCount = 0
                 , stateRecordLimits
                 , takePartOnStateRecordLimit = 4
+                , stackStats = initialStack
                 }

--- a/src/wrench/Wrench/Machine.hs
+++ b/src/wrench/Wrench/Machine.hs
@@ -1,70 +1,12 @@
 {-# OPTIONS_GHC -Wno-missing-signatures #-}
 
-module Wrench.Machine (
-    powerOn,
-    RuntimeStats (..),
-    StackStats (..),
-) where
+module Wrench.Machine (powerOn) where
 
 import Relude
 import Relude.Extra
 import Wrench.Machine.Types
 
--- | Stats accumulated while simulating, classified by stack architecture.
---
--- For SP-based stacks the "top" is taken as the SP value observed just before
--- the first decrease — this skips over the multi-step initialisation sequence
--- (e.g. RiscIv's @lui sp, 0 ; addi sp, sp, _@ or M68k's
--- @movea.l label, A7 ; movea.l (A7), A7@) where intermediate SP values are
--- transient address-of-label rather than the true stack top.
-data StackStats w
-    = StackStatsNone
-    | StackStatsSp
-        { ssLastSp :: !(Maybe w)
-        -- ^ last observed SP value (for trend detection)
-        , ssTopSp :: !(Maybe w)
-        -- ^ "settled" top — the value just before the first decrease
-        , ssMinSp :: !(Maybe w)
-        -- ^ minimum SP observed after the first decrease
-        }
-    | StackStatsList
-        { ssMaxDDepth :: !Int
-        , ssMaxRDepth :: !Int
-        }
-    deriving (Show)
-
-data RuntimeStats w = RuntimeStats
-    { rsInstructions :: !Int
-    , rsStack :: !(StackStats w)
-    }
-    deriving (Show)
-
-initStackStats :: StackInfo w -> StackStats w
-initStackStats NoStack = StackStatsNone
-initStackStats SpStack{} = StackStatsSp{ssLastSp = Nothing, ssTopSp = Nothing, ssMinSp = Nothing}
-initStackStats ListStack{} = StackStatsList{ssMaxDDepth = 0, ssMaxRDepth = 0}
-
-mergeStack :: (Ord w) => StackInfo w -> StackStats w -> StackStats w
-mergeStack NoStack acc = acc
-mergeStack SpStack{spInitialised = False} acc = acc
-mergeStack SpStack{sp, spInitialised = True} acc =
-    case acc of
-        StackStatsSp{ssLastSp = Nothing} ->
-            StackStatsSp{ssLastSp = Just sp, ssTopSp = Just sp, ssMinSp = Nothing}
-        StackStatsSp{ssLastSp = Just prev, ssMinSp = Nothing} ->
-            if sp < prev
-                then StackStatsSp{ssLastSp = Just sp, ssTopSp = Just prev, ssMinSp = Just sp}
-                else StackStatsSp{ssLastSp = Just sp, ssTopSp = Just sp, ssMinSp = Nothing}
-        StackStatsSp{ssTopSp, ssMinSp = Just lo} ->
-            StackStatsSp{ssLastSp = Just sp, ssTopSp, ssMinSp = Just (min lo sp)}
-        _ -> acc
-mergeStack ListStack{dDepth, rDepth} acc =
-    case acc of
-        StackStatsList{ssMaxDDepth, ssMaxRDepth} ->
-            StackStatsList{ssMaxDDepth = max ssMaxDDepth dDepth, ssMaxRDepth = max ssMaxRDepth rDepth}
-        _ -> acc
-
-data Simulation st isa w = Simulation
+data Simulation st isa = Simulation
     { log :: [Trace st isa]
     , machineState :: st
     , pc2label :: HashMap Int String
@@ -73,54 +15,55 @@ data Simulation st isa w = Simulation
     , stateRecordCount :: Int
     , stateRecordLimits :: Int
     , takePartOnStateRecordLimit :: Int
-    , stackStats :: StackStats w
     }
 
-tellState :: (StateInterspector st m isa w, Ord w) => st -> State (Simulation st isa w) ()
+tellState :: st -> State (Simulation st isa) ()
 tellState machineState = modify
-    $ \sim@Simulation{log, stateRecordCount, stateRecordLimits, takePartOnStateRecordLimit, stackStats} ->
-        let stackStats' = mergeStack (stackInfo machineState) stackStats
-            sim' = sim{stackStats = stackStats'}
-         in if stateRecordCount >= stateRecordLimits
-                then
-                    let n = (stateRecordLimits `div` takePartOnStateRecordLimit)
-                        rest = drop n log
-                        rest' =
-                            filter
-                                ( \case
-                                    TState _ -> False
-                                    _ -> True
-                                )
-                                rest
-                        dropped = length rest - length rest'
-                        warn = "Dropped " <> show dropped <> " states"
-                     in sim'
-                            { log = take n log <> rest' <> [TWarn warn]
-                            , stateRecordCount = stateRecordCount - dropped
-                            }
-                else
-                    sim'
-                        { log = TState machineState : log
-                        , stateRecordCount = stateRecordCount + 1
+    $ \sim@Simulation{log, stateRecordCount, stateRecordLimits, takePartOnStateRecordLimit} ->
+        if stateRecordCount >= stateRecordLimits
+            then
+                let n = (stateRecordLimits `div` takePartOnStateRecordLimit)
+                    rest = drop n log
+                    rest' =
+                        filter
+                            ( \case
+                                TState _ -> False
+                                _ -> True
+                            )
+                            rest
+                    dropped = length rest - length rest'
+                    warn = "Dropped " <> show dropped <> " states"
+                 in sim
+                        { log = take n log <> rest' <> [TWarn warn]
+                        , stateRecordCount = stateRecordCount - dropped
                         }
+            else
+                sim
+                    { log = TState machineState : log
+                    , stateRecordCount = stateRecordCount + 1
+                    }
 
 tellError msg = modify $ \sim@Simulation{log} ->
     sim{log = TError msg : log}
 
-simulate :: (Machine st isa w, StateInterspector st m isa w, Ord w) => Simulation st isa w -> ([Trace st isa], RuntimeStats w)
+-- | Run the simulation, returning the trace log together with the collected
+-- statistics: the generic counters tracked by the simulator (instruction count)
+-- plus the ISA-specific stats accumulated inside the machine state.
+simulate :: (Machine st isa w, StateInterspector st m isa w) => Simulation st isa -> ([Trace st isa], [StatEntry])
 simulate sim =
-    let Simulation{log, instructionCount, stackStats} = execState simulate' sim
-     in (reverse log, RuntimeStats{rsInstructions = instructionCount, rsStack = stackStats})
+    let Simulation{log, instructionCount, machineState} = execState simulate' sim
+        stats = ("instructions", show instructionCount) : machineStats machineState
+     in (reverse log, stats)
 
-simulateInstructionStep :: (Machine st isa w) => State (Simulation st isa w) ()
+simulateInstructionStep :: (Machine st isa w, StateInterspector st m isa w) => State (Simulation st isa) ()
 simulateInstructionStep =
     modify $ \sim@Simulation{machineState, instructionCount} ->
         sim
-            { machineState = execState instructionStep machineState
+            { machineState = recordStats (execState instructionStep machineState)
             , instructionCount = instructionCount + 1
             }
 
-simulate' :: (Machine st isa w, StateInterspector st m isa w, Ord w) => State (Simulation st isa w) ()
+simulate' :: (Machine st isa w, StateInterspector st m isa w) => State (Simulation st isa) ()
 simulate' = do
     Simulation{machineState, instructionCount, instructionLimits} <- get
     if instructionCount >= instructionLimits
@@ -139,10 +82,9 @@ powerOn ::
     -> Int
     -> HashMap String w
     -> st
-    -> Either Text ([Trace st isa], RuntimeStats w)
+    -> Either Text ([Trace st isa], [StatEntry])
 powerOn instructionLimits stateRecordLimits labels machineInitState = do
     let pc2label = fromList $ map (\(a, b) -> (fromEnum b, a)) $ toPairs labels
-        initialStack = initStackStats (stackInfo machineInitState)
     Right
         $ simulate
             Simulation
@@ -154,5 +96,4 @@ powerOn instructionLimits stateRecordLimits labels machineInitState = do
                 , stateRecordCount = 0
                 , stateRecordLimits
                 , takePartOnStateRecordLimit = 4
-                , stackStats = initialStack
                 }

--- a/src/wrench/Wrench/Machine/Memory.hs
+++ b/src/wrench/Wrench/Machine/Memory.hs
@@ -10,6 +10,7 @@ module Wrench.Machine.Memory (
     prepareDump,
     prettyDump,
     DumpStats (..),
+    dumpStatsEntries,
 ) where
 
 import Data.Bits (FiniteBits, finiteBitSize)
@@ -30,6 +31,18 @@ data DumpStats = DumpStats
     --   (i.e. the position of the first placeholder cell counted from 0).
     }
     deriving (Eq, Show)
+
+-- | Render translation-time layout stats as key/value pairs.
+dumpStatsEntries :: DumpStats -> [(Text, Text)]
+dumpStatsEntries DumpStats{dsSectionsTotalBytes, dsCodeDataExtent} =
+    [ ("sections", show dsSectionsTotalBytes <> " bytes")
+    ,
+        ( "code/data"
+        , if dsCodeDataExtent == 0
+            then "0 bytes"
+            else show dsCodeDataExtent <> " bytes (0.." <> show (dsCodeDataExtent - 1) <> ")"
+        )
+    ]
 
 prepareDump :: (ByteSize isa, MachineWord w) => Int -> [Section isa w w] -> (Mem isa w, DumpStats)
 prepareDump memorySize sections =

--- a/src/wrench/Wrench/Machine/Memory.hs
+++ b/src/wrench/Wrench/Machine/Memory.hs
@@ -9,6 +9,7 @@ module Wrench.Machine.Memory (
     word32ToHex,
     prepareDump,
     prettyDump,
+    DumpStats (..),
 ) where
 
 import Data.Bits (FiniteBits, finiteBitSize)
@@ -20,7 +21,17 @@ import Relude.Unsafe qualified as Unsafe
 import Wrench.Machine.Types
 import Wrench.Translator.Types
 
-prepareDump :: (ByteSize isa, MachineWord w) => Int -> [Section isa w w] -> Mem isa w
+-- | Translation-time memory layout statistics.
+data DumpStats = DumpStats
+    { dsSectionsTotalBytes :: !Int
+    -- ^ Sum of byte sizes of all sections (no gaps from .org).
+    , dsCodeDataExtent :: !Int
+    -- ^ Address right after the last byte holding section content
+    --   (i.e. the position of the first placeholder cell counted from 0).
+    }
+    deriving (Eq, Show)
+
+prepareDump :: (ByteSize isa, MachineWord w) => Int -> [Section isa w w] -> (Mem isa w, DumpStats)
 prepareDump memorySize sections =
     let addSection cells offset dump =
             let dump' = zip [offset ..] cells
@@ -55,14 +66,19 @@ prepareDump memorySize sections =
                     sections
         dumpSize = maximum1 $ 0 :| keys fromSections
         placeholder = map (,Value 0) [0 .. memorySize - 1]
+        sectionsTotalBytes = sum (map byteSize sections)
+        codeDataExtent = if null fromSections then 0 else dumpSize + 1
+        dumpStats = DumpStats{dsSectionsTotalBytes = sectionsTotalBytes, dsCodeDataExtent = codeDataExtent}
      in if dumpSize > memorySize
             then
                 error $ "error: can not fit translation results in memory, need: " <> show dumpSize <> " available: " <> show memorySize
             else
-                Mem
+                ( Mem
                     { memorySize
                     , memoryData = fromList (placeholder <> fromSections)
                     }
+                , dumpStats
+                )
 
 isValue Value{} = True
 isValue _ = False

--- a/src/wrench/Wrench/Machine/Types.hs
+++ b/src/wrench/Wrench/Machine/Types.hs
@@ -7,7 +7,15 @@ module Wrench.Machine.Types (
     Cell (..),
     InitState (..),
     StateInterspector (..),
-    StackInfo (..),
+    StatEntry,
+    SpStatsAcc,
+    emptySpStatsAcc,
+    recordSp,
+    renderSpStats,
+    DepthStatsAcc,
+    emptyDepthStatsAcc,
+    recordDepth,
+    renderDepthStats,
     MachineWord,
     FromSign (..),
     RegisterId,
@@ -154,17 +162,8 @@ instance (ByteSize t, Default t) => ByteSizeT t where
 class InitState mem st | st -> mem where
     initState :: Int -> mem -> [Int] -> st
 
--- | Per-state snapshot of stack architecture used for runtime stats accounting.
-data StackInfo w
-    = -- | Architecture has no stack (e.g. accumulator-only ISAs).
-      NoStack
-    | -- | Stack pointer lives in a register / RAM. 'spInitialised' is True once
-      --   the program has written a value to SP at least once; while False the
-      --   value is ignored by stats accumulation.
-      SpStack {sp :: w, spInitialised :: Bool}
-    | -- | Host-side list stacks (e.g. f32a's data / return stacks).
-      ListStack {dDepth :: !Int, rDepth :: !Int}
-    deriving (Show)
+-- | A single statistic as a key/value text pair, e.g. @("stack", "32 bytes (566..597)")@.
+type StatEntry = (Text, Text)
 
 class StateInterspector st m isa w | st -> m isa w where
     programCounter :: st -> Int
@@ -172,8 +171,87 @@ class StateInterspector st m isa w | st -> m isa w where
     ioStreams :: st -> IntMap ([w], [w])
     reprState :: HashMap String w -> st -> Text -> Text
     reprState _labels _st var = "unknown variable: " <> var
-    stackInfo :: st -> StackInfo w
-    stackInfo _ = NoStack
+
+    -- | Update the state's own statistics accumulators. Called by the simulator
+    --   once per executed instruction (after the step). ISAs that track runtime
+    --   stats store the accumulators inside their own state and override this.
+    recordStats :: st -> st
+    recordStats = id
+
+    -- | Extract the accumulated ISA-specific stats as key/value pairs.
+    machineStats :: st -> [StatEntry]
+    machineStats _ = []
+
+-----------------------------------------------------------
+-- Shared stat accumulators
+--
+-- These helpers let each ISA keep a small accumulator inside its own state and
+-- render it to 'StatEntry' pairs, without the generic simulator needing to know
+-- anything about stack architecture.
+
+-- | Stack-pointer usage tracker with a "settled top" heuristic: the top is the
+-- SP value observed just before the first decrease. This skips the multi-step
+-- initialisation sequence (e.g. RiscIv's @lui sp, 0 ; addi sp, sp, _@ or M68k's
+-- @movea.l label, A7 ; movea.l (A7), A7@) whose intermediate SP values are
+-- transient address-of-label rather than the true stack top.
+data SpStatsAcc w = SpStatsAcc
+    { spsaLast :: !(Maybe w)
+    -- ^ last observed SP value (for trend detection)
+    , spsaTop :: !(Maybe w)
+    -- ^ "settled" top — the value just before the first decrease
+    , spsaMin :: !(Maybe w)
+    -- ^ minimum SP observed after the first decrease
+    }
+    deriving (Eq, Show)
+
+emptySpStatsAcc :: SpStatsAcc w
+emptySpStatsAcc = SpStatsAcc{spsaLast = Nothing, spsaTop = Nothing, spsaMin = Nothing}
+
+-- | Record an SP observation. Pass 'Nothing' while SP is not yet meaningfully
+-- set (e.g. before the program writes it) so it is ignored.
+recordSp :: (Ord w) => Maybe w -> SpStatsAcc w -> SpStatsAcc w
+recordSp Nothing acc = acc
+recordSp (Just sp) acc@SpStatsAcc{spsaLast, spsaMin} =
+    case (spsaLast, spsaMin) of
+        (Nothing, _) -> SpStatsAcc{spsaLast = Just sp, spsaTop = Just sp, spsaMin = Nothing}
+        (Just prev, Nothing)
+            | sp < prev -> SpStatsAcc{spsaLast = Just sp, spsaTop = Just prev, spsaMin = Just sp}
+            | otherwise -> SpStatsAcc{spsaLast = Just sp, spsaTop = Just sp, spsaMin = Nothing}
+        (Just _, Just lo) -> acc{spsaLast = Just sp, spsaMin = Just (min lo sp)}
+
+renderSpStats :: (MachineWord w) => SpStatsAcc w -> [StatEntry]
+renderSpStats SpStatsAcc{spsaTop, spsaMin} =
+    case (spsaTop, spsaMin) of
+        (Nothing, _) -> [("stack", "0 bytes (uninitialised)")]
+        (Just _, Nothing) -> [("stack", "0 bytes (no push observed)")]
+        (Just hi, Just lo) ->
+            let bytes = fromEnum hi - fromEnum lo
+                rangeNote :: Text
+                rangeNote =
+                    if bytes == 0
+                        then ""
+                        else " (" <> show (fromEnum lo) <> ".." <> show (fromEnum hi - 1) <> ")"
+             in [("stack", show bytes <> " bytes" <> rangeNote)]
+
+-- | Depth tracker for host-side list stacks (e.g. f32a's data / return stacks).
+data DepthStatsAcc = DepthStatsAcc
+    { dsaMaxDepth :: !Int
+    , dsaMaxReturn :: !Int
+    }
+    deriving (Eq, Show)
+
+emptyDepthStatsAcc :: DepthStatsAcc
+emptyDepthStatsAcc = DepthStatsAcc{dsaMaxDepth = 0, dsaMaxReturn = 0}
+
+recordDepth :: Int -> Int -> DepthStatsAcc -> DepthStatsAcc
+recordDepth d r DepthStatsAcc{dsaMaxDepth, dsaMaxReturn} =
+    DepthStatsAcc{dsaMaxDepth = max dsaMaxDepth d, dsaMaxReturn = max dsaMaxReturn r}
+
+renderDepthStats :: Int -> DepthStatsAcc -> [StatEntry]
+renderDepthStats wordBytes DepthStatsAcc{dsaMaxDepth, dsaMaxReturn} =
+    [ ("dstack depth", show dsaMaxDepth <> " (" <> show (dsaMaxDepth * wordBytes) <> " bytes)")
+    , ("rstack depth", show dsaMaxReturn <> " (" <> show (dsaMaxReturn * wordBytes) <> " bytes)")
+    ]
 
 class Machine st isa w | st -> isa w where
     instructionFetch :: State st (Either Text (Int, isa))

--- a/src/wrench/Wrench/Machine/Types.hs
+++ b/src/wrench/Wrench/Machine/Types.hs
@@ -7,6 +7,7 @@ module Wrench.Machine.Types (
     Cell (..),
     InitState (..),
     StateInterspector (..),
+    StackInfo (..),
     MachineWord,
     FromSign (..),
     RegisterId,
@@ -153,12 +154,26 @@ instance (ByteSize t, Default t) => ByteSizeT t where
 class InitState mem st | st -> mem where
     initState :: Int -> mem -> [Int] -> st
 
+-- | Per-state snapshot of stack architecture used for runtime stats accounting.
+data StackInfo w
+    = -- | Architecture has no stack (e.g. accumulator-only ISAs).
+      NoStack
+    | -- | Stack pointer lives in a register / RAM. 'spInitialised' is True once
+      --   the program has written a value to SP at least once; while False the
+      --   value is ignored by stats accumulation.
+      SpStack {sp :: w, spInitialised :: Bool}
+    | -- | Host-side list stacks (e.g. f32a's data / return stacks).
+      ListStack {dDepth :: !Int, rDepth :: !Int}
+    deriving (Show)
+
 class StateInterspector st m isa w | st -> m isa w where
     programCounter :: st -> Int
     memoryDump :: st -> m
     ioStreams :: st -> IntMap ([w], [w])
     reprState :: HashMap String w -> st -> Text -> Text
     reprState _labels _st var = "unknown variable: " <> var
+    stackInfo :: st -> StackInfo w
+    stackInfo _ = NoStack
 
 class Machine st isa w | st -> isa w where
     instructionFetch :: State st (Either Text (Int, isa))

--- a/src/wrench/Wrench/Translator.hs
+++ b/src/wrench/Wrench/Translator.hs
@@ -18,6 +18,7 @@ import Wrench.Translator.Types
 data TranslatorResult mem w = TranslatorResult
     { dump :: !mem
     , labels :: !(HashMap String w)
+    , dumpStats :: !DumpStats
     }
     deriving (Show)
 
@@ -83,6 +84,6 @@ translate memorySize fn src =
                 (Right labels) ->
                     let resolveLabel l = (labels !? l)
                         code = map (uncurry (derefSection resolveLabel)) (markupSectionOffsets 0 sections)
-                        dump = prepareDump memorySize code
-                     in Right $ TranslatorResult dump labels
+                        (dump, stats) = prepareDump memorySize code
+                     in Right $ TranslatorResult dump labels stats
         Left err -> Left $ toText $ errorBundlePretty err

--- a/src/wrench/Wrench/Wrench.hs
+++ b/src/wrench/Wrench/Wrench.hs
@@ -157,7 +157,7 @@ wrench ::
     -> String
     -> Either Text (Result (IntMap (Cell isa2 w)) w)
 wrench Options{input = fn, verbose, maxStateLogLimit} Config{cMemorySize, cLimit, cMemoryMappedIoFlat, cReports, cSeed} src = do
-    trResult@TranslatorResult{dump, labels} <- translate cMemorySize fn src
+    trResult@TranslatorResult{dump, labels, dumpStats} <- translate cMemorySize fn src
 
     pc <- maybeToRight "_start label should be defined." (labels !? "_start")
     let mIoStreams = bimap (map int2mword) (map int2mword) <$> fromMaybe mempty cMemoryMappedIoFlat
@@ -165,15 +165,17 @@ wrench Options{input = fn, verbose, maxStateLogLimit} Config{cMemorySize, cLimit
         ioDump = mkIoMem mIoStreams dump
         st :: st = initState (fromEnum pc) ioDump randomStream
 
-    traceLog <- powerOn cLimit maxStateLogLimit labels st
+    (traceLog, runtimeStats) <- powerOn cLimit maxStateLogLimit labels st
 
     let reports = maybe [] (map (prepareReport trResult verbose traceLog)) cReports
         isSuccess = all fst reports
         reportTexts = map snd reports
+        statsText = formatStats cMemorySize dumpStats runtimeStats
+        allSections = map (T.strip . ("---\n" <>)) reportTexts <> ["---\n" <> statsText]
 
     return
         $ Result
-            { rTrace = unlines $ map (T.strip . ("---\n" <>)) reportTexts
+            { rTrace = unlines allSections
             , rLabels = labels
             , rSuccess = isSuccess
             , rDump = dumpCells dump
@@ -191,3 +193,45 @@ wrench Options{input = fn, verbose, maxStateLogLimit} Config{cMemorySize, cLimit
         randomInts range gen =
             let (val, gen') = uniformR range gen
              in val : randomInts range gen'
+
+formatStats :: forall w. (MachineWord w) => Int -> DumpStats -> RuntimeStats w -> Text
+formatStats memorySize DumpStats{dsSectionsTotalBytes, dsCodeDataExtent} RuntimeStats{rsInstructions, rsStack} =
+    let wordBytes = byteSizeT @w
+        codeDataLine :: Text
+        codeDataLine =
+            if dsCodeDataExtent == 0
+                then "code/data: 0 bytes"
+                else "code/data: " <> show dsCodeDataExtent <> " bytes (0.." <> show (dsCodeDataExtent - 1) <> ")"
+        stackLines :: [Text]
+        stackLines = case rsStack of
+            StackStatsNone -> []
+            StackStatsSp{ssTopSp = Nothing} -> ["stack: 0 bytes (uninitialised)"]
+            StackStatsSp{ssMinSp = Nothing} -> ["stack: 0 bytes (no push observed)"]
+            StackStatsSp{ssTopSp = Just hi, ssMinSp = Just lo} ->
+                let bytes = fromEnum hi - fromEnum lo
+                    rangeNote :: Text
+                    rangeNote =
+                        if bytes == 0
+                            then ""
+                            else " (" <> show (fromEnum lo) <> ".." <> show (fromEnum hi - 1) <> ")"
+                 in ["stack: " <> show bytes <> " bytes" <> rangeNote]
+            StackStatsList{ssMaxDDepth, ssMaxRDepth} ->
+                [ "dstack depth: " <> show ssMaxDDepth <> " (" <> show (ssMaxDDepth * wordBytes) <> " bytes)"
+                , "rstack depth: " <> show ssMaxRDepth <> " (" <> show (ssMaxRDepth * wordBytes) <> " bytes)"
+                ]
+        topBytes = case rsStack of
+            StackStatsNone -> 0
+            StackStatsSp{ssTopSp = Just hi, ssMinSp = Just lo} -> fromEnum hi - fromEnum lo
+            StackStatsSp{} -> 0
+            StackStatsList{ssMaxDDepth, ssMaxRDepth} -> (ssMaxDDepth + ssMaxRDepth) * wordBytes
+        effective = dsCodeDataExtent + topBytes
+        coreLines :: [Text]
+        coreLines =
+            [ "# stats"
+            , "instructions: " <> show rsInstructions
+            , "sections: " <> show dsSectionsTotalBytes <> " bytes"
+            , codeDataLine
+            ]
+                <> stackLines
+                <> ["effective memory: " <> show effective <> " / " <> show memorySize <> " bytes"]
+     in unlines coreLines

--- a/src/wrench/Wrench/Wrench.hs
+++ b/src/wrench/Wrench/Wrench.hs
@@ -170,7 +170,7 @@ wrench Options{input = fn, verbose, maxStateLogLimit} Config{cMemorySize, cLimit
     let reports = maybe [] (map (prepareReport trResult verbose traceLog)) cReports
         isSuccess = all fst reports
         reportTexts = map snd reports
-        statsText = formatStats cMemorySize dumpStats runtimeStats
+        statsText = formatStats $ dumpStatsEntries dumpStats <> runtimeStats
         allSections = map (T.strip . ("---\n" <>)) reportTexts <> ["---\n" <> statsText]
 
     return
@@ -194,44 +194,7 @@ wrench Options{input = fn, verbose, maxStateLogLimit} Config{cMemorySize, cLimit
             let (val, gen') = uniformR range gen
              in val : randomInts range gen'
 
-formatStats :: forall w. (MachineWord w) => Int -> DumpStats -> RuntimeStats w -> Text
-formatStats memorySize DumpStats{dsSectionsTotalBytes, dsCodeDataExtent} RuntimeStats{rsInstructions, rsStack} =
-    let wordBytes = byteSizeT @w
-        codeDataLine :: Text
-        codeDataLine =
-            if dsCodeDataExtent == 0
-                then "code/data: 0 bytes"
-                else "code/data: " <> show dsCodeDataExtent <> " bytes (0.." <> show (dsCodeDataExtent - 1) <> ")"
-        stackLines :: [Text]
-        stackLines = case rsStack of
-            StackStatsNone -> []
-            StackStatsSp{ssTopSp = Nothing} -> ["stack: 0 bytes (uninitialised)"]
-            StackStatsSp{ssMinSp = Nothing} -> ["stack: 0 bytes (no push observed)"]
-            StackStatsSp{ssTopSp = Just hi, ssMinSp = Just lo} ->
-                let bytes = fromEnum hi - fromEnum lo
-                    rangeNote :: Text
-                    rangeNote =
-                        if bytes == 0
-                            then ""
-                            else " (" <> show (fromEnum lo) <> ".." <> show (fromEnum hi - 1) <> ")"
-                 in ["stack: " <> show bytes <> " bytes" <> rangeNote]
-            StackStatsList{ssMaxDDepth, ssMaxRDepth} ->
-                [ "dstack depth: " <> show ssMaxDDepth <> " (" <> show (ssMaxDDepth * wordBytes) <> " bytes)"
-                , "rstack depth: " <> show ssMaxRDepth <> " (" <> show (ssMaxRDepth * wordBytes) <> " bytes)"
-                ]
-        topBytes = case rsStack of
-            StackStatsNone -> 0
-            StackStatsSp{ssTopSp = Just hi, ssMinSp = Just lo} -> fromEnum hi - fromEnum lo
-            StackStatsSp{} -> 0
-            StackStatsList{ssMaxDDepth, ssMaxRDepth} -> (ssMaxDDepth + ssMaxRDepth) * wordBytes
-        effective = dsCodeDataExtent + topBytes
-        coreLines :: [Text]
-        coreLines =
-            [ "# stats"
-            , "instructions: " <> show rsInstructions
-            , "sections: " <> show dsSectionsTotalBytes <> " bytes"
-            , codeDataLine
-            ]
-                <> stackLines
-                <> ["effective memory: " <> show effective <> " / " <> show memorySize <> " bytes"]
-     in unlines coreLines
+-- | Render the collected stats (key/value pairs) as a @# stats@ report section.
+formatStats :: [StatEntry] -> Text
+formatStats entries =
+    unlines $ "# stats" : map (\(k, v) -> k <> ": " <> v) entries

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -242,7 +242,8 @@ generatedTest' :: Isa -> String -> String -> Int -> TestTree
 generatedTest' isa sname vname n = testGroup sname testCases
     where
         testCases =
-            [ goldenSimulate
+            [ goldenSimulateTagged
+                (if sname == vname then Nothing else Just sname)
                 isa
                 ("test/golden/" <> isaPath isa <> "/" <> sname <> ".s")
                 ("test/golden/generated/" <> vname <> "/" <> show i <> ".yaml")
@@ -290,29 +291,33 @@ goldenTranslate' isa fn =
     goldenVsString (fn2name fn) (fn <> "." <> isaPath isa <> ".result") $ do
         src <- decodeUtf8 <$> readFileBS fn
         case translate @isa @Int32 1000 fn src of
-            Right (TranslatorResult dump labels) ->
+            Right (TranslatorResult dump labels _stats) ->
                 return $ encodeUtf8 $ intercalate "\n---\n" [prettyLabels labels, prettyDump labels $ dumpCells dump, ""]
             Left err ->
                 error $ "Translation failed: " <> show err
 
 goldenSimulate :: Isa -> FilePath -> FilePath -> TestTree
-goldenSimulate = goldenSimulate' False
+goldenSimulate = goldenSimulate' Nothing False
 
 goldenSimulateFail :: Isa -> FilePath -> FilePath -> TestTree
-goldenSimulateFail = goldenSimulate' True
+goldenSimulateFail = goldenSimulate' Nothing True
 
-goldenSimulate' :: Bool -> Isa -> FilePath -> FilePath -> TestTree
-goldenSimulate' shouldFail isa =
+goldenSimulateTagged :: Maybe String -> Isa -> FilePath -> FilePath -> TestTree
+goldenSimulateTagged tag = goldenSimulate' tag False
+
+goldenSimulate' :: Maybe String -> Bool -> Isa -> FilePath -> FilePath -> TestTree
+goldenSimulate' goldenTag shouldFail isa =
     case isa of
-        RiscIv -> goldenSimulateInner (wrench @(RiscIvState Int32)) ".risc-iv-32.result" shouldFail
-        F32a -> goldenSimulateInner (wrench @(F32aState Int32)) ".f32a.result" shouldFail
-        Acc32 -> goldenSimulateInner (wrench @(Acc32State Int32)) ".acc32.result" shouldFail
-        M68k -> goldenSimulateInner (wrench @(M68kState Int32)) ".m68k.result" shouldFail
-        VliwIv -> goldenSimulateInner (wrench @(VliwIvState Int32)) ".vliw-iv.result" shouldFail
+        RiscIv -> goldenSimulateInner goldenTag (wrench @(RiscIvState Int32)) ".risc-iv-32.result" shouldFail
+        F32a -> goldenSimulateInner goldenTag (wrench @(F32aState Int32)) ".f32a.result" shouldFail
+        Acc32 -> goldenSimulateInner goldenTag (wrench @(Acc32State Int32)) ".acc32.result" shouldFail
+        M68k -> goldenSimulateInner goldenTag (wrench @(M68kState Int32)) ".m68k.result" shouldFail
+        VliwIv -> goldenSimulateInner goldenTag (wrench @(VliwIvState Int32)) ".vliw-iv.result" shouldFail
     where
-        goldenSimulateInner wrench' ext shouldFail' fn confFn =
-            let testName = "Test case: " <> fn2name confFn
-                goldenPath = dropExtension confFn <> ext
+        goldenSimulateInner tag wrench' ext shouldFail' fn confFn =
+            let tagSuffix = maybe "" ("." <>) tag
+                testName = "Test case: " <> fn2name confFn
+                goldenPath = dropExtension confFn <> tagSuffix <> ext
                 action = do
                     src <- decodeUtf8 <$> readFileBS fn
                     conf <- either (error . toText) id <$> readConfig confFn

--- a/test/golden/acc32/error_sym.acc32.result
+++ b/test/golden/acc32/error_sym.acc32.result
@@ -16,8 +16,7 @@ symio[0x84]: "" >>> "??o"
 mem[0..11]: 	cc cc cc cc ff ff ff ff 6f 00 00 00
 ---
 # stats
-instructions: 7
 sections: 47 bytes
 code/data: 47 bytes (0..46)
-effective memory: 47 / 4096 bytes
+instructions: 7
 

--- a/test/golden/acc32/error_sym.acc32.result
+++ b/test/golden/acc32/error_sym.acc32.result
@@ -14,3 +14,10 @@ numio[0x84]: [] >>> [-858993460,-1,111]
 symio[0x80]: "" >>> ""
 symio[0x84]: "" >>> "??o"
 mem[0..11]: 	cc cc cc cc ff ff ff ff 6f 00 00 00
+---
+# stats
+instructions: 7
+sections: 47 bytes
+code/data: 47 bytes (0..46)
+effective memory: 47 / 4096 bytes
+

--- a/test/golden/acc32/get_put_char_nothing.acc32.result
+++ b/test/golden/acc32/get_put_char_nothing.acc32.result
@@ -1,3 +1,10 @@
 ---
 # Check results
 ERROR: nextPc: memory access error: iomemory[128]: input is depleted
+---
+# stats
+instructions: 2
+sections: 91 bytes
+code/data: 91 bytes (0..90)
+effective memory: 91 / 4096 bytes
+

--- a/test/golden/acc32/get_put_char_nothing.acc32.result
+++ b/test/golden/acc32/get_put_char_nothing.acc32.result
@@ -3,8 +3,7 @@
 ERROR: nextPc: memory access error: iomemory[128]: input is depleted
 ---
 # stats
-instructions: 2
 sections: 91 bytes
 code/data: 91 bytes (0..90)
-effective memory: 91 / 4096 bytes
+instructions: 2
 

--- a/test/golden/acc32/overflow.acc32.result
+++ b/test/golden/acc32/overflow.acc32.result
@@ -14,8 +14,7 @@
 47:	Halt	 Acc: 0 Overflow: 0 Carry: 0
 ---
 # stats
-instructions: 12
 sections: 48 bytes
 code/data: 48 bytes (0..47)
-effective memory: 48 / 4096 bytes
+instructions: 12
 

--- a/test/golden/acc32/overflow.acc32.result
+++ b/test/golden/acc32/overflow.acc32.result
@@ -12,3 +12,10 @@
 40:	Bcs 46	 Acc: 0 Overflow: 0 Carry: 1
 46:	Clc	@clean_carry Acc: 0 Overflow: 0 Carry: 1
 47:	Halt	 Acc: 0 Overflow: 0 Carry: 0
+---
+# stats
+instructions: 12
+sections: 48 bytes
+code/data: 48 bytes (0..47)
+effective memory: 48 / 4096 bytes
+

--- a/test/golden/f32a/carry.f32a.result
+++ b/test/golden/f32a/carry.f32a.result
@@ -21,10 +21,9 @@
 54: Halt  carry: 0 eam: 1 stack:
 ---
 # stats
-instructions: 19
 sections: 55 bytes
 code/data: 55 bytes (0..54)
+instructions: 19
 dstack depth: 3 (12 bytes)
 rstack depth: 0 (0 bytes)
-effective memory: 67 / 576 bytes
 

--- a/test/golden/f32a/carry.f32a.result
+++ b/test/golden/f32a/carry.f32a.result
@@ -19,3 +19,12 @@
 52: Add  carry: 1 eam: 1 stack: 0x00000000:0x00000002
 53: Drop  carry: 0 eam: 1 stack: 0x00000003
 54: Halt  carry: 0 eam: 1 stack:
+---
+# stats
+instructions: 19
+sections: 55 bytes
+code/data: 55 bytes (0..54)
+dstack depth: 3 (12 bytes)
+rstack depth: 0 (0 bytes)
+effective memory: 67 / 576 bytes
+

--- a/test/golden/f32a/div_27_4.f32a.result
+++ b/test/golden/f32a/div_27_4.f32a.result
@@ -328,3 +328,12 @@ dstack:  rstack:
 # Result
 numio[0x80]: [] >>> [6,3]
 numio[0x84]: [] >>> []
+---
+# stats
+instructions: 81
+sections: 59 bytes
+code/data: 59 bytes (0..58)
+dstack depth: 3 (12 bytes)
+rstack depth: 1 (4 bytes)
+effective memory: 75 / 256 bytes
+

--- a/test/golden/f32a/div_27_4.f32a.result
+++ b/test/golden/f32a/div_27_4.f32a.result
@@ -330,10 +330,9 @@ numio[0x80]: [] >>> [6,3]
 numio[0x84]: [] >>> []
 ---
 # stats
-instructions: 81
 sections: 59 bytes
 code/data: 59 bytes (0..58)
+instructions: 81
 dstack depth: 3 (12 bytes)
 rstack depth: 1 (4 bytes)
-effective memory: 75 / 256 bytes
 

--- a/test/golden/f32a/div_2_3.f32a.result
+++ b/test/golden/f32a/div_2_3.f32a.result
@@ -171,10 +171,9 @@ numio[0x80]: [] >>> [0,2]
 numio[0x84]: [] >>> []
 ---
 # stats
-instructions: 81
 sections: 59 bytes
 code/data: 59 bytes (0..58)
+instructions: 81
 dstack depth: 3 (12 bytes)
 rstack depth: 1 (4 bytes)
-effective memory: 75 / 256 bytes
 

--- a/test/golden/f32a/div_2_3.f32a.result
+++ b/test/golden/f32a/div_2_3.f32a.result
@@ -169,3 +169,12 @@ numio[0x84]: [] >>> []
 ASSERTION FAIL, expect:
 numio[0x80]: [] >>> [0,2]
 numio[0x84]: [] >>> []
+---
+# stats
+instructions: 81
+sections: 59 bytes
+code/data: 59 bytes (0..58)
+dstack depth: 3 (12 bytes)
+rstack depth: 1 (4 bytes)
+effective memory: 75 / 256 bytes
+

--- a/test/golden/f32a/div_3_2.f32a.result
+++ b/test/golden/f32a/div_3_2.f32a.result
@@ -166,3 +166,12 @@ A B T S BUF 0x00000080 0x00000088 0x00000000 0x00000000 mem[136..146]: 	02 00 00
 # Result
 numio[0x80]: [] >>> [1,1]
 numio[0x84]: [] >>> []
+---
+# stats
+instructions: 81
+sections: 59 bytes
+code/data: 59 bytes (0..58)
+dstack depth: 3 (12 bytes)
+rstack depth: 1 (4 bytes)
+effective memory: 75 / 256 bytes
+

--- a/test/golden/f32a/div_3_2.f32a.result
+++ b/test/golden/f32a/div_3_2.f32a.result
@@ -168,10 +168,9 @@ numio[0x80]: [] >>> [1,1]
 numio[0x84]: [] >>> []
 ---
 # stats
-instructions: 81
 sections: 59 bytes
 code/data: 59 bytes (0..58)
+instructions: 81
 dstack depth: 3 (12 bytes)
 rstack depth: 1 (4 bytes)
-effective memory: 75 / 256 bytes
 

--- a/test/golden/f32a/factorial.f32a.result
+++ b/test/golden/f32a/factorial.f32a.result
@@ -1444,10 +1444,9 @@ numio[0x80]: [] >>> []
 numio[0x84]: [] >>> [24]
 ---
 # stats
-instructions: 719
 sections: 348 bytes
 code/data: 348 bytes (0..347)
+instructions: 719
 dstack depth: 5 (20 bytes)
 rstack depth: 3 (12 bytes)
-effective memory: 380 / 576 bytes
 

--- a/test/golden/f32a/factorial.f32a.result
+++ b/test/golden/f32a/factorial.f32a.result
@@ -1442,3 +1442,12 @@ T A S 0x00000000 0x00000084 0x00000000 R 0
 # Result
 numio[0x80]: [] >>> []
 numio[0x84]: [] >>> [24]
+---
+# stats
+instructions: 719
+sections: 348 bytes
+code/data: 348 bytes (0..347)
+dstack depth: 5 (20 bytes)
+rstack depth: 3 (12 bytes)
+effective memory: 380 / 576 bytes
+

--- a/test/golden/f32a/get_put_char_nothing.f32a.result
+++ b/test/golden/f32a/get_put_char_nothing.f32a.result
@@ -1,3 +1,12 @@
 ---
 # Check results
 ERROR: nextPc: memory access error: iomemory[128]: input is depleted
+---
+# stats
+instructions: 5
+sections: 78 bytes
+code/data: 78 bytes (0..77)
+dstack depth: 1 (4 bytes)
+rstack depth: 0 (0 bytes)
+effective memory: 82 / 4096 bytes
+

--- a/test/golden/f32a/get_put_char_nothing.f32a.result
+++ b/test/golden/f32a/get_put_char_nothing.f32a.result
@@ -3,10 +3,9 @@
 ERROR: nextPc: memory access error: iomemory[128]: input is depleted
 ---
 # stats
-instructions: 5
 sections: 78 bytes
 code/data: 78 bytes (0..77)
+instructions: 5
 dstack depth: 1 (4 bytes)
 rstack depth: 0 (0 bytes)
-effective memory: 82 / 4096 bytes
 

--- a/test/golden/f32a/jmp_and_call.f32a.result
+++ b/test/golden/f32a/jmp_and_call.f32a.result
@@ -10,3 +10,12 @@
 ---
 # Check results
 T A B S 50 0 0x00000000 0
+---
+# stats
+instructions: 7
+sections: 23 bytes
+code/data: 23 bytes (0..22)
+dstack depth: 2 (8 bytes)
+rstack depth: 1 (4 bytes)
+effective memory: 35 / 4096 bytes
+

--- a/test/golden/f32a/jmp_and_call.f32a.result
+++ b/test/golden/f32a/jmp_and_call.f32a.result
@@ -12,10 +12,9 @@
 T A B S 50 0 0x00000000 0
 ---
 # stats
-instructions: 7
 sections: 23 bytes
 code/data: 23 bytes (0..22)
+instructions: 7
 dstack depth: 2 (8 bytes)
 rstack depth: 1 (4 bytes)
-effective memory: 35 / 4096 bytes
 

--- a/test/golden/generated/dup/1.acc32.result
+++ b/test/golden/generated/dup/1.acc32.result
@@ -4,8 +4,7 @@ numio[0x80]: [] >>> []
 numio[0x84]: [] >>> [42,42]
 ---
 # stats
-instructions: 5
 sections: 23 bytes
 code/data: 23 bytes (0..22)
-effective memory: 23 / 4096 bytes
+instructions: 5
 

--- a/test/golden/generated/dup/1.acc32.result
+++ b/test/golden/generated/dup/1.acc32.result
@@ -2,3 +2,10 @@
 # Check results
 numio[0x80]: [] >>> []
 numio[0x84]: [] >>> [42,42]
+---
+# stats
+instructions: 5
+sections: 23 bytes
+code/data: 23 bytes (0..22)
+effective memory: 23 / 4096 bytes
+

--- a/test/golden/generated/factorial/1.acc32.result
+++ b/test/golden/generated/factorial/1.acc32.result
@@ -2,3 +2,10 @@
 # Check results
 numio[0x80]: [] >>> []
 numio[0x84]: [] >>> [1]
+---
+# stats
+instructions: 11
+sections: 105 bytes
+code/data: 105 bytes (0..104)
+effective memory: 105 / 4096 bytes
+

--- a/test/golden/generated/factorial/1.acc32.result
+++ b/test/golden/generated/factorial/1.acc32.result
@@ -4,8 +4,7 @@ numio[0x80]: [] >>> []
 numio[0x84]: [] >>> [1]
 ---
 # stats
-instructions: 11
 sections: 105 bytes
 code/data: 105 bytes (0..104)
-effective memory: 105 / 4096 bytes
+instructions: 11
 

--- a/test/golden/generated/factorial/1.f32a.result
+++ b/test/golden/generated/factorial/1.f32a.result
@@ -4,10 +4,9 @@ numio[0x80]: [] >>> []
 numio[0x84]: [] >>> [1]
 ---
 # stats
-instructions: 23
 sections: 348 bytes
 code/data: 348 bytes (0..347)
+instructions: 23
 dstack depth: 3 (12 bytes)
 rstack depth: 3 (12 bytes)
-effective memory: 372 / 4096 bytes
 

--- a/test/golden/generated/factorial/1.f32a.result
+++ b/test/golden/generated/factorial/1.f32a.result
@@ -2,3 +2,12 @@
 # Check results
 numio[0x80]: [] >>> []
 numio[0x84]: [] >>> [1]
+---
+# stats
+instructions: 23
+sections: 348 bytes
+code/data: 348 bytes (0..347)
+dstack depth: 3 (12 bytes)
+rstack depth: 3 (12 bytes)
+effective memory: 372 / 4096 bytes
+

--- a/test/golden/generated/factorial/1.factorial_rec.risc-iv-32.result
+++ b/test/golden/generated/factorial/1.factorial_rec.risc-iv-32.result
@@ -4,9 +4,8 @@ numio[0x80]: [] >>> []
 numio[0x84]: [] >>> [1]
 ---
 # stats
-instructions: 19
 sections: 160 bytes
 code/data: 192 bytes (0..191)
+instructions: 19
 stack: 0 bytes (no push observed)
-effective memory: 192 / 4096 bytes
 

--- a/test/golden/generated/factorial/1.factorial_rec.risc-iv-32.result
+++ b/test/golden/generated/factorial/1.factorial_rec.risc-iv-32.result
@@ -1,0 +1,12 @@
+---
+# Check results
+numio[0x80]: [] >>> []
+numio[0x84]: [] >>> [1]
+---
+# stats
+instructions: 19
+sections: 160 bytes
+code/data: 192 bytes (0..191)
+stack: 0 bytes (no push observed)
+effective memory: 192 / 4096 bytes
+

--- a/test/golden/generated/factorial/1.factorial_rec.vliw-iv.result
+++ b/test/golden/generated/factorial/1.factorial_rec.vliw-iv.result
@@ -4,9 +4,8 @@ numio[0x80]: [] >>> []
 numio[0x84]: [] >>> [1]
 ---
 # stats
-instructions: 19
 sections: 426 bytes
 code/data: 674 bytes (0..673)
+instructions: 19
 stack: 0 bytes (no push observed)
-effective memory: 674 / 4096 bytes
 

--- a/test/golden/generated/factorial/1.factorial_rec.vliw-iv.result
+++ b/test/golden/generated/factorial/1.factorial_rec.vliw-iv.result
@@ -1,0 +1,12 @@
+---
+# Check results
+numio[0x80]: [] >>> []
+numio[0x84]: [] >>> [1]
+---
+# stats
+instructions: 19
+sections: 426 bytes
+code/data: 674 bytes (0..673)
+stack: 0 bytes (no push observed)
+effective memory: 674 / 4096 bytes
+

--- a/test/golden/generated/factorial/1.m68k.result
+++ b/test/golden/generated/factorial/1.m68k.result
@@ -2,3 +2,11 @@
 # Check results
 numio[0x80]: [] >>> []
 numio[0x84]: [] >>> [1]
+---
+# stats
+instructions: 10
+sections: 114 bytes
+code/data: 114 bytes (0..113)
+stack: 0 bytes (no push observed)
+effective memory: 114 / 4096 bytes
+

--- a/test/golden/generated/factorial/1.m68k.result
+++ b/test/golden/generated/factorial/1.m68k.result
@@ -4,9 +4,8 @@ numio[0x80]: [] >>> []
 numio[0x84]: [] >>> [1]
 ---
 # stats
-instructions: 10
 sections: 114 bytes
 code/data: 114 bytes (0..113)
+instructions: 10
 stack: 0 bytes (no push observed)
-effective memory: 114 / 4096 bytes
 

--- a/test/golden/generated/factorial/1.risc-iv-32.result
+++ b/test/golden/generated/factorial/1.risc-iv-32.result
@@ -2,3 +2,11 @@
 # Check results
 numio[0x80]: [] >>> []
 numio[0x84]: [] >>> [1]
+---
+# stats
+instructions: 12
+sections: 128 bytes
+code/data: 128 bytes (0..127)
+stack: 0 bytes (uninitialised)
+effective memory: 128 / 4096 bytes
+

--- a/test/golden/generated/factorial/1.risc-iv-32.result
+++ b/test/golden/generated/factorial/1.risc-iv-32.result
@@ -4,9 +4,8 @@ numio[0x80]: [] >>> []
 numio[0x84]: [] >>> [1]
 ---
 # stats
-instructions: 12
 sections: 128 bytes
 code/data: 128 bytes (0..127)
+instructions: 12
 stack: 0 bytes (uninitialised)
-effective memory: 128 / 4096 bytes
 

--- a/test/golden/generated/factorial/1.vliw-iv.result
+++ b/test/golden/generated/factorial/1.vliw-iv.result
@@ -2,3 +2,11 @@
 # Check results
 numio[0x80]: [] >>> []
 numio[0x84]: [] >>> [1]
+---
+# stats
+instructions: 12
+sections: 338 bytes
+code/data: 474 bytes (0..473)
+stack: 0 bytes (uninitialised)
+effective memory: 474 / 4096 bytes
+

--- a/test/golden/generated/factorial/1.vliw-iv.result
+++ b/test/golden/generated/factorial/1.vliw-iv.result
@@ -4,9 +4,8 @@ numio[0x80]: [] >>> []
 numio[0x84]: [] >>> [1]
 ---
 # stats
-instructions: 12
 sections: 338 bytes
 code/data: 474 bytes (0..473)
+instructions: 12
 stack: 0 bytes (uninitialised)
-effective memory: 474 / 4096 bytes
 

--- a/test/golden/generated/factorial/10.acc32.result
+++ b/test/golden/generated/factorial/10.acc32.result
@@ -2,3 +2,10 @@
 # Check results
 numio[0x80]: [] >>> []
 numio[0x84]: [] >>> [-1]
+---
+# stats
+instructions: 7
+sections: 105 bytes
+code/data: 105 bytes (0..104)
+effective memory: 105 / 4096 bytes
+

--- a/test/golden/generated/factorial/10.acc32.result
+++ b/test/golden/generated/factorial/10.acc32.result
@@ -4,8 +4,7 @@ numio[0x80]: [] >>> []
 numio[0x84]: [] >>> [-1]
 ---
 # stats
-instructions: 7
 sections: 105 bytes
 code/data: 105 bytes (0..104)
-effective memory: 105 / 4096 bytes
+instructions: 7
 

--- a/test/golden/generated/factorial/10.f32a.result
+++ b/test/golden/generated/factorial/10.f32a.result
@@ -2,3 +2,12 @@
 # Check results
 numio[0x80]: [] >>> []
 numio[0x84]: [] >>> [-1]
+---
+# stats
+instructions: 13
+sections: 348 bytes
+code/data: 348 bytes (0..347)
+dstack depth: 3 (12 bytes)
+rstack depth: 1 (4 bytes)
+effective memory: 364 / 4096 bytes
+

--- a/test/golden/generated/factorial/10.f32a.result
+++ b/test/golden/generated/factorial/10.f32a.result
@@ -4,10 +4,9 @@ numio[0x80]: [] >>> []
 numio[0x84]: [] >>> [-1]
 ---
 # stats
-instructions: 13
 sections: 348 bytes
 code/data: 348 bytes (0..347)
+instructions: 13
 dstack depth: 3 (12 bytes)
 rstack depth: 1 (4 bytes)
-effective memory: 364 / 4096 bytes
 

--- a/test/golden/generated/factorial/10.factorial_rec.risc-iv-32.result
+++ b/test/golden/generated/factorial/10.factorial_rec.risc-iv-32.result
@@ -4,9 +4,8 @@ numio[0x80]: [] >>> []
 numio[0x84]: [] >>> [-1]
 ---
 # stats
-instructions: 17
 sections: 160 bytes
 code/data: 192 bytes (0..191)
+instructions: 17
 stack: 0 bytes (no push observed)
-effective memory: 192 / 4096 bytes
 

--- a/test/golden/generated/factorial/10.factorial_rec.risc-iv-32.result
+++ b/test/golden/generated/factorial/10.factorial_rec.risc-iv-32.result
@@ -1,0 +1,12 @@
+---
+# Check results
+numio[0x80]: [] >>> []
+numio[0x84]: [] >>> [-1]
+---
+# stats
+instructions: 17
+sections: 160 bytes
+code/data: 192 bytes (0..191)
+stack: 0 bytes (no push observed)
+effective memory: 192 / 4096 bytes
+

--- a/test/golden/generated/factorial/10.factorial_rec.vliw-iv.result
+++ b/test/golden/generated/factorial/10.factorial_rec.vliw-iv.result
@@ -1,0 +1,12 @@
+---
+# Check results
+numio[0x80]: [] >>> []
+numio[0x84]: [] >>> [-1]
+---
+# stats
+instructions: 17
+sections: 426 bytes
+code/data: 674 bytes (0..673)
+stack: 0 bytes (no push observed)
+effective memory: 674 / 4096 bytes
+

--- a/test/golden/generated/factorial/10.factorial_rec.vliw-iv.result
+++ b/test/golden/generated/factorial/10.factorial_rec.vliw-iv.result
@@ -4,9 +4,8 @@ numio[0x80]: [] >>> []
 numio[0x84]: [] >>> [-1]
 ---
 # stats
-instructions: 17
 sections: 426 bytes
 code/data: 674 bytes (0..673)
+instructions: 17
 stack: 0 bytes (no push observed)
-effective memory: 674 / 4096 bytes
 

--- a/test/golden/generated/factorial/10.m68k.result
+++ b/test/golden/generated/factorial/10.m68k.result
@@ -2,3 +2,11 @@
 # Check results
 numio[0x80]: [] >>> []
 numio[0x84]: [] >>> [-1]
+---
+# stats
+instructions: 11
+sections: 114 bytes
+code/data: 114 bytes (0..113)
+stack: 0 bytes (no push observed)
+effective memory: 114 / 4096 bytes
+

--- a/test/golden/generated/factorial/10.m68k.result
+++ b/test/golden/generated/factorial/10.m68k.result
@@ -4,9 +4,8 @@ numio[0x80]: [] >>> []
 numio[0x84]: [] >>> [-1]
 ---
 # stats
-instructions: 11
 sections: 114 bytes
 code/data: 114 bytes (0..113)
+instructions: 11
 stack: 0 bytes (no push observed)
-effective memory: 114 / 4096 bytes
 

--- a/test/golden/generated/factorial/10.risc-iv-32.result
+++ b/test/golden/generated/factorial/10.risc-iv-32.result
@@ -2,3 +2,11 @@
 # Check results
 numio[0x80]: [] >>> []
 numio[0x84]: [] >>> [-1]
+---
+# stats
+instructions: 12
+sections: 128 bytes
+code/data: 128 bytes (0..127)
+stack: 0 bytes (uninitialised)
+effective memory: 128 / 4096 bytes
+

--- a/test/golden/generated/factorial/10.risc-iv-32.result
+++ b/test/golden/generated/factorial/10.risc-iv-32.result
@@ -4,9 +4,8 @@ numio[0x80]: [] >>> []
 numio[0x84]: [] >>> [-1]
 ---
 # stats
-instructions: 12
 sections: 128 bytes
 code/data: 128 bytes (0..127)
+instructions: 12
 stack: 0 bytes (uninitialised)
-effective memory: 128 / 4096 bytes
 

--- a/test/golden/generated/factorial/10.vliw-iv.result
+++ b/test/golden/generated/factorial/10.vliw-iv.result
@@ -4,9 +4,8 @@ numio[0x80]: [] >>> []
 numio[0x84]: [] >>> [-1]
 ---
 # stats
-instructions: 12
 sections: 338 bytes
 code/data: 474 bytes (0..473)
+instructions: 12
 stack: 0 bytes (uninitialised)
-effective memory: 474 / 4096 bytes
 

--- a/test/golden/generated/factorial/10.vliw-iv.result
+++ b/test/golden/generated/factorial/10.vliw-iv.result
@@ -2,3 +2,11 @@
 # Check results
 numio[0x80]: [] >>> []
 numio[0x84]: [] >>> [-1]
+---
+# stats
+instructions: 12
+sections: 338 bytes
+code/data: 474 bytes (0..473)
+stack: 0 bytes (uninitialised)
+effective memory: 474 / 4096 bytes
+

--- a/test/golden/generated/factorial/11.acc32.result
+++ b/test/golden/generated/factorial/11.acc32.result
@@ -2,3 +2,10 @@
 # Check results
 numio[0x80]: [] >>> []
 numio[0x84]: [] >>> [-1]
+---
+# stats
+instructions: 7
+sections: 105 bytes
+code/data: 105 bytes (0..104)
+effective memory: 105 / 4096 bytes
+

--- a/test/golden/generated/factorial/11.acc32.result
+++ b/test/golden/generated/factorial/11.acc32.result
@@ -4,8 +4,7 @@ numio[0x80]: [] >>> []
 numio[0x84]: [] >>> [-1]
 ---
 # stats
-instructions: 7
 sections: 105 bytes
 code/data: 105 bytes (0..104)
-effective memory: 105 / 4096 bytes
+instructions: 7
 

--- a/test/golden/generated/factorial/11.f32a.result
+++ b/test/golden/generated/factorial/11.f32a.result
@@ -2,3 +2,12 @@
 # Check results
 numio[0x80]: [] >>> []
 numio[0x84]: [] >>> [-1]
+---
+# stats
+instructions: 13
+sections: 348 bytes
+code/data: 348 bytes (0..347)
+dstack depth: 3 (12 bytes)
+rstack depth: 1 (4 bytes)
+effective memory: 364 / 4096 bytes
+

--- a/test/golden/generated/factorial/11.f32a.result
+++ b/test/golden/generated/factorial/11.f32a.result
@@ -4,10 +4,9 @@ numio[0x80]: [] >>> []
 numio[0x84]: [] >>> [-1]
 ---
 # stats
-instructions: 13
 sections: 348 bytes
 code/data: 348 bytes (0..347)
+instructions: 13
 dstack depth: 3 (12 bytes)
 rstack depth: 1 (4 bytes)
-effective memory: 364 / 4096 bytes
 

--- a/test/golden/generated/factorial/11.factorial_rec.risc-iv-32.result
+++ b/test/golden/generated/factorial/11.factorial_rec.risc-iv-32.result
@@ -4,9 +4,8 @@ numio[0x80]: [] >>> []
 numio[0x84]: [] >>> [-1]
 ---
 # stats
-instructions: 17
 sections: 160 bytes
 code/data: 192 bytes (0..191)
+instructions: 17
 stack: 0 bytes (no push observed)
-effective memory: 192 / 4096 bytes
 

--- a/test/golden/generated/factorial/11.factorial_rec.risc-iv-32.result
+++ b/test/golden/generated/factorial/11.factorial_rec.risc-iv-32.result
@@ -1,0 +1,12 @@
+---
+# Check results
+numio[0x80]: [] >>> []
+numio[0x84]: [] >>> [-1]
+---
+# stats
+instructions: 17
+sections: 160 bytes
+code/data: 192 bytes (0..191)
+stack: 0 bytes (no push observed)
+effective memory: 192 / 4096 bytes
+

--- a/test/golden/generated/factorial/11.factorial_rec.vliw-iv.result
+++ b/test/golden/generated/factorial/11.factorial_rec.vliw-iv.result
@@ -1,0 +1,12 @@
+---
+# Check results
+numio[0x80]: [] >>> []
+numio[0x84]: [] >>> [-1]
+---
+# stats
+instructions: 17
+sections: 426 bytes
+code/data: 674 bytes (0..673)
+stack: 0 bytes (no push observed)
+effective memory: 674 / 4096 bytes
+

--- a/test/golden/generated/factorial/11.factorial_rec.vliw-iv.result
+++ b/test/golden/generated/factorial/11.factorial_rec.vliw-iv.result
@@ -4,9 +4,8 @@ numio[0x80]: [] >>> []
 numio[0x84]: [] >>> [-1]
 ---
 # stats
-instructions: 17
 sections: 426 bytes
 code/data: 674 bytes (0..673)
+instructions: 17
 stack: 0 bytes (no push observed)
-effective memory: 674 / 4096 bytes
 

--- a/test/golden/generated/factorial/11.m68k.result
+++ b/test/golden/generated/factorial/11.m68k.result
@@ -2,3 +2,11 @@
 # Check results
 numio[0x80]: [] >>> []
 numio[0x84]: [] >>> [-1]
+---
+# stats
+instructions: 11
+sections: 114 bytes
+code/data: 114 bytes (0..113)
+stack: 0 bytes (no push observed)
+effective memory: 114 / 4096 bytes
+

--- a/test/golden/generated/factorial/11.m68k.result
+++ b/test/golden/generated/factorial/11.m68k.result
@@ -4,9 +4,8 @@ numio[0x80]: [] >>> []
 numio[0x84]: [] >>> [-1]
 ---
 # stats
-instructions: 11
 sections: 114 bytes
 code/data: 114 bytes (0..113)
+instructions: 11
 stack: 0 bytes (no push observed)
-effective memory: 114 / 4096 bytes
 

--- a/test/golden/generated/factorial/11.risc-iv-32.result
+++ b/test/golden/generated/factorial/11.risc-iv-32.result
@@ -2,3 +2,11 @@
 # Check results
 numio[0x80]: [] >>> []
 numio[0x84]: [] >>> [-1]
+---
+# stats
+instructions: 12
+sections: 128 bytes
+code/data: 128 bytes (0..127)
+stack: 0 bytes (uninitialised)
+effective memory: 128 / 4096 bytes
+

--- a/test/golden/generated/factorial/11.risc-iv-32.result
+++ b/test/golden/generated/factorial/11.risc-iv-32.result
@@ -4,9 +4,8 @@ numio[0x80]: [] >>> []
 numio[0x84]: [] >>> [-1]
 ---
 # stats
-instructions: 12
 sections: 128 bytes
 code/data: 128 bytes (0..127)
+instructions: 12
 stack: 0 bytes (uninitialised)
-effective memory: 128 / 4096 bytes
 

--- a/test/golden/generated/factorial/11.vliw-iv.result
+++ b/test/golden/generated/factorial/11.vliw-iv.result
@@ -4,9 +4,8 @@ numio[0x80]: [] >>> []
 numio[0x84]: [] >>> [-1]
 ---
 # stats
-instructions: 12
 sections: 338 bytes
 code/data: 474 bytes (0..473)
+instructions: 12
 stack: 0 bytes (uninitialised)
-effective memory: 474 / 4096 bytes
 

--- a/test/golden/generated/factorial/11.vliw-iv.result
+++ b/test/golden/generated/factorial/11.vliw-iv.result
@@ -2,3 +2,11 @@
 # Check results
 numio[0x80]: [] >>> []
 numio[0x84]: [] >>> [-1]
+---
+# stats
+instructions: 12
+sections: 338 bytes
+code/data: 474 bytes (0..473)
+stack: 0 bytes (uninitialised)
+effective memory: 474 / 4096 bytes
+

--- a/test/golden/generated/factorial/2.acc32.result
+++ b/test/golden/generated/factorial/2.acc32.result
@@ -4,8 +4,7 @@ numio[0x80]: [] >>> []
 numio[0x84]: [] >>> [120]
 ---
 # stats
-instructions: 56
 sections: 105 bytes
 code/data: 105 bytes (0..104)
-effective memory: 105 / 4096 bytes
+instructions: 56
 

--- a/test/golden/generated/factorial/2.acc32.result
+++ b/test/golden/generated/factorial/2.acc32.result
@@ -2,3 +2,10 @@
 # Check results
 numio[0x80]: [] >>> []
 numio[0x84]: [] >>> [120]
+---
+# stats
+instructions: 56
+sections: 105 bytes
+code/data: 105 bytes (0..104)
+effective memory: 105 / 4096 bytes
+

--- a/test/golden/generated/factorial/2.f32a.result
+++ b/test/golden/generated/factorial/2.f32a.result
@@ -4,10 +4,9 @@ numio[0x80]: [] >>> []
 numio[0x84]: [] >>> [120]
 ---
 # stats
-instructions: 893
 sections: 348 bytes
 code/data: 348 bytes (0..347)
+instructions: 893
 dstack depth: 5 (20 bytes)
 rstack depth: 3 (12 bytes)
-effective memory: 380 / 4096 bytes
 

--- a/test/golden/generated/factorial/2.f32a.result
+++ b/test/golden/generated/factorial/2.f32a.result
@@ -2,3 +2,12 @@
 # Check results
 numio[0x80]: [] >>> []
 numio[0x84]: [] >>> [120]
+---
+# stats
+instructions: 893
+sections: 348 bytes
+code/data: 348 bytes (0..347)
+dstack depth: 5 (20 bytes)
+rstack depth: 3 (12 bytes)
+effective memory: 380 / 4096 bytes
+

--- a/test/golden/generated/factorial/2.factorial_rec.risc-iv-32.result
+++ b/test/golden/generated/factorial/2.factorial_rec.risc-iv-32.result
@@ -1,0 +1,12 @@
+---
+# Check results
+numio[0x80]: [] >>> []
+numio[0x84]: [] >>> [120]
+---
+# stats
+instructions: 87
+sections: 160 bytes
+code/data: 192 bytes (0..191)
+stack: 32 bytes (566..597)
+effective memory: 224 / 4096 bytes
+

--- a/test/golden/generated/factorial/2.factorial_rec.risc-iv-32.result
+++ b/test/golden/generated/factorial/2.factorial_rec.risc-iv-32.result
@@ -4,9 +4,8 @@ numio[0x80]: [] >>> []
 numio[0x84]: [] >>> [120]
 ---
 # stats
-instructions: 87
 sections: 160 bytes
 code/data: 192 bytes (0..191)
+instructions: 87
 stack: 32 bytes (566..597)
-effective memory: 224 / 4096 bytes
 

--- a/test/golden/generated/factorial/2.factorial_rec.vliw-iv.result
+++ b/test/golden/generated/factorial/2.factorial_rec.vliw-iv.result
@@ -1,0 +1,12 @@
+---
+# Check results
+numio[0x80]: [] >>> []
+numio[0x84]: [] >>> [120]
+---
+# stats
+instructions: 87
+sections: 426 bytes
+code/data: 674 bytes (0..673)
+stack: 32 bytes (1266..1297)
+effective memory: 706 / 4096 bytes
+

--- a/test/golden/generated/factorial/2.factorial_rec.vliw-iv.result
+++ b/test/golden/generated/factorial/2.factorial_rec.vliw-iv.result
@@ -4,9 +4,8 @@ numio[0x80]: [] >>> []
 numio[0x84]: [] >>> [120]
 ---
 # stats
-instructions: 87
 sections: 426 bytes
 code/data: 674 bytes (0..673)
+instructions: 87
 stack: 32 bytes (1266..1297)
-effective memory: 706 / 4096 bytes
 

--- a/test/golden/generated/factorial/2.m68k.result
+++ b/test/golden/generated/factorial/2.m68k.result
@@ -4,9 +4,8 @@ numio[0x80]: [] >>> []
 numio[0x84]: [] >>> [120]
 ---
 # stats
-instructions: 32
 sections: 114 bytes
 code/data: 114 bytes (0..113)
+instructions: 32
 stack: 0 bytes (no push observed)
-effective memory: 114 / 4096 bytes
 

--- a/test/golden/generated/factorial/2.m68k.result
+++ b/test/golden/generated/factorial/2.m68k.result
@@ -2,3 +2,11 @@
 # Check results
 numio[0x80]: [] >>> []
 numio[0x84]: [] >>> [120]
+---
+# stats
+instructions: 32
+sections: 114 bytes
+code/data: 114 bytes (0..113)
+stack: 0 bytes (no push observed)
+effective memory: 114 / 4096 bytes
+

--- a/test/golden/generated/factorial/2.risc-iv-32.result
+++ b/test/golden/generated/factorial/2.risc-iv-32.result
@@ -4,9 +4,8 @@ numio[0x80]: [] >>> []
 numio[0x84]: [] >>> [120]
 ---
 # stats
-instructions: 42
 sections: 128 bytes
 code/data: 128 bytes (0..127)
+instructions: 42
 stack: 0 bytes (uninitialised)
-effective memory: 128 / 4096 bytes
 

--- a/test/golden/generated/factorial/2.risc-iv-32.result
+++ b/test/golden/generated/factorial/2.risc-iv-32.result
@@ -2,3 +2,11 @@
 # Check results
 numio[0x80]: [] >>> []
 numio[0x84]: [] >>> [120]
+---
+# stats
+instructions: 42
+sections: 128 bytes
+code/data: 128 bytes (0..127)
+stack: 0 bytes (uninitialised)
+effective memory: 128 / 4096 bytes
+

--- a/test/golden/generated/factorial/2.vliw-iv.result
+++ b/test/golden/generated/factorial/2.vliw-iv.result
@@ -4,9 +4,8 @@ numio[0x80]: [] >>> []
 numio[0x84]: [] >>> [120]
 ---
 # stats
-instructions: 42
 sections: 338 bytes
 code/data: 474 bytes (0..473)
+instructions: 42
 stack: 0 bytes (uninitialised)
-effective memory: 474 / 4096 bytes
 

--- a/test/golden/generated/factorial/2.vliw-iv.result
+++ b/test/golden/generated/factorial/2.vliw-iv.result
@@ -2,3 +2,11 @@
 # Check results
 numio[0x80]: [] >>> []
 numio[0x84]: [] >>> [120]
+---
+# stats
+instructions: 42
+sections: 338 bytes
+code/data: 474 bytes (0..473)
+stack: 0 bytes (uninitialised)
+effective memory: 474 / 4096 bytes
+

--- a/test/golden/generated/factorial/3.acc32.result
+++ b/test/golden/generated/factorial/3.acc32.result
@@ -2,3 +2,10 @@
 # Check results
 numio[0x80]: [] >>> []
 numio[0x84]: [] >>> [720]
+---
+# stats
+instructions: 65
+sections: 105 bytes
+code/data: 105 bytes (0..104)
+effective memory: 105 / 4096 bytes
+

--- a/test/golden/generated/factorial/3.acc32.result
+++ b/test/golden/generated/factorial/3.acc32.result
@@ -4,8 +4,7 @@ numio[0x80]: [] >>> []
 numio[0x84]: [] >>> [720]
 ---
 # stats
-instructions: 65
 sections: 105 bytes
 code/data: 105 bytes (0..104)
-effective memory: 105 / 4096 bytes
+instructions: 65
 

--- a/test/golden/generated/factorial/3.f32a.result
+++ b/test/golden/generated/factorial/3.f32a.result
@@ -2,3 +2,12 @@
 # Check results
 numio[0x80]: [] >>> []
 numio[0x84]: [] >>> [720]
+---
+# stats
+instructions: 1067
+sections: 348 bytes
+code/data: 348 bytes (0..347)
+dstack depth: 5 (20 bytes)
+rstack depth: 3 (12 bytes)
+effective memory: 380 / 4096 bytes
+

--- a/test/golden/generated/factorial/3.f32a.result
+++ b/test/golden/generated/factorial/3.f32a.result
@@ -4,10 +4,9 @@ numio[0x80]: [] >>> []
 numio[0x84]: [] >>> [720]
 ---
 # stats
-instructions: 1067
 sections: 348 bytes
 code/data: 348 bytes (0..347)
+instructions: 1067
 dstack depth: 5 (20 bytes)
 rstack depth: 3 (12 bytes)
-effective memory: 380 / 4096 bytes
 

--- a/test/golden/generated/factorial/3.factorial_rec.risc-iv-32.result
+++ b/test/golden/generated/factorial/3.factorial_rec.risc-iv-32.result
@@ -1,0 +1,12 @@
+---
+# Check results
+numio[0x80]: [] >>> []
+numio[0x84]: [] >>> [720]
+---
+# stats
+instructions: 104
+sections: 160 bytes
+code/data: 192 bytes (0..191)
+stack: 40 bytes (558..597)
+effective memory: 232 / 4096 bytes
+

--- a/test/golden/generated/factorial/3.factorial_rec.risc-iv-32.result
+++ b/test/golden/generated/factorial/3.factorial_rec.risc-iv-32.result
@@ -4,9 +4,8 @@ numio[0x80]: [] >>> []
 numio[0x84]: [] >>> [720]
 ---
 # stats
-instructions: 104
 sections: 160 bytes
 code/data: 192 bytes (0..191)
+instructions: 104
 stack: 40 bytes (558..597)
-effective memory: 232 / 4096 bytes
 

--- a/test/golden/generated/factorial/3.factorial_rec.vliw-iv.result
+++ b/test/golden/generated/factorial/3.factorial_rec.vliw-iv.result
@@ -4,9 +4,8 @@ numio[0x80]: [] >>> []
 numio[0x84]: [] >>> [720]
 ---
 # stats
-instructions: 104
 sections: 426 bytes
 code/data: 674 bytes (0..673)
+instructions: 104
 stack: 40 bytes (1258..1297)
-effective memory: 714 / 4096 bytes
 

--- a/test/golden/generated/factorial/3.factorial_rec.vliw-iv.result
+++ b/test/golden/generated/factorial/3.factorial_rec.vliw-iv.result
@@ -1,0 +1,12 @@
+---
+# Check results
+numio[0x80]: [] >>> []
+numio[0x84]: [] >>> [720]
+---
+# stats
+instructions: 104
+sections: 426 bytes
+code/data: 674 bytes (0..673)
+stack: 40 bytes (1258..1297)
+effective memory: 714 / 4096 bytes
+

--- a/test/golden/generated/factorial/3.m68k.result
+++ b/test/golden/generated/factorial/3.m68k.result
@@ -2,3 +2,11 @@
 # Check results
 numio[0x80]: [] >>> []
 numio[0x84]: [] >>> [720]
+---
+# stats
+instructions: 37
+sections: 114 bytes
+code/data: 114 bytes (0..113)
+stack: 0 bytes (no push observed)
+effective memory: 114 / 4096 bytes
+

--- a/test/golden/generated/factorial/3.m68k.result
+++ b/test/golden/generated/factorial/3.m68k.result
@@ -4,9 +4,8 @@ numio[0x80]: [] >>> []
 numio[0x84]: [] >>> [720]
 ---
 # stats
-instructions: 37
 sections: 114 bytes
 code/data: 114 bytes (0..113)
+instructions: 37
 stack: 0 bytes (no push observed)
-effective memory: 114 / 4096 bytes
 

--- a/test/golden/generated/factorial/3.risc-iv-32.result
+++ b/test/golden/generated/factorial/3.risc-iv-32.result
@@ -2,3 +2,11 @@
 # Check results
 numio[0x80]: [] >>> []
 numio[0x84]: [] >>> [720]
+---
+# stats
+instructions: 48
+sections: 128 bytes
+code/data: 128 bytes (0..127)
+stack: 0 bytes (uninitialised)
+effective memory: 128 / 4096 bytes
+

--- a/test/golden/generated/factorial/3.risc-iv-32.result
+++ b/test/golden/generated/factorial/3.risc-iv-32.result
@@ -4,9 +4,8 @@ numio[0x80]: [] >>> []
 numio[0x84]: [] >>> [720]
 ---
 # stats
-instructions: 48
 sections: 128 bytes
 code/data: 128 bytes (0..127)
+instructions: 48
 stack: 0 bytes (uninitialised)
-effective memory: 128 / 4096 bytes
 

--- a/test/golden/generated/factorial/3.vliw-iv.result
+++ b/test/golden/generated/factorial/3.vliw-iv.result
@@ -2,3 +2,11 @@
 # Check results
 numio[0x80]: [] >>> []
 numio[0x84]: [] >>> [720]
+---
+# stats
+instructions: 48
+sections: 338 bytes
+code/data: 474 bytes (0..473)
+stack: 0 bytes (uninitialised)
+effective memory: 474 / 4096 bytes
+

--- a/test/golden/generated/factorial/3.vliw-iv.result
+++ b/test/golden/generated/factorial/3.vliw-iv.result
@@ -4,9 +4,8 @@ numio[0x80]: [] >>> []
 numio[0x84]: [] >>> [720]
 ---
 # stats
-instructions: 48
 sections: 338 bytes
 code/data: 474 bytes (0..473)
+instructions: 48
 stack: 0 bytes (uninitialised)
-effective memory: 474 / 4096 bytes
 

--- a/test/golden/generated/factorial/4.acc32.result
+++ b/test/golden/generated/factorial/4.acc32.result
@@ -4,8 +4,7 @@ numio[0x80]: [] >>> []
 numio[0x84]: [] >>> [5040]
 ---
 # stats
-instructions: 74
 sections: 105 bytes
 code/data: 105 bytes (0..104)
-effective memory: 105 / 4096 bytes
+instructions: 74
 

--- a/test/golden/generated/factorial/4.acc32.result
+++ b/test/golden/generated/factorial/4.acc32.result
@@ -2,3 +2,10 @@
 # Check results
 numio[0x80]: [] >>> []
 numio[0x84]: [] >>> [5040]
+---
+# stats
+instructions: 74
+sections: 105 bytes
+code/data: 105 bytes (0..104)
+effective memory: 105 / 4096 bytes
+

--- a/test/golden/generated/factorial/4.f32a.result
+++ b/test/golden/generated/factorial/4.f32a.result
@@ -2,3 +2,12 @@
 # Check results
 numio[0x80]: [] >>> []
 numio[0x84]: [] >>> [5040]
+---
+# stats
+instructions: 1241
+sections: 348 bytes
+code/data: 348 bytes (0..347)
+dstack depth: 5 (20 bytes)
+rstack depth: 3 (12 bytes)
+effective memory: 380 / 4096 bytes
+

--- a/test/golden/generated/factorial/4.f32a.result
+++ b/test/golden/generated/factorial/4.f32a.result
@@ -4,10 +4,9 @@ numio[0x80]: [] >>> []
 numio[0x84]: [] >>> [5040]
 ---
 # stats
-instructions: 1241
 sections: 348 bytes
 code/data: 348 bytes (0..347)
+instructions: 1241
 dstack depth: 5 (20 bytes)
 rstack depth: 3 (12 bytes)
-effective memory: 380 / 4096 bytes
 

--- a/test/golden/generated/factorial/4.factorial_rec.risc-iv-32.result
+++ b/test/golden/generated/factorial/4.factorial_rec.risc-iv-32.result
@@ -4,9 +4,8 @@ numio[0x80]: [] >>> []
 numio[0x84]: [] >>> [5040]
 ---
 # stats
-instructions: 121
 sections: 160 bytes
 code/data: 192 bytes (0..191)
+instructions: 121
 stack: 48 bytes (550..597)
-effective memory: 240 / 4096 bytes
 

--- a/test/golden/generated/factorial/4.factorial_rec.risc-iv-32.result
+++ b/test/golden/generated/factorial/4.factorial_rec.risc-iv-32.result
@@ -1,0 +1,12 @@
+---
+# Check results
+numio[0x80]: [] >>> []
+numio[0x84]: [] >>> [5040]
+---
+# stats
+instructions: 121
+sections: 160 bytes
+code/data: 192 bytes (0..191)
+stack: 48 bytes (550..597)
+effective memory: 240 / 4096 bytes
+

--- a/test/golden/generated/factorial/4.factorial_rec.vliw-iv.result
+++ b/test/golden/generated/factorial/4.factorial_rec.vliw-iv.result
@@ -1,0 +1,12 @@
+---
+# Check results
+numio[0x80]: [] >>> []
+numio[0x84]: [] >>> [5040]
+---
+# stats
+instructions: 121
+sections: 426 bytes
+code/data: 674 bytes (0..673)
+stack: 48 bytes (1250..1297)
+effective memory: 722 / 4096 bytes
+

--- a/test/golden/generated/factorial/4.factorial_rec.vliw-iv.result
+++ b/test/golden/generated/factorial/4.factorial_rec.vliw-iv.result
@@ -4,9 +4,8 @@ numio[0x80]: [] >>> []
 numio[0x84]: [] >>> [5040]
 ---
 # stats
-instructions: 121
 sections: 426 bytes
 code/data: 674 bytes (0..673)
+instructions: 121
 stack: 48 bytes (1250..1297)
-effective memory: 722 / 4096 bytes
 

--- a/test/golden/generated/factorial/4.m68k.result
+++ b/test/golden/generated/factorial/4.m68k.result
@@ -4,9 +4,8 @@ numio[0x80]: [] >>> []
 numio[0x84]: [] >>> [5040]
 ---
 # stats
-instructions: 42
 sections: 114 bytes
 code/data: 114 bytes (0..113)
+instructions: 42
 stack: 0 bytes (no push observed)
-effective memory: 114 / 4096 bytes
 

--- a/test/golden/generated/factorial/4.m68k.result
+++ b/test/golden/generated/factorial/4.m68k.result
@@ -2,3 +2,11 @@
 # Check results
 numio[0x80]: [] >>> []
 numio[0x84]: [] >>> [5040]
+---
+# stats
+instructions: 42
+sections: 114 bytes
+code/data: 114 bytes (0..113)
+stack: 0 bytes (no push observed)
+effective memory: 114 / 4096 bytes
+

--- a/test/golden/generated/factorial/4.risc-iv-32.result
+++ b/test/golden/generated/factorial/4.risc-iv-32.result
@@ -2,3 +2,11 @@
 # Check results
 numio[0x80]: [] >>> []
 numio[0x84]: [] >>> [5040]
+---
+# stats
+instructions: 54
+sections: 128 bytes
+code/data: 128 bytes (0..127)
+stack: 0 bytes (uninitialised)
+effective memory: 128 / 4096 bytes
+

--- a/test/golden/generated/factorial/4.risc-iv-32.result
+++ b/test/golden/generated/factorial/4.risc-iv-32.result
@@ -4,9 +4,8 @@ numio[0x80]: [] >>> []
 numio[0x84]: [] >>> [5040]
 ---
 # stats
-instructions: 54
 sections: 128 bytes
 code/data: 128 bytes (0..127)
+instructions: 54
 stack: 0 bytes (uninitialised)
-effective memory: 128 / 4096 bytes
 

--- a/test/golden/generated/factorial/4.vliw-iv.result
+++ b/test/golden/generated/factorial/4.vliw-iv.result
@@ -2,3 +2,11 @@
 # Check results
 numio[0x80]: [] >>> []
 numio[0x84]: [] >>> [5040]
+---
+# stats
+instructions: 54
+sections: 338 bytes
+code/data: 474 bytes (0..473)
+stack: 0 bytes (uninitialised)
+effective memory: 474 / 4096 bytes
+

--- a/test/golden/generated/factorial/4.vliw-iv.result
+++ b/test/golden/generated/factorial/4.vliw-iv.result
@@ -4,9 +4,8 @@ numio[0x80]: [] >>> []
 numio[0x84]: [] >>> [5040]
 ---
 # stats
-instructions: 54
 sections: 338 bytes
 code/data: 474 bytes (0..473)
+instructions: 54
 stack: 0 bytes (uninitialised)
-effective memory: 474 / 4096 bytes
 

--- a/test/golden/generated/factorial/5.acc32.result
+++ b/test/golden/generated/factorial/5.acc32.result
@@ -4,8 +4,7 @@ numio[0x80]: [] >>> []
 numio[0x84]: [] >>> [40320]
 ---
 # stats
-instructions: 83
 sections: 105 bytes
 code/data: 105 bytes (0..104)
-effective memory: 105 / 4096 bytes
+instructions: 83
 

--- a/test/golden/generated/factorial/5.acc32.result
+++ b/test/golden/generated/factorial/5.acc32.result
@@ -2,3 +2,10 @@
 # Check results
 numio[0x80]: [] >>> []
 numio[0x84]: [] >>> [40320]
+---
+# stats
+instructions: 83
+sections: 105 bytes
+code/data: 105 bytes (0..104)
+effective memory: 105 / 4096 bytes
+

--- a/test/golden/generated/factorial/5.f32a.result
+++ b/test/golden/generated/factorial/5.f32a.result
@@ -2,3 +2,12 @@
 # Check results
 numio[0x80]: [] >>> []
 numio[0x84]: [] >>> [40320]
+---
+# stats
+instructions: 1415
+sections: 348 bytes
+code/data: 348 bytes (0..347)
+dstack depth: 5 (20 bytes)
+rstack depth: 3 (12 bytes)
+effective memory: 380 / 4096 bytes
+

--- a/test/golden/generated/factorial/5.f32a.result
+++ b/test/golden/generated/factorial/5.f32a.result
@@ -4,10 +4,9 @@ numio[0x80]: [] >>> []
 numio[0x84]: [] >>> [40320]
 ---
 # stats
-instructions: 1415
 sections: 348 bytes
 code/data: 348 bytes (0..347)
+instructions: 1415
 dstack depth: 5 (20 bytes)
 rstack depth: 3 (12 bytes)
-effective memory: 380 / 4096 bytes
 

--- a/test/golden/generated/factorial/5.factorial_rec.risc-iv-32.result
+++ b/test/golden/generated/factorial/5.factorial_rec.risc-iv-32.result
@@ -1,0 +1,12 @@
+---
+# Check results
+numio[0x80]: [] >>> []
+numio[0x84]: [] >>> [40320]
+---
+# stats
+instructions: 138
+sections: 160 bytes
+code/data: 192 bytes (0..191)
+stack: 56 bytes (542..597)
+effective memory: 248 / 4096 bytes
+

--- a/test/golden/generated/factorial/5.factorial_rec.risc-iv-32.result
+++ b/test/golden/generated/factorial/5.factorial_rec.risc-iv-32.result
@@ -4,9 +4,8 @@ numio[0x80]: [] >>> []
 numio[0x84]: [] >>> [40320]
 ---
 # stats
-instructions: 138
 sections: 160 bytes
 code/data: 192 bytes (0..191)
+instructions: 138
 stack: 56 bytes (542..597)
-effective memory: 248 / 4096 bytes
 

--- a/test/golden/generated/factorial/5.factorial_rec.vliw-iv.result
+++ b/test/golden/generated/factorial/5.factorial_rec.vliw-iv.result
@@ -4,9 +4,8 @@ numio[0x80]: [] >>> []
 numio[0x84]: [] >>> [40320]
 ---
 # stats
-instructions: 138
 sections: 426 bytes
 code/data: 674 bytes (0..673)
+instructions: 138
 stack: 56 bytes (1242..1297)
-effective memory: 730 / 4096 bytes
 

--- a/test/golden/generated/factorial/5.factorial_rec.vliw-iv.result
+++ b/test/golden/generated/factorial/5.factorial_rec.vliw-iv.result
@@ -1,0 +1,12 @@
+---
+# Check results
+numio[0x80]: [] >>> []
+numio[0x84]: [] >>> [40320]
+---
+# stats
+instructions: 138
+sections: 426 bytes
+code/data: 674 bytes (0..673)
+stack: 56 bytes (1242..1297)
+effective memory: 730 / 4096 bytes
+

--- a/test/golden/generated/factorial/5.m68k.result
+++ b/test/golden/generated/factorial/5.m68k.result
@@ -4,9 +4,8 @@ numio[0x80]: [] >>> []
 numio[0x84]: [] >>> [40320]
 ---
 # stats
-instructions: 47
 sections: 114 bytes
 code/data: 114 bytes (0..113)
+instructions: 47
 stack: 0 bytes (no push observed)
-effective memory: 114 / 4096 bytes
 

--- a/test/golden/generated/factorial/5.m68k.result
+++ b/test/golden/generated/factorial/5.m68k.result
@@ -2,3 +2,11 @@
 # Check results
 numio[0x80]: [] >>> []
 numio[0x84]: [] >>> [40320]
+---
+# stats
+instructions: 47
+sections: 114 bytes
+code/data: 114 bytes (0..113)
+stack: 0 bytes (no push observed)
+effective memory: 114 / 4096 bytes
+

--- a/test/golden/generated/factorial/5.risc-iv-32.result
+++ b/test/golden/generated/factorial/5.risc-iv-32.result
@@ -4,9 +4,8 @@ numio[0x80]: [] >>> []
 numio[0x84]: [] >>> [40320]
 ---
 # stats
-instructions: 60
 sections: 128 bytes
 code/data: 128 bytes (0..127)
+instructions: 60
 stack: 0 bytes (uninitialised)
-effective memory: 128 / 4096 bytes
 

--- a/test/golden/generated/factorial/5.risc-iv-32.result
+++ b/test/golden/generated/factorial/5.risc-iv-32.result
@@ -2,3 +2,11 @@
 # Check results
 numio[0x80]: [] >>> []
 numio[0x84]: [] >>> [40320]
+---
+# stats
+instructions: 60
+sections: 128 bytes
+code/data: 128 bytes (0..127)
+stack: 0 bytes (uninitialised)
+effective memory: 128 / 4096 bytes
+

--- a/test/golden/generated/factorial/5.vliw-iv.result
+++ b/test/golden/generated/factorial/5.vliw-iv.result
@@ -2,3 +2,11 @@
 # Check results
 numio[0x80]: [] >>> []
 numio[0x84]: [] >>> [40320]
+---
+# stats
+instructions: 60
+sections: 338 bytes
+code/data: 474 bytes (0..473)
+stack: 0 bytes (uninitialised)
+effective memory: 474 / 4096 bytes
+

--- a/test/golden/generated/factorial/5.vliw-iv.result
+++ b/test/golden/generated/factorial/5.vliw-iv.result
@@ -4,9 +4,8 @@ numio[0x80]: [] >>> []
 numio[0x84]: [] >>> [40320]
 ---
 # stats
-instructions: 60
 sections: 338 bytes
 code/data: 474 bytes (0..473)
+instructions: 60
 stack: 0 bytes (uninitialised)
-effective memory: 474 / 4096 bytes
 

--- a/test/golden/generated/factorial/6.acc32.result
+++ b/test/golden/generated/factorial/6.acc32.result
@@ -2,3 +2,10 @@
 # Check results
 numio[0x80]: [] >>> []
 numio[0x84]: [] >>> [362880]
+---
+# stats
+instructions: 92
+sections: 105 bytes
+code/data: 105 bytes (0..104)
+effective memory: 105 / 4096 bytes
+

--- a/test/golden/generated/factorial/6.acc32.result
+++ b/test/golden/generated/factorial/6.acc32.result
@@ -4,8 +4,7 @@ numio[0x80]: [] >>> []
 numio[0x84]: [] >>> [362880]
 ---
 # stats
-instructions: 92
 sections: 105 bytes
 code/data: 105 bytes (0..104)
-effective memory: 105 / 4096 bytes
+instructions: 92
 

--- a/test/golden/generated/factorial/6.f32a.result
+++ b/test/golden/generated/factorial/6.f32a.result
@@ -4,10 +4,9 @@ numio[0x80]: [] >>> []
 numio[0x84]: [] >>> [362880]
 ---
 # stats
-instructions: 1589
 sections: 348 bytes
 code/data: 348 bytes (0..347)
+instructions: 1589
 dstack depth: 5 (20 bytes)
 rstack depth: 3 (12 bytes)
-effective memory: 380 / 4096 bytes
 

--- a/test/golden/generated/factorial/6.f32a.result
+++ b/test/golden/generated/factorial/6.f32a.result
@@ -2,3 +2,12 @@
 # Check results
 numio[0x80]: [] >>> []
 numio[0x84]: [] >>> [362880]
+---
+# stats
+instructions: 1589
+sections: 348 bytes
+code/data: 348 bytes (0..347)
+dstack depth: 5 (20 bytes)
+rstack depth: 3 (12 bytes)
+effective memory: 380 / 4096 bytes
+

--- a/test/golden/generated/factorial/6.factorial_rec.risc-iv-32.result
+++ b/test/golden/generated/factorial/6.factorial_rec.risc-iv-32.result
@@ -4,9 +4,8 @@ numio[0x80]: [] >>> []
 numio[0x84]: [] >>> [362880]
 ---
 # stats
-instructions: 155
 sections: 160 bytes
 code/data: 192 bytes (0..191)
+instructions: 155
 stack: 64 bytes (534..597)
-effective memory: 256 / 4096 bytes
 

--- a/test/golden/generated/factorial/6.factorial_rec.risc-iv-32.result
+++ b/test/golden/generated/factorial/6.factorial_rec.risc-iv-32.result
@@ -1,0 +1,12 @@
+---
+# Check results
+numio[0x80]: [] >>> []
+numio[0x84]: [] >>> [362880]
+---
+# stats
+instructions: 155
+sections: 160 bytes
+code/data: 192 bytes (0..191)
+stack: 64 bytes (534..597)
+effective memory: 256 / 4096 bytes
+

--- a/test/golden/generated/factorial/6.factorial_rec.vliw-iv.result
+++ b/test/golden/generated/factorial/6.factorial_rec.vliw-iv.result
@@ -1,0 +1,12 @@
+---
+# Check results
+numio[0x80]: [] >>> []
+numio[0x84]: [] >>> [362880]
+---
+# stats
+instructions: 155
+sections: 426 bytes
+code/data: 674 bytes (0..673)
+stack: 64 bytes (1234..1297)
+effective memory: 738 / 4096 bytes
+

--- a/test/golden/generated/factorial/6.factorial_rec.vliw-iv.result
+++ b/test/golden/generated/factorial/6.factorial_rec.vliw-iv.result
@@ -4,9 +4,8 @@ numio[0x80]: [] >>> []
 numio[0x84]: [] >>> [362880]
 ---
 # stats
-instructions: 155
 sections: 426 bytes
 code/data: 674 bytes (0..673)
+instructions: 155
 stack: 64 bytes (1234..1297)
-effective memory: 738 / 4096 bytes
 

--- a/test/golden/generated/factorial/6.m68k.result
+++ b/test/golden/generated/factorial/6.m68k.result
@@ -2,3 +2,11 @@
 # Check results
 numio[0x80]: [] >>> []
 numio[0x84]: [] >>> [362880]
+---
+# stats
+instructions: 52
+sections: 114 bytes
+code/data: 114 bytes (0..113)
+stack: 0 bytes (no push observed)
+effective memory: 114 / 4096 bytes
+

--- a/test/golden/generated/factorial/6.m68k.result
+++ b/test/golden/generated/factorial/6.m68k.result
@@ -4,9 +4,8 @@ numio[0x80]: [] >>> []
 numio[0x84]: [] >>> [362880]
 ---
 # stats
-instructions: 52
 sections: 114 bytes
 code/data: 114 bytes (0..113)
+instructions: 52
 stack: 0 bytes (no push observed)
-effective memory: 114 / 4096 bytes
 

--- a/test/golden/generated/factorial/6.risc-iv-32.result
+++ b/test/golden/generated/factorial/6.risc-iv-32.result
@@ -4,9 +4,8 @@ numio[0x80]: [] >>> []
 numio[0x84]: [] >>> [362880]
 ---
 # stats
-instructions: 66
 sections: 128 bytes
 code/data: 128 bytes (0..127)
+instructions: 66
 stack: 0 bytes (uninitialised)
-effective memory: 128 / 4096 bytes
 

--- a/test/golden/generated/factorial/6.risc-iv-32.result
+++ b/test/golden/generated/factorial/6.risc-iv-32.result
@@ -2,3 +2,11 @@
 # Check results
 numio[0x80]: [] >>> []
 numio[0x84]: [] >>> [362880]
+---
+# stats
+instructions: 66
+sections: 128 bytes
+code/data: 128 bytes (0..127)
+stack: 0 bytes (uninitialised)
+effective memory: 128 / 4096 bytes
+

--- a/test/golden/generated/factorial/6.vliw-iv.result
+++ b/test/golden/generated/factorial/6.vliw-iv.result
@@ -2,3 +2,11 @@
 # Check results
 numio[0x80]: [] >>> []
 numio[0x84]: [] >>> [362880]
+---
+# stats
+instructions: 66
+sections: 338 bytes
+code/data: 474 bytes (0..473)
+stack: 0 bytes (uninitialised)
+effective memory: 474 / 4096 bytes
+

--- a/test/golden/generated/factorial/6.vliw-iv.result
+++ b/test/golden/generated/factorial/6.vliw-iv.result
@@ -4,9 +4,8 @@ numio[0x80]: [] >>> []
 numio[0x84]: [] >>> [362880]
 ---
 # stats
-instructions: 66
 sections: 338 bytes
 code/data: 474 bytes (0..473)
+instructions: 66
 stack: 0 bytes (uninitialised)
-effective memory: 474 / 4096 bytes
 

--- a/test/golden/generated/factorial/7.acc32.result
+++ b/test/golden/generated/factorial/7.acc32.result
@@ -2,3 +2,10 @@
 # Check results
 numio[0x80]: [] >>> []
 numio[0x84]: [] >>> [479001600]
+---
+# stats
+instructions: 119
+sections: 105 bytes
+code/data: 105 bytes (0..104)
+effective memory: 105 / 4096 bytes
+

--- a/test/golden/generated/factorial/7.acc32.result
+++ b/test/golden/generated/factorial/7.acc32.result
@@ -4,8 +4,7 @@ numio[0x80]: [] >>> []
 numio[0x84]: [] >>> [479001600]
 ---
 # stats
-instructions: 119
 sections: 105 bytes
 code/data: 105 bytes (0..104)
-effective memory: 105 / 4096 bytes
+instructions: 119
 

--- a/test/golden/generated/factorial/7.f32a.result
+++ b/test/golden/generated/factorial/7.f32a.result
@@ -4,10 +4,9 @@ numio[0x80]: [] >>> []
 numio[0x84]: [] >>> [479001600]
 ---
 # stats
-instructions: 2111
 sections: 348 bytes
 code/data: 348 bytes (0..347)
+instructions: 2111
 dstack depth: 5 (20 bytes)
 rstack depth: 3 (12 bytes)
-effective memory: 380 / 4096 bytes
 

--- a/test/golden/generated/factorial/7.f32a.result
+++ b/test/golden/generated/factorial/7.f32a.result
@@ -2,3 +2,12 @@
 # Check results
 numio[0x80]: [] >>> []
 numio[0x84]: [] >>> [479001600]
+---
+# stats
+instructions: 2111
+sections: 348 bytes
+code/data: 348 bytes (0..347)
+dstack depth: 5 (20 bytes)
+rstack depth: 3 (12 bytes)
+effective memory: 380 / 4096 bytes
+

--- a/test/golden/generated/factorial/7.factorial_rec.risc-iv-32.result
+++ b/test/golden/generated/factorial/7.factorial_rec.risc-iv-32.result
@@ -1,0 +1,12 @@
+---
+# Check results
+numio[0x80]: [] >>> []
+numio[0x84]: [] >>> [479001600]
+---
+# stats
+instructions: 206
+sections: 160 bytes
+code/data: 192 bytes (0..191)
+stack: 88 bytes (510..597)
+effective memory: 280 / 4096 bytes
+

--- a/test/golden/generated/factorial/7.factorial_rec.risc-iv-32.result
+++ b/test/golden/generated/factorial/7.factorial_rec.risc-iv-32.result
@@ -4,9 +4,8 @@ numio[0x80]: [] >>> []
 numio[0x84]: [] >>> [479001600]
 ---
 # stats
-instructions: 206
 sections: 160 bytes
 code/data: 192 bytes (0..191)
+instructions: 206
 stack: 88 bytes (510..597)
-effective memory: 280 / 4096 bytes
 

--- a/test/golden/generated/factorial/7.factorial_rec.vliw-iv.result
+++ b/test/golden/generated/factorial/7.factorial_rec.vliw-iv.result
@@ -1,0 +1,12 @@
+---
+# Check results
+numio[0x80]: [] >>> []
+numio[0x84]: [] >>> [479001600]
+---
+# stats
+instructions: 206
+sections: 426 bytes
+code/data: 674 bytes (0..673)
+stack: 88 bytes (1210..1297)
+effective memory: 762 / 4096 bytes
+

--- a/test/golden/generated/factorial/7.factorial_rec.vliw-iv.result
+++ b/test/golden/generated/factorial/7.factorial_rec.vliw-iv.result
@@ -4,9 +4,8 @@ numio[0x80]: [] >>> []
 numio[0x84]: [] >>> [479001600]
 ---
 # stats
-instructions: 206
 sections: 426 bytes
 code/data: 674 bytes (0..673)
+instructions: 206
 stack: 88 bytes (1210..1297)
-effective memory: 762 / 4096 bytes
 

--- a/test/golden/generated/factorial/7.m68k.result
+++ b/test/golden/generated/factorial/7.m68k.result
@@ -2,3 +2,11 @@
 # Check results
 numio[0x80]: [] >>> []
 numio[0x84]: [] >>> [479001600]
+---
+# stats
+instructions: 67
+sections: 114 bytes
+code/data: 114 bytes (0..113)
+stack: 0 bytes (no push observed)
+effective memory: 114 / 4096 bytes
+

--- a/test/golden/generated/factorial/7.m68k.result
+++ b/test/golden/generated/factorial/7.m68k.result
@@ -4,9 +4,8 @@ numio[0x80]: [] >>> []
 numio[0x84]: [] >>> [479001600]
 ---
 # stats
-instructions: 67
 sections: 114 bytes
 code/data: 114 bytes (0..113)
+instructions: 67
 stack: 0 bytes (no push observed)
-effective memory: 114 / 4096 bytes
 

--- a/test/golden/generated/factorial/7.risc-iv-32.result
+++ b/test/golden/generated/factorial/7.risc-iv-32.result
@@ -4,9 +4,8 @@ numio[0x80]: [] >>> []
 numio[0x84]: [] >>> [479001600]
 ---
 # stats
-instructions: 84
 sections: 128 bytes
 code/data: 128 bytes (0..127)
+instructions: 84
 stack: 0 bytes (uninitialised)
-effective memory: 128 / 4096 bytes
 

--- a/test/golden/generated/factorial/7.risc-iv-32.result
+++ b/test/golden/generated/factorial/7.risc-iv-32.result
@@ -2,3 +2,11 @@
 # Check results
 numio[0x80]: [] >>> []
 numio[0x84]: [] >>> [479001600]
+---
+# stats
+instructions: 84
+sections: 128 bytes
+code/data: 128 bytes (0..127)
+stack: 0 bytes (uninitialised)
+effective memory: 128 / 4096 bytes
+

--- a/test/golden/generated/factorial/7.vliw-iv.result
+++ b/test/golden/generated/factorial/7.vliw-iv.result
@@ -4,9 +4,8 @@ numio[0x80]: [] >>> []
 numio[0x84]: [] >>> [479001600]
 ---
 # stats
-instructions: 84
 sections: 338 bytes
 code/data: 474 bytes (0..473)
+instructions: 84
 stack: 0 bytes (uninitialised)
-effective memory: 474 / 4096 bytes
 

--- a/test/golden/generated/factorial/7.vliw-iv.result
+++ b/test/golden/generated/factorial/7.vliw-iv.result
@@ -2,3 +2,11 @@
 # Check results
 numio[0x80]: [] >>> []
 numio[0x84]: [] >>> [479001600]
+---
+# stats
+instructions: 84
+sections: 338 bytes
+code/data: 474 bytes (0..473)
+stack: 0 bytes (uninitialised)
+effective memory: 474 / 4096 bytes
+

--- a/test/golden/generated/factorial/8.acc32.result
+++ b/test/golden/generated/factorial/8.acc32.result
@@ -4,8 +4,7 @@ numio[0x80]: [] >>> []
 numio[0x84]: [] >>> [-858993460]
 ---
 # stats
-instructions: 104
 sections: 105 bytes
 code/data: 105 bytes (0..104)
-effective memory: 105 / 4096 bytes
+instructions: 104
 

--- a/test/golden/generated/factorial/8.acc32.result
+++ b/test/golden/generated/factorial/8.acc32.result
@@ -2,3 +2,10 @@
 # Check results
 numio[0x80]: [] >>> []
 numio[0x84]: [] >>> [-858993460]
+---
+# stats
+instructions: 104
+sections: 105 bytes
+code/data: 105 bytes (0..104)
+effective memory: 105 / 4096 bytes
+

--- a/test/golden/generated/factorial/8.f32a.result
+++ b/test/golden/generated/factorial/8.f32a.result
@@ -2,3 +2,12 @@
 # Check results
 numio[0x80]: [] >>> []
 numio[0x84]: [] >>> [-858993460]
+---
+# stats
+instructions: 2106
+sections: 348 bytes
+code/data: 348 bytes (0..347)
+dstack depth: 5 (20 bytes)
+rstack depth: 3 (12 bytes)
+effective memory: 380 / 4096 bytes
+

--- a/test/golden/generated/factorial/8.f32a.result
+++ b/test/golden/generated/factorial/8.f32a.result
@@ -4,10 +4,9 @@ numio[0x80]: [] >>> []
 numio[0x84]: [] >>> [-858993460]
 ---
 # stats
-instructions: 2106
 sections: 348 bytes
 code/data: 348 bytes (0..347)
+instructions: 2106
 dstack depth: 5 (20 bytes)
 rstack depth: 3 (12 bytes)
-effective memory: 380 / 4096 bytes
 

--- a/test/golden/generated/factorial/8.factorial_rec.risc-iv-32.result
+++ b/test/golden/generated/factorial/8.factorial_rec.risc-iv-32.result
@@ -1,0 +1,12 @@
+---
+# Check results
+numio[0x80]: [] >>> []
+numio[0x84]: [] >>> [-858993460]
+---
+# stats
+instructions: 225
+sections: 160 bytes
+code/data: 192 bytes (0..191)
+stack: 96 bytes (502..597)
+effective memory: 288 / 4096 bytes
+

--- a/test/golden/generated/factorial/8.factorial_rec.risc-iv-32.result
+++ b/test/golden/generated/factorial/8.factorial_rec.risc-iv-32.result
@@ -4,9 +4,8 @@ numio[0x80]: [] >>> []
 numio[0x84]: [] >>> [-858993460]
 ---
 # stats
-instructions: 225
 sections: 160 bytes
 code/data: 192 bytes (0..191)
+instructions: 225
 stack: 96 bytes (502..597)
-effective memory: 288 / 4096 bytes
 

--- a/test/golden/generated/factorial/8.factorial_rec.vliw-iv.result
+++ b/test/golden/generated/factorial/8.factorial_rec.vliw-iv.result
@@ -1,0 +1,12 @@
+---
+# Check results
+numio[0x80]: [] >>> []
+numio[0x84]: [] >>> [-858993460]
+---
+# stats
+instructions: 225
+sections: 426 bytes
+code/data: 674 bytes (0..673)
+stack: 96 bytes (1202..1297)
+effective memory: 770 / 4096 bytes
+

--- a/test/golden/generated/factorial/8.factorial_rec.vliw-iv.result
+++ b/test/golden/generated/factorial/8.factorial_rec.vliw-iv.result
@@ -4,9 +4,8 @@ numio[0x80]: [] >>> []
 numio[0x84]: [] >>> [-858993460]
 ---
 # stats
-instructions: 225
 sections: 426 bytes
 code/data: 674 bytes (0..673)
+instructions: 225
 stack: 96 bytes (1202..1297)
-effective memory: 770 / 4096 bytes
 

--- a/test/golden/generated/factorial/8.m68k.result
+++ b/test/golden/generated/factorial/8.m68k.result
@@ -2,3 +2,11 @@
 # Check results
 numio[0x80]: [] >>> []
 numio[0x84]: [] >>> [-858993460]
+---
+# stats
+instructions: 61
+sections: 114 bytes
+code/data: 114 bytes (0..113)
+stack: 0 bytes (no push observed)
+effective memory: 114 / 4096 bytes
+

--- a/test/golden/generated/factorial/8.m68k.result
+++ b/test/golden/generated/factorial/8.m68k.result
@@ -4,9 +4,8 @@ numio[0x80]: [] >>> []
 numio[0x84]: [] >>> [-858993460]
 ---
 # stats
-instructions: 61
 sections: 114 bytes
 code/data: 114 bytes (0..113)
+instructions: 61
 stack: 0 bytes (no push observed)
-effective memory: 114 / 4096 bytes
 

--- a/test/golden/generated/factorial/8.risc-iv-32.result
+++ b/test/golden/generated/factorial/8.risc-iv-32.result
@@ -2,3 +2,11 @@
 # Check results
 numio[0x80]: [] >>> []
 numio[0x84]: [] >>> [-858993460]
+---
+# stats
+instructions: 83
+sections: 128 bytes
+code/data: 128 bytes (0..127)
+stack: 0 bytes (uninitialised)
+effective memory: 128 / 4096 bytes
+

--- a/test/golden/generated/factorial/8.risc-iv-32.result
+++ b/test/golden/generated/factorial/8.risc-iv-32.result
@@ -4,9 +4,8 @@ numio[0x80]: [] >>> []
 numio[0x84]: [] >>> [-858993460]
 ---
 # stats
-instructions: 83
 sections: 128 bytes
 code/data: 128 bytes (0..127)
+instructions: 83
 stack: 0 bytes (uninitialised)
-effective memory: 128 / 4096 bytes
 

--- a/test/golden/generated/factorial/8.vliw-iv.result
+++ b/test/golden/generated/factorial/8.vliw-iv.result
@@ -4,9 +4,8 @@ numio[0x80]: [] >>> []
 numio[0x84]: [] >>> [-858993460]
 ---
 # stats
-instructions: 83
 sections: 338 bytes
 code/data: 474 bytes (0..473)
+instructions: 83
 stack: 0 bytes (uninitialised)
-effective memory: 474 / 4096 bytes
 

--- a/test/golden/generated/factorial/8.vliw-iv.result
+++ b/test/golden/generated/factorial/8.vliw-iv.result
@@ -2,3 +2,11 @@
 # Check results
 numio[0x80]: [] >>> []
 numio[0x84]: [] >>> [-858993460]
+---
+# stats
+instructions: 83
+sections: 338 bytes
+code/data: 474 bytes (0..473)
+stack: 0 bytes (uninitialised)
+effective memory: 474 / 4096 bytes
+

--- a/test/golden/generated/factorial/9.acc32.result
+++ b/test/golden/generated/factorial/9.acc32.result
@@ -2,3 +2,10 @@
 # Check results
 numio[0x80]: [] >>> []
 numio[0x84]: [] >>> [-858993460]
+---
+# stats
+instructions: 95
+sections: 105 bytes
+code/data: 105 bytes (0..104)
+effective memory: 105 / 4096 bytes
+

--- a/test/golden/generated/factorial/9.acc32.result
+++ b/test/golden/generated/factorial/9.acc32.result
@@ -4,8 +4,7 @@ numio[0x80]: [] >>> []
 numio[0x84]: [] >>> [-858993460]
 ---
 # stats
-instructions: 95
 sections: 105 bytes
 code/data: 105 bytes (0..104)
-effective memory: 105 / 4096 bytes
+instructions: 95
 

--- a/test/golden/generated/factorial/9.f32a.result
+++ b/test/golden/generated/factorial/9.f32a.result
@@ -4,10 +4,9 @@ numio[0x80]: [] >>> []
 numio[0x84]: [] >>> [-858993460]
 ---
 # stats
-instructions: 1932
 sections: 348 bytes
 code/data: 348 bytes (0..347)
+instructions: 1932
 dstack depth: 5 (20 bytes)
 rstack depth: 3 (12 bytes)
-effective memory: 380 / 4096 bytes
 

--- a/test/golden/generated/factorial/9.f32a.result
+++ b/test/golden/generated/factorial/9.f32a.result
@@ -2,3 +2,12 @@
 # Check results
 numio[0x80]: [] >>> []
 numio[0x84]: [] >>> [-858993460]
+---
+# stats
+instructions: 1932
+sections: 348 bytes
+code/data: 348 bytes (0..347)
+dstack depth: 5 (20 bytes)
+rstack depth: 3 (12 bytes)
+effective memory: 380 / 4096 bytes
+

--- a/test/golden/generated/factorial/9.factorial_rec.risc-iv-32.result
+++ b/test/golden/generated/factorial/9.factorial_rec.risc-iv-32.result
@@ -1,0 +1,12 @@
+---
+# Check results
+numio[0x80]: [] >>> []
+numio[0x84]: [] >>> [-858993460]
+---
+# stats
+instructions: 242
+sections: 160 bytes
+code/data: 192 bytes (0..191)
+stack: 104 bytes (494..597)
+effective memory: 296 / 4096 bytes
+

--- a/test/golden/generated/factorial/9.factorial_rec.risc-iv-32.result
+++ b/test/golden/generated/factorial/9.factorial_rec.risc-iv-32.result
@@ -4,9 +4,8 @@ numio[0x80]: [] >>> []
 numio[0x84]: [] >>> [-858993460]
 ---
 # stats
-instructions: 242
 sections: 160 bytes
 code/data: 192 bytes (0..191)
+instructions: 242
 stack: 104 bytes (494..597)
-effective memory: 296 / 4096 bytes
 

--- a/test/golden/generated/factorial/9.factorial_rec.vliw-iv.result
+++ b/test/golden/generated/factorial/9.factorial_rec.vliw-iv.result
@@ -1,0 +1,12 @@
+---
+# Check results
+numio[0x80]: [] >>> []
+numio[0x84]: [] >>> [-858993460]
+---
+# stats
+instructions: 242
+sections: 426 bytes
+code/data: 674 bytes (0..673)
+stack: 104 bytes (1194..1297)
+effective memory: 778 / 4096 bytes
+

--- a/test/golden/generated/factorial/9.factorial_rec.vliw-iv.result
+++ b/test/golden/generated/factorial/9.factorial_rec.vliw-iv.result
@@ -4,9 +4,8 @@ numio[0x80]: [] >>> []
 numio[0x84]: [] >>> [-858993460]
 ---
 # stats
-instructions: 242
 sections: 426 bytes
 code/data: 674 bytes (0..673)
+instructions: 242
 stack: 104 bytes (1194..1297)
-effective memory: 778 / 4096 bytes
 

--- a/test/golden/generated/factorial/9.m68k.result
+++ b/test/golden/generated/factorial/9.m68k.result
@@ -2,3 +2,11 @@
 # Check results
 numio[0x80]: [] >>> []
 numio[0x84]: [] >>> [-858993460]
+---
+# stats
+instructions: 56
+sections: 114 bytes
+code/data: 114 bytes (0..113)
+stack: 0 bytes (no push observed)
+effective memory: 114 / 4096 bytes
+

--- a/test/golden/generated/factorial/9.m68k.result
+++ b/test/golden/generated/factorial/9.m68k.result
@@ -4,9 +4,8 @@ numio[0x80]: [] >>> []
 numio[0x84]: [] >>> [-858993460]
 ---
 # stats
-instructions: 56
 sections: 114 bytes
 code/data: 114 bytes (0..113)
+instructions: 56
 stack: 0 bytes (no push observed)
-effective memory: 114 / 4096 bytes
 

--- a/test/golden/generated/factorial/9.risc-iv-32.result
+++ b/test/golden/generated/factorial/9.risc-iv-32.result
@@ -4,9 +4,8 @@ numio[0x80]: [] >>> []
 numio[0x84]: [] >>> [-858993460]
 ---
 # stats
-instructions: 77
 sections: 128 bytes
 code/data: 128 bytes (0..127)
+instructions: 77
 stack: 0 bytes (uninitialised)
-effective memory: 128 / 4096 bytes
 

--- a/test/golden/generated/factorial/9.risc-iv-32.result
+++ b/test/golden/generated/factorial/9.risc-iv-32.result
@@ -2,3 +2,11 @@
 # Check results
 numio[0x80]: [] >>> []
 numio[0x84]: [] >>> [-858993460]
+---
+# stats
+instructions: 77
+sections: 128 bytes
+code/data: 128 bytes (0..127)
+stack: 0 bytes (uninitialised)
+effective memory: 128 / 4096 bytes
+

--- a/test/golden/generated/factorial/9.vliw-iv.result
+++ b/test/golden/generated/factorial/9.vliw-iv.result
@@ -4,9 +4,8 @@ numio[0x80]: [] >>> []
 numio[0x84]: [] >>> [-858993460]
 ---
 # stats
-instructions: 77
 sections: 338 bytes
 code/data: 474 bytes (0..473)
+instructions: 77
 stack: 0 bytes (uninitialised)
-effective memory: 474 / 4096 bytes
 

--- a/test/golden/generated/factorial/9.vliw-iv.result
+++ b/test/golden/generated/factorial/9.vliw-iv.result
@@ -2,3 +2,11 @@
 # Check results
 numio[0x80]: [] >>> []
 numio[0x84]: [] >>> [-858993460]
+---
+# stats
+instructions: 77
+sections: 338 bytes
+code/data: 474 bytes (0..473)
+stack: 0 bytes (uninitialised)
+effective memory: 474 / 4096 bytes
+

--- a/test/golden/generated/get_put_char/1.acc32.result
+++ b/test/golden/generated/get_put_char/1.acc32.result
@@ -6,8 +6,7 @@ symio[0x80]: "" >>> ""
 symio[0x84]: "" >>> "A"
 ---
 # stats
-instructions: 11
 sections: 91 bytes
 code/data: 91 bytes (0..90)
-effective memory: 91 / 4096 bytes
+instructions: 11
 

--- a/test/golden/generated/get_put_char/1.acc32.result
+++ b/test/golden/generated/get_put_char/1.acc32.result
@@ -4,3 +4,10 @@ numio[0x80]: [] >>> []
 numio[0x84]: [] >>> [65]
 symio[0x80]: "" >>> ""
 symio[0x84]: "" >>> "A"
+---
+# stats
+instructions: 11
+sections: 91 bytes
+code/data: 91 bytes (0..90)
+effective memory: 91 / 4096 bytes
+

--- a/test/golden/generated/get_put_char/1.f32a.result
+++ b/test/golden/generated/get_put_char/1.f32a.result
@@ -6,10 +6,9 @@ symio[0x80]: "" >>> ""
 symio[0x84]: "" >>> "A"
 ---
 # stats
-instructions: 25
 sections: 78 bytes
 code/data: 78 bytes (0..77)
+instructions: 25
 dstack depth: 4 (16 bytes)
 rstack depth: 1 (4 bytes)
-effective memory: 98 / 4096 bytes
 

--- a/test/golden/generated/get_put_char/1.f32a.result
+++ b/test/golden/generated/get_put_char/1.f32a.result
@@ -4,3 +4,12 @@ numio[0x80]: [] >>> []
 numio[0x84]: [] >>> [65]
 symio[0x80]: "" >>> ""
 symio[0x84]: "" >>> "A"
+---
+# stats
+instructions: 25
+sections: 78 bytes
+code/data: 78 bytes (0..77)
+dstack depth: 4 (16 bytes)
+rstack depth: 1 (4 bytes)
+effective memory: 98 / 4096 bytes
+

--- a/test/golden/generated/get_put_char/1.m68k.result
+++ b/test/golden/generated/get_put_char/1.m68k.result
@@ -6,9 +6,8 @@ symio[0x80]: "" >>> ""
 symio[0x84]: "" >>> "A"
 ---
 # stats
-instructions: 13
 sections: 98 bytes
 code/data: 98 bytes (0..97)
+instructions: 13
 stack: 0 bytes (no push observed)
-effective memory: 98 / 4096 bytes
 

--- a/test/golden/generated/get_put_char/1.m68k.result
+++ b/test/golden/generated/get_put_char/1.m68k.result
@@ -4,3 +4,11 @@ numio[0x80]: [] >>> []
 numio[0x84]: [] >>> [65]
 symio[0x80]: "" >>> ""
 symio[0x84]: "" >>> "A"
+---
+# stats
+instructions: 13
+sections: 98 bytes
+code/data: 98 bytes (0..97)
+stack: 0 bytes (no push observed)
+effective memory: 98 / 4096 bytes
+

--- a/test/golden/generated/get_put_char/1.risc-iv-32.result
+++ b/test/golden/generated/get_put_char/1.risc-iv-32.result
@@ -4,3 +4,11 @@ numio[0x80]: [] >>> []
 numio[0x84]: [] >>> [65]
 symio[0x80]: "" >>> ""
 symio[0x84]: "" >>> "A"
+---
+# stats
+instructions: 13
+sections: 88 bytes
+code/data: 88 bytes (0..87)
+stack: 0 bytes (uninitialised)
+effective memory: 88 / 4096 bytes
+

--- a/test/golden/generated/get_put_char/1.risc-iv-32.result
+++ b/test/golden/generated/get_put_char/1.risc-iv-32.result
@@ -6,9 +6,8 @@ symio[0x80]: "" >>> ""
 symio[0x84]: "" >>> "A"
 ---
 # stats
-instructions: 13
 sections: 88 bytes
 code/data: 88 bytes (0..87)
+instructions: 13
 stack: 0 bytes (uninitialised)
-effective memory: 88 / 4096 bytes
 

--- a/test/golden/generated/get_put_char/1.vliw-iv.result
+++ b/test/golden/generated/get_put_char/1.vliw-iv.result
@@ -4,3 +4,11 @@ numio[0x80]: [] >>> []
 numio[0x84]: [] >>> [65]
 symio[0x80]: "" >>> ""
 symio[0x84]: "" >>> "A"
+---
+# stats
+instructions: 13
+sections: 228 bytes
+code/data: 476 bytes (0..475)
+stack: 0 bytes (uninitialised)
+effective memory: 476 / 4096 bytes
+

--- a/test/golden/generated/get_put_char/1.vliw-iv.result
+++ b/test/golden/generated/get_put_char/1.vliw-iv.result
@@ -6,9 +6,8 @@ symio[0x80]: "" >>> ""
 symio[0x84]: "" >>> "A"
 ---
 # stats
-instructions: 13
 sections: 228 bytes
 code/data: 476 bytes (0..475)
+instructions: 13
 stack: 0 bytes (uninitialised)
-effective memory: 476 / 4096 bytes
 

--- a/test/golden/generated/get_put_char/10.acc32.result
+++ b/test/golden/generated/get_put_char/10.acc32.result
@@ -6,8 +6,7 @@ symio[0x80]: "" >>> ""
 symio[0x84]: "" >>> "?"
 ---
 # stats
-instructions: 11
 sections: 91 bytes
 code/data: 91 bytes (0..90)
-effective memory: 91 / 4096 bytes
+instructions: 11
 

--- a/test/golden/generated/get_put_char/10.acc32.result
+++ b/test/golden/generated/get_put_char/10.acc32.result
@@ -4,3 +4,10 @@ numio[0x80]: [] >>> []
 numio[0x84]: [] >>> [-858993460]
 symio[0x80]: "" >>> ""
 symio[0x84]: "" >>> "?"
+---
+# stats
+instructions: 11
+sections: 91 bytes
+code/data: 91 bytes (0..90)
+effective memory: 91 / 4096 bytes
+

--- a/test/golden/generated/get_put_char/10.f32a.result
+++ b/test/golden/generated/get_put_char/10.f32a.result
@@ -4,3 +4,12 @@ numio[0x80]: [] >>> []
 numio[0x84]: [] >>> [-858993460]
 symio[0x80]: "" >>> ""
 symio[0x84]: "" >>> "?"
+---
+# stats
+instructions: 26
+sections: 78 bytes
+code/data: 78 bytes (0..77)
+dstack depth: 4 (16 bytes)
+rstack depth: 1 (4 bytes)
+effective memory: 98 / 4096 bytes
+

--- a/test/golden/generated/get_put_char/10.f32a.result
+++ b/test/golden/generated/get_put_char/10.f32a.result
@@ -6,10 +6,9 @@ symio[0x80]: "" >>> ""
 symio[0x84]: "" >>> "?"
 ---
 # stats
-instructions: 26
 sections: 78 bytes
 code/data: 78 bytes (0..77)
+instructions: 26
 dstack depth: 4 (16 bytes)
 rstack depth: 1 (4 bytes)
-effective memory: 98 / 4096 bytes
 

--- a/test/golden/generated/get_put_char/10.m68k.result
+++ b/test/golden/generated/get_put_char/10.m68k.result
@@ -4,3 +4,11 @@ numio[0x80]: [] >>> []
 numio[0x84]: [] >>> [-858993460]
 symio[0x80]: "" >>> ""
 symio[0x84]: "" >>> "?"
+---
+# stats
+instructions: 14
+sections: 98 bytes
+code/data: 98 bytes (0..97)
+stack: 0 bytes (no push observed)
+effective memory: 98 / 4096 bytes
+

--- a/test/golden/generated/get_put_char/10.m68k.result
+++ b/test/golden/generated/get_put_char/10.m68k.result
@@ -6,9 +6,8 @@ symio[0x80]: "" >>> ""
 symio[0x84]: "" >>> "?"
 ---
 # stats
-instructions: 14
 sections: 98 bytes
 code/data: 98 bytes (0..97)
+instructions: 14
 stack: 0 bytes (no push observed)
-effective memory: 98 / 4096 bytes
 

--- a/test/golden/generated/get_put_char/10.risc-iv-32.result
+++ b/test/golden/generated/get_put_char/10.risc-iv-32.result
@@ -4,3 +4,11 @@ numio[0x80]: [] >>> []
 numio[0x84]: [] >>> [-858993460]
 symio[0x80]: "" >>> ""
 symio[0x84]: "" >>> "?"
+---
+# stats
+instructions: 15
+sections: 88 bytes
+code/data: 88 bytes (0..87)
+stack: 0 bytes (uninitialised)
+effective memory: 88 / 4096 bytes
+

--- a/test/golden/generated/get_put_char/10.risc-iv-32.result
+++ b/test/golden/generated/get_put_char/10.risc-iv-32.result
@@ -6,9 +6,8 @@ symio[0x80]: "" >>> ""
 symio[0x84]: "" >>> "?"
 ---
 # stats
-instructions: 15
 sections: 88 bytes
 code/data: 88 bytes (0..87)
+instructions: 15
 stack: 0 bytes (uninitialised)
-effective memory: 88 / 4096 bytes
 

--- a/test/golden/generated/get_put_char/10.vliw-iv.result
+++ b/test/golden/generated/get_put_char/10.vliw-iv.result
@@ -4,3 +4,11 @@ numio[0x80]: [] >>> []
 numio[0x84]: [] >>> [-858993460]
 symio[0x80]: "" >>> ""
 symio[0x84]: "" >>> "?"
+---
+# stats
+instructions: 15
+sections: 228 bytes
+code/data: 476 bytes (0..475)
+stack: 0 bytes (uninitialised)
+effective memory: 476 / 4096 bytes
+

--- a/test/golden/generated/get_put_char/10.vliw-iv.result
+++ b/test/golden/generated/get_put_char/10.vliw-iv.result
@@ -6,9 +6,8 @@ symio[0x80]: "" >>> ""
 symio[0x84]: "" >>> "?"
 ---
 # stats
-instructions: 15
 sections: 228 bytes
 code/data: 476 bytes (0..475)
+instructions: 15
 stack: 0 bytes (uninitialised)
-effective memory: 476 / 4096 bytes
 

--- a/test/golden/generated/get_put_char/11.acc32.result
+++ b/test/golden/generated/get_put_char/11.acc32.result
@@ -4,3 +4,10 @@ numio[0x80]: [90] >>> []
 numio[0x84]: [] >>> [-1]
 symio[0x80]: "Z" >>> ""
 symio[0x84]: "" >>> "?"
+---
+# stats
+instructions: 8
+sections: 91 bytes
+code/data: 91 bytes (0..90)
+effective memory: 91 / 4096 bytes
+

--- a/test/golden/generated/get_put_char/11.acc32.result
+++ b/test/golden/generated/get_put_char/11.acc32.result
@@ -6,8 +6,7 @@ symio[0x80]: "Z" >>> ""
 symio[0x84]: "" >>> "?"
 ---
 # stats
-instructions: 8
 sections: 91 bytes
 code/data: 91 bytes (0..90)
-effective memory: 91 / 4096 bytes
+instructions: 8
 

--- a/test/golden/generated/get_put_char/11.f32a.result
+++ b/test/golden/generated/get_put_char/11.f32a.result
@@ -4,3 +4,12 @@ numio[0x80]: [90] >>> []
 numio[0x84]: [] >>> [-1]
 symio[0x80]: "Z" >>> ""
 symio[0x84]: "" >>> "?"
+---
+# stats
+instructions: 17
+sections: 78 bytes
+code/data: 78 bytes (0..77)
+dstack depth: 4 (16 bytes)
+rstack depth: 1 (4 bytes)
+effective memory: 98 / 4096 bytes
+

--- a/test/golden/generated/get_put_char/11.f32a.result
+++ b/test/golden/generated/get_put_char/11.f32a.result
@@ -6,10 +6,9 @@ symio[0x80]: "Z" >>> ""
 symio[0x84]: "" >>> "?"
 ---
 # stats
-instructions: 17
 sections: 78 bytes
 code/data: 78 bytes (0..77)
+instructions: 17
 dstack depth: 4 (16 bytes)
 rstack depth: 1 (4 bytes)
-effective memory: 98 / 4096 bytes
 

--- a/test/golden/generated/get_put_char/11.m68k.result
+++ b/test/golden/generated/get_put_char/11.m68k.result
@@ -6,9 +6,8 @@ symio[0x80]: "Z" >>> ""
 symio[0x84]: "" >>> "?"
 ---
 # stats
-instructions: 11
 sections: 98 bytes
 code/data: 98 bytes (0..97)
+instructions: 11
 stack: 0 bytes (no push observed)
-effective memory: 98 / 4096 bytes
 

--- a/test/golden/generated/get_put_char/11.m68k.result
+++ b/test/golden/generated/get_put_char/11.m68k.result
@@ -4,3 +4,11 @@ numio[0x80]: [90] >>> []
 numio[0x84]: [] >>> [-1]
 symio[0x80]: "Z" >>> ""
 symio[0x84]: "" >>> "?"
+---
+# stats
+instructions: 11
+sections: 98 bytes
+code/data: 98 bytes (0..97)
+stack: 0 bytes (no push observed)
+effective memory: 98 / 4096 bytes
+

--- a/test/golden/generated/get_put_char/11.risc-iv-32.result
+++ b/test/golden/generated/get_put_char/11.risc-iv-32.result
@@ -6,9 +6,8 @@ symio[0x80]: "Z" >>> ""
 symio[0x84]: "" >>> "?"
 ---
 # stats
-instructions: 12
 sections: 88 bytes
 code/data: 88 bytes (0..87)
+instructions: 12
 stack: 0 bytes (uninitialised)
-effective memory: 88 / 4096 bytes
 

--- a/test/golden/generated/get_put_char/11.risc-iv-32.result
+++ b/test/golden/generated/get_put_char/11.risc-iv-32.result
@@ -4,3 +4,11 @@ numio[0x80]: [90] >>> []
 numio[0x84]: [] >>> [-1]
 symio[0x80]: "Z" >>> ""
 symio[0x84]: "" >>> "?"
+---
+# stats
+instructions: 12
+sections: 88 bytes
+code/data: 88 bytes (0..87)
+stack: 0 bytes (uninitialised)
+effective memory: 88 / 4096 bytes
+

--- a/test/golden/generated/get_put_char/11.vliw-iv.result
+++ b/test/golden/generated/get_put_char/11.vliw-iv.result
@@ -6,9 +6,8 @@ symio[0x80]: "Z" >>> ""
 symio[0x84]: "" >>> "?"
 ---
 # stats
-instructions: 12
 sections: 228 bytes
 code/data: 476 bytes (0..475)
+instructions: 12
 stack: 0 bytes (uninitialised)
-effective memory: 476 / 4096 bytes
 

--- a/test/golden/generated/get_put_char/11.vliw-iv.result
+++ b/test/golden/generated/get_put_char/11.vliw-iv.result
@@ -4,3 +4,11 @@ numio[0x80]: [90] >>> []
 numio[0x84]: [] >>> [-1]
 symio[0x80]: "Z" >>> ""
 symio[0x84]: "" >>> "?"
+---
+# stats
+instructions: 12
+sections: 228 bytes
+code/data: 476 bytes (0..475)
+stack: 0 bytes (uninitialised)
+effective memory: 476 / 4096 bytes
+

--- a/test/golden/generated/get_put_char/12.acc32.result
+++ b/test/golden/generated/get_put_char/12.acc32.result
@@ -6,8 +6,7 @@ symio[0x80]: "Z" >>> ""
 symio[0x84]: "" >>> "?"
 ---
 # stats
-instructions: 11
 sections: 91 bytes
 code/data: 91 bytes (0..90)
-effective memory: 91 / 4096 bytes
+instructions: 11
 

--- a/test/golden/generated/get_put_char/12.acc32.result
+++ b/test/golden/generated/get_put_char/12.acc32.result
@@ -4,3 +4,10 @@ numio[0x80]: [90] >>> []
 numio[0x84]: [] >>> [-858993460]
 symio[0x80]: "Z" >>> ""
 symio[0x84]: "" >>> "?"
+---
+# stats
+instructions: 11
+sections: 91 bytes
+code/data: 91 bytes (0..90)
+effective memory: 91 / 4096 bytes
+

--- a/test/golden/generated/get_put_char/12.f32a.result
+++ b/test/golden/generated/get_put_char/12.f32a.result
@@ -6,10 +6,9 @@ symio[0x80]: "Z" >>> ""
 symio[0x84]: "" >>> "?"
 ---
 # stats
-instructions: 26
 sections: 78 bytes
 code/data: 78 bytes (0..77)
+instructions: 26
 dstack depth: 4 (16 bytes)
 rstack depth: 1 (4 bytes)
-effective memory: 98 / 4096 bytes
 

--- a/test/golden/generated/get_put_char/12.f32a.result
+++ b/test/golden/generated/get_put_char/12.f32a.result
@@ -4,3 +4,12 @@ numio[0x80]: [90] >>> []
 numio[0x84]: [] >>> [-858993460]
 symio[0x80]: "Z" >>> ""
 symio[0x84]: "" >>> "?"
+---
+# stats
+instructions: 26
+sections: 78 bytes
+code/data: 78 bytes (0..77)
+dstack depth: 4 (16 bytes)
+rstack depth: 1 (4 bytes)
+effective memory: 98 / 4096 bytes
+

--- a/test/golden/generated/get_put_char/12.m68k.result
+++ b/test/golden/generated/get_put_char/12.m68k.result
@@ -6,9 +6,8 @@ symio[0x80]: "Z" >>> ""
 symio[0x84]: "" >>> "?"
 ---
 # stats
-instructions: 14
 sections: 98 bytes
 code/data: 98 bytes (0..97)
+instructions: 14
 stack: 0 bytes (no push observed)
-effective memory: 98 / 4096 bytes
 

--- a/test/golden/generated/get_put_char/12.m68k.result
+++ b/test/golden/generated/get_put_char/12.m68k.result
@@ -4,3 +4,11 @@ numio[0x80]: [90] >>> []
 numio[0x84]: [] >>> [-858993460]
 symio[0x80]: "Z" >>> ""
 symio[0x84]: "" >>> "?"
+---
+# stats
+instructions: 14
+sections: 98 bytes
+code/data: 98 bytes (0..97)
+stack: 0 bytes (no push observed)
+effective memory: 98 / 4096 bytes
+

--- a/test/golden/generated/get_put_char/12.risc-iv-32.result
+++ b/test/golden/generated/get_put_char/12.risc-iv-32.result
@@ -4,3 +4,11 @@ numio[0x80]: [90] >>> []
 numio[0x84]: [] >>> [-858993460]
 symio[0x80]: "Z" >>> ""
 symio[0x84]: "" >>> "?"
+---
+# stats
+instructions: 15
+sections: 88 bytes
+code/data: 88 bytes (0..87)
+stack: 0 bytes (uninitialised)
+effective memory: 88 / 4096 bytes
+

--- a/test/golden/generated/get_put_char/12.risc-iv-32.result
+++ b/test/golden/generated/get_put_char/12.risc-iv-32.result
@@ -6,9 +6,8 @@ symio[0x80]: "Z" >>> ""
 symio[0x84]: "" >>> "?"
 ---
 # stats
-instructions: 15
 sections: 88 bytes
 code/data: 88 bytes (0..87)
+instructions: 15
 stack: 0 bytes (uninitialised)
-effective memory: 88 / 4096 bytes
 

--- a/test/golden/generated/get_put_char/12.vliw-iv.result
+++ b/test/golden/generated/get_put_char/12.vliw-iv.result
@@ -4,3 +4,11 @@ numio[0x80]: [90] >>> []
 numio[0x84]: [] >>> [-858993460]
 symio[0x80]: "Z" >>> ""
 symio[0x84]: "" >>> "?"
+---
+# stats
+instructions: 15
+sections: 228 bytes
+code/data: 476 bytes (0..475)
+stack: 0 bytes (uninitialised)
+effective memory: 476 / 4096 bytes
+

--- a/test/golden/generated/get_put_char/12.vliw-iv.result
+++ b/test/golden/generated/get_put_char/12.vliw-iv.result
@@ -6,9 +6,8 @@ symio[0x80]: "Z" >>> ""
 symio[0x84]: "" >>> "?"
 ---
 # stats
-instructions: 15
 sections: 228 bytes
 code/data: 476 bytes (0..475)
+instructions: 15
 stack: 0 bytes (uninitialised)
-effective memory: 476 / 4096 bytes
 

--- a/test/golden/generated/get_put_char/2.acc32.result
+++ b/test/golden/generated/get_put_char/2.acc32.result
@@ -4,3 +4,10 @@ numio[0x80]: [] >>> []
 numio[0x84]: [] >>> [66]
 symio[0x80]: "" >>> ""
 symio[0x84]: "" >>> "B"
+---
+# stats
+instructions: 11
+sections: 91 bytes
+code/data: 91 bytes (0..90)
+effective memory: 91 / 4096 bytes
+

--- a/test/golden/generated/get_put_char/2.acc32.result
+++ b/test/golden/generated/get_put_char/2.acc32.result
@@ -6,8 +6,7 @@ symio[0x80]: "" >>> ""
 symio[0x84]: "" >>> "B"
 ---
 # stats
-instructions: 11
 sections: 91 bytes
 code/data: 91 bytes (0..90)
-effective memory: 91 / 4096 bytes
+instructions: 11
 

--- a/test/golden/generated/get_put_char/2.f32a.result
+++ b/test/golden/generated/get_put_char/2.f32a.result
@@ -6,10 +6,9 @@ symio[0x80]: "" >>> ""
 symio[0x84]: "" >>> "B"
 ---
 # stats
-instructions: 25
 sections: 78 bytes
 code/data: 78 bytes (0..77)
+instructions: 25
 dstack depth: 4 (16 bytes)
 rstack depth: 1 (4 bytes)
-effective memory: 98 / 4096 bytes
 

--- a/test/golden/generated/get_put_char/2.f32a.result
+++ b/test/golden/generated/get_put_char/2.f32a.result
@@ -4,3 +4,12 @@ numio[0x80]: [] >>> []
 numio[0x84]: [] >>> [66]
 symio[0x80]: "" >>> ""
 symio[0x84]: "" >>> "B"
+---
+# stats
+instructions: 25
+sections: 78 bytes
+code/data: 78 bytes (0..77)
+dstack depth: 4 (16 bytes)
+rstack depth: 1 (4 bytes)
+effective memory: 98 / 4096 bytes
+

--- a/test/golden/generated/get_put_char/2.m68k.result
+++ b/test/golden/generated/get_put_char/2.m68k.result
@@ -6,9 +6,8 @@ symio[0x80]: "" >>> ""
 symio[0x84]: "" >>> "B"
 ---
 # stats
-instructions: 13
 sections: 98 bytes
 code/data: 98 bytes (0..97)
+instructions: 13
 stack: 0 bytes (no push observed)
-effective memory: 98 / 4096 bytes
 

--- a/test/golden/generated/get_put_char/2.m68k.result
+++ b/test/golden/generated/get_put_char/2.m68k.result
@@ -4,3 +4,11 @@ numio[0x80]: [] >>> []
 numio[0x84]: [] >>> [66]
 symio[0x80]: "" >>> ""
 symio[0x84]: "" >>> "B"
+---
+# stats
+instructions: 13
+sections: 98 bytes
+code/data: 98 bytes (0..97)
+stack: 0 bytes (no push observed)
+effective memory: 98 / 4096 bytes
+

--- a/test/golden/generated/get_put_char/2.risc-iv-32.result
+++ b/test/golden/generated/get_put_char/2.risc-iv-32.result
@@ -4,3 +4,11 @@ numio[0x80]: [] >>> []
 numio[0x84]: [] >>> [66]
 symio[0x80]: "" >>> ""
 symio[0x84]: "" >>> "B"
+---
+# stats
+instructions: 13
+sections: 88 bytes
+code/data: 88 bytes (0..87)
+stack: 0 bytes (uninitialised)
+effective memory: 88 / 4096 bytes
+

--- a/test/golden/generated/get_put_char/2.risc-iv-32.result
+++ b/test/golden/generated/get_put_char/2.risc-iv-32.result
@@ -6,9 +6,8 @@ symio[0x80]: "" >>> ""
 symio[0x84]: "" >>> "B"
 ---
 # stats
-instructions: 13
 sections: 88 bytes
 code/data: 88 bytes (0..87)
+instructions: 13
 stack: 0 bytes (uninitialised)
-effective memory: 88 / 4096 bytes
 

--- a/test/golden/generated/get_put_char/2.vliw-iv.result
+++ b/test/golden/generated/get_put_char/2.vliw-iv.result
@@ -6,9 +6,8 @@ symio[0x80]: "" >>> ""
 symio[0x84]: "" >>> "B"
 ---
 # stats
-instructions: 13
 sections: 228 bytes
 code/data: 476 bytes (0..475)
+instructions: 13
 stack: 0 bytes (uninitialised)
-effective memory: 476 / 4096 bytes
 

--- a/test/golden/generated/get_put_char/2.vliw-iv.result
+++ b/test/golden/generated/get_put_char/2.vliw-iv.result
@@ -4,3 +4,11 @@ numio[0x80]: [] >>> []
 numio[0x84]: [] >>> [66]
 symio[0x80]: "" >>> ""
 symio[0x84]: "" >>> "B"
+---
+# stats
+instructions: 13
+sections: 228 bytes
+code/data: 476 bytes (0..475)
+stack: 0 bytes (uninitialised)
+effective memory: 476 / 4096 bytes
+

--- a/test/golden/generated/get_put_char/3.acc32.result
+++ b/test/golden/generated/get_put_char/3.acc32.result
@@ -4,3 +4,10 @@ numio[0x80]: [] >>> []
 numio[0x84]: [] >>> [67]
 symio[0x80]: "" >>> ""
 symio[0x84]: "" >>> "C"
+---
+# stats
+instructions: 11
+sections: 91 bytes
+code/data: 91 bytes (0..90)
+effective memory: 91 / 4096 bytes
+

--- a/test/golden/generated/get_put_char/3.acc32.result
+++ b/test/golden/generated/get_put_char/3.acc32.result
@@ -6,8 +6,7 @@ symio[0x80]: "" >>> ""
 symio[0x84]: "" >>> "C"
 ---
 # stats
-instructions: 11
 sections: 91 bytes
 code/data: 91 bytes (0..90)
-effective memory: 91 / 4096 bytes
+instructions: 11
 

--- a/test/golden/generated/get_put_char/3.f32a.result
+++ b/test/golden/generated/get_put_char/3.f32a.result
@@ -6,10 +6,9 @@ symio[0x80]: "" >>> ""
 symio[0x84]: "" >>> "C"
 ---
 # stats
-instructions: 25
 sections: 78 bytes
 code/data: 78 bytes (0..77)
+instructions: 25
 dstack depth: 4 (16 bytes)
 rstack depth: 1 (4 bytes)
-effective memory: 98 / 4096 bytes
 

--- a/test/golden/generated/get_put_char/3.f32a.result
+++ b/test/golden/generated/get_put_char/3.f32a.result
@@ -4,3 +4,12 @@ numio[0x80]: [] >>> []
 numio[0x84]: [] >>> [67]
 symio[0x80]: "" >>> ""
 symio[0x84]: "" >>> "C"
+---
+# stats
+instructions: 25
+sections: 78 bytes
+code/data: 78 bytes (0..77)
+dstack depth: 4 (16 bytes)
+rstack depth: 1 (4 bytes)
+effective memory: 98 / 4096 bytes
+

--- a/test/golden/generated/get_put_char/3.m68k.result
+++ b/test/golden/generated/get_put_char/3.m68k.result
@@ -6,9 +6,8 @@ symio[0x80]: "" >>> ""
 symio[0x84]: "" >>> "C"
 ---
 # stats
-instructions: 13
 sections: 98 bytes
 code/data: 98 bytes (0..97)
+instructions: 13
 stack: 0 bytes (no push observed)
-effective memory: 98 / 4096 bytes
 

--- a/test/golden/generated/get_put_char/3.m68k.result
+++ b/test/golden/generated/get_put_char/3.m68k.result
@@ -4,3 +4,11 @@ numio[0x80]: [] >>> []
 numio[0x84]: [] >>> [67]
 symio[0x80]: "" >>> ""
 symio[0x84]: "" >>> "C"
+---
+# stats
+instructions: 13
+sections: 98 bytes
+code/data: 98 bytes (0..97)
+stack: 0 bytes (no push observed)
+effective memory: 98 / 4096 bytes
+

--- a/test/golden/generated/get_put_char/3.risc-iv-32.result
+++ b/test/golden/generated/get_put_char/3.risc-iv-32.result
@@ -6,9 +6,8 @@ symio[0x80]: "" >>> ""
 symio[0x84]: "" >>> "C"
 ---
 # stats
-instructions: 13
 sections: 88 bytes
 code/data: 88 bytes (0..87)
+instructions: 13
 stack: 0 bytes (uninitialised)
-effective memory: 88 / 4096 bytes
 

--- a/test/golden/generated/get_put_char/3.risc-iv-32.result
+++ b/test/golden/generated/get_put_char/3.risc-iv-32.result
@@ -4,3 +4,11 @@ numio[0x80]: [] >>> []
 numio[0x84]: [] >>> [67]
 symio[0x80]: "" >>> ""
 symio[0x84]: "" >>> "C"
+---
+# stats
+instructions: 13
+sections: 88 bytes
+code/data: 88 bytes (0..87)
+stack: 0 bytes (uninitialised)
+effective memory: 88 / 4096 bytes
+

--- a/test/golden/generated/get_put_char/3.vliw-iv.result
+++ b/test/golden/generated/get_put_char/3.vliw-iv.result
@@ -4,3 +4,11 @@ numio[0x80]: [] >>> []
 numio[0x84]: [] >>> [67]
 symio[0x80]: "" >>> ""
 symio[0x84]: "" >>> "C"
+---
+# stats
+instructions: 13
+sections: 228 bytes
+code/data: 476 bytes (0..475)
+stack: 0 bytes (uninitialised)
+effective memory: 476 / 4096 bytes
+

--- a/test/golden/generated/get_put_char/3.vliw-iv.result
+++ b/test/golden/generated/get_put_char/3.vliw-iv.result
@@ -6,9 +6,8 @@ symio[0x80]: "" >>> ""
 symio[0x84]: "" >>> "C"
 ---
 # stats
-instructions: 13
 sections: 228 bytes
 code/data: 476 bytes (0..475)
+instructions: 13
 stack: 0 bytes (uninitialised)
-effective memory: 476 / 4096 bytes
 

--- a/test/golden/generated/get_put_char/4.acc32.result
+++ b/test/golden/generated/get_put_char/4.acc32.result
@@ -6,8 +6,7 @@ symio[0x80]: "BCD" >>> ""
 symio[0x84]: "" >>> "A"
 ---
 # stats
-instructions: 11
 sections: 91 bytes
 code/data: 91 bytes (0..90)
-effective memory: 91 / 4096 bytes
+instructions: 11
 

--- a/test/golden/generated/get_put_char/4.acc32.result
+++ b/test/golden/generated/get_put_char/4.acc32.result
@@ -4,3 +4,10 @@ numio[0x80]: [66,67,68] >>> []
 numio[0x84]: [] >>> [65]
 symio[0x80]: "BCD" >>> ""
 symio[0x84]: "" >>> "A"
+---
+# stats
+instructions: 11
+sections: 91 bytes
+code/data: 91 bytes (0..90)
+effective memory: 91 / 4096 bytes
+

--- a/test/golden/generated/get_put_char/4.f32a.result
+++ b/test/golden/generated/get_put_char/4.f32a.result
@@ -6,10 +6,9 @@ symio[0x80]: "BCD" >>> ""
 symio[0x84]: "" >>> "A"
 ---
 # stats
-instructions: 25
 sections: 78 bytes
 code/data: 78 bytes (0..77)
+instructions: 25
 dstack depth: 4 (16 bytes)
 rstack depth: 1 (4 bytes)
-effective memory: 98 / 4096 bytes
 

--- a/test/golden/generated/get_put_char/4.f32a.result
+++ b/test/golden/generated/get_put_char/4.f32a.result
@@ -4,3 +4,12 @@ numio[0x80]: [66,67,68] >>> []
 numio[0x84]: [] >>> [65]
 symio[0x80]: "BCD" >>> ""
 symio[0x84]: "" >>> "A"
+---
+# stats
+instructions: 25
+sections: 78 bytes
+code/data: 78 bytes (0..77)
+dstack depth: 4 (16 bytes)
+rstack depth: 1 (4 bytes)
+effective memory: 98 / 4096 bytes
+

--- a/test/golden/generated/get_put_char/4.m68k.result
+++ b/test/golden/generated/get_put_char/4.m68k.result
@@ -4,3 +4,11 @@ numio[0x80]: [66,67,68] >>> []
 numio[0x84]: [] >>> [65]
 symio[0x80]: "BCD" >>> ""
 symio[0x84]: "" >>> "A"
+---
+# stats
+instructions: 13
+sections: 98 bytes
+code/data: 98 bytes (0..97)
+stack: 0 bytes (no push observed)
+effective memory: 98 / 4096 bytes
+

--- a/test/golden/generated/get_put_char/4.m68k.result
+++ b/test/golden/generated/get_put_char/4.m68k.result
@@ -6,9 +6,8 @@ symio[0x80]: "BCD" >>> ""
 symio[0x84]: "" >>> "A"
 ---
 # stats
-instructions: 13
 sections: 98 bytes
 code/data: 98 bytes (0..97)
+instructions: 13
 stack: 0 bytes (no push observed)
-effective memory: 98 / 4096 bytes
 

--- a/test/golden/generated/get_put_char/4.risc-iv-32.result
+++ b/test/golden/generated/get_put_char/4.risc-iv-32.result
@@ -4,3 +4,11 @@ numio[0x80]: [66,67,68] >>> []
 numio[0x84]: [] >>> [65]
 symio[0x80]: "BCD" >>> ""
 symio[0x84]: "" >>> "A"
+---
+# stats
+instructions: 13
+sections: 88 bytes
+code/data: 88 bytes (0..87)
+stack: 0 bytes (uninitialised)
+effective memory: 88 / 4096 bytes
+

--- a/test/golden/generated/get_put_char/4.risc-iv-32.result
+++ b/test/golden/generated/get_put_char/4.risc-iv-32.result
@@ -6,9 +6,8 @@ symio[0x80]: "BCD" >>> ""
 symio[0x84]: "" >>> "A"
 ---
 # stats
-instructions: 13
 sections: 88 bytes
 code/data: 88 bytes (0..87)
+instructions: 13
 stack: 0 bytes (uninitialised)
-effective memory: 88 / 4096 bytes
 

--- a/test/golden/generated/get_put_char/4.vliw-iv.result
+++ b/test/golden/generated/get_put_char/4.vliw-iv.result
@@ -6,9 +6,8 @@ symio[0x80]: "BCD" >>> ""
 symio[0x84]: "" >>> "A"
 ---
 # stats
-instructions: 13
 sections: 228 bytes
 code/data: 476 bytes (0..475)
+instructions: 13
 stack: 0 bytes (uninitialised)
-effective memory: 476 / 4096 bytes
 

--- a/test/golden/generated/get_put_char/4.vliw-iv.result
+++ b/test/golden/generated/get_put_char/4.vliw-iv.result
@@ -4,3 +4,11 @@ numio[0x80]: [66,67,68] >>> []
 numio[0x84]: [] >>> [65]
 symio[0x80]: "BCD" >>> ""
 symio[0x84]: "" >>> "A"
+---
+# stats
+instructions: 13
+sections: 228 bytes
+code/data: 476 bytes (0..475)
+stack: 0 bytes (uninitialised)
+effective memory: 476 / 4096 bytes
+

--- a/test/golden/generated/get_put_char/5.acc32.result
+++ b/test/golden/generated/get_put_char/5.acc32.result
@@ -6,8 +6,7 @@ symio[0x80]: "" >>> ""
 symio[0x84]: "" >>> "\0"
 ---
 # stats
-instructions: 11
 sections: 91 bytes
 code/data: 91 bytes (0..90)
-effective memory: 91 / 4096 bytes
+instructions: 11
 

--- a/test/golden/generated/get_put_char/5.acc32.result
+++ b/test/golden/generated/get_put_char/5.acc32.result
@@ -4,3 +4,10 @@ numio[0x80]: [] >>> []
 numio[0x84]: [] >>> [0]
 symio[0x80]: "" >>> ""
 symio[0x84]: "" >>> "\0"
+---
+# stats
+instructions: 11
+sections: 91 bytes
+code/data: 91 bytes (0..90)
+effective memory: 91 / 4096 bytes
+

--- a/test/golden/generated/get_put_char/5.f32a.result
+++ b/test/golden/generated/get_put_char/5.f32a.result
@@ -4,3 +4,12 @@ numio[0x80]: [] >>> []
 numio[0x84]: [] >>> [0]
 symio[0x80]: "" >>> ""
 symio[0x84]: "" >>> "\0"
+---
+# stats
+instructions: 25
+sections: 78 bytes
+code/data: 78 bytes (0..77)
+dstack depth: 4 (16 bytes)
+rstack depth: 1 (4 bytes)
+effective memory: 98 / 4096 bytes
+

--- a/test/golden/generated/get_put_char/5.f32a.result
+++ b/test/golden/generated/get_put_char/5.f32a.result
@@ -6,10 +6,9 @@ symio[0x80]: "" >>> ""
 symio[0x84]: "" >>> "\0"
 ---
 # stats
-instructions: 25
 sections: 78 bytes
 code/data: 78 bytes (0..77)
+instructions: 25
 dstack depth: 4 (16 bytes)
 rstack depth: 1 (4 bytes)
-effective memory: 98 / 4096 bytes
 

--- a/test/golden/generated/get_put_char/5.m68k.result
+++ b/test/golden/generated/get_put_char/5.m68k.result
@@ -6,9 +6,8 @@ symio[0x80]: "" >>> ""
 symio[0x84]: "" >>> "\0"
 ---
 # stats
-instructions: 13
 sections: 98 bytes
 code/data: 98 bytes (0..97)
+instructions: 13
 stack: 0 bytes (no push observed)
-effective memory: 98 / 4096 bytes
 

--- a/test/golden/generated/get_put_char/5.m68k.result
+++ b/test/golden/generated/get_put_char/5.m68k.result
@@ -4,3 +4,11 @@ numio[0x80]: [] >>> []
 numio[0x84]: [] >>> [0]
 symio[0x80]: "" >>> ""
 symio[0x84]: "" >>> "\0"
+---
+# stats
+instructions: 13
+sections: 98 bytes
+code/data: 98 bytes (0..97)
+stack: 0 bytes (no push observed)
+effective memory: 98 / 4096 bytes
+

--- a/test/golden/generated/get_put_char/5.risc-iv-32.result
+++ b/test/golden/generated/get_put_char/5.risc-iv-32.result
@@ -4,3 +4,11 @@ numio[0x80]: [] >>> []
 numio[0x84]: [] >>> [0]
 symio[0x80]: "" >>> ""
 symio[0x84]: "" >>> "\0"
+---
+# stats
+instructions: 13
+sections: 88 bytes
+code/data: 88 bytes (0..87)
+stack: 0 bytes (uninitialised)
+effective memory: 88 / 4096 bytes
+

--- a/test/golden/generated/get_put_char/5.risc-iv-32.result
+++ b/test/golden/generated/get_put_char/5.risc-iv-32.result
@@ -6,9 +6,8 @@ symio[0x80]: "" >>> ""
 symio[0x84]: "" >>> "\0"
 ---
 # stats
-instructions: 13
 sections: 88 bytes
 code/data: 88 bytes (0..87)
+instructions: 13
 stack: 0 bytes (uninitialised)
-effective memory: 88 / 4096 bytes
 

--- a/test/golden/generated/get_put_char/5.vliw-iv.result
+++ b/test/golden/generated/get_put_char/5.vliw-iv.result
@@ -6,9 +6,8 @@ symio[0x80]: "" >>> ""
 symio[0x84]: "" >>> "\0"
 ---
 # stats
-instructions: 13
 sections: 228 bytes
 code/data: 476 bytes (0..475)
+instructions: 13
 stack: 0 bytes (uninitialised)
-effective memory: 476 / 4096 bytes
 

--- a/test/golden/generated/get_put_char/5.vliw-iv.result
+++ b/test/golden/generated/get_put_char/5.vliw-iv.result
@@ -4,3 +4,11 @@ numio[0x80]: [] >>> []
 numio[0x84]: [] >>> [0]
 symio[0x80]: "" >>> ""
 symio[0x84]: "" >>> "\0"
+---
+# stats
+instructions: 13
+sections: 228 bytes
+code/data: 476 bytes (0..475)
+stack: 0 bytes (uninitialised)
+effective memory: 476 / 4096 bytes
+

--- a/test/golden/generated/get_put_char/6.acc32.result
+++ b/test/golden/generated/get_put_char/6.acc32.result
@@ -6,8 +6,7 @@ symio[0x80]: "" >>> ""
 symio[0x84]: "" >>> "\n"
 ---
 # stats
-instructions: 11
 sections: 91 bytes
 code/data: 91 bytes (0..90)
-effective memory: 91 / 4096 bytes
+instructions: 11
 

--- a/test/golden/generated/get_put_char/6.acc32.result
+++ b/test/golden/generated/get_put_char/6.acc32.result
@@ -4,3 +4,10 @@ numio[0x80]: [] >>> []
 numio[0x84]: [] >>> [10]
 symio[0x80]: "" >>> ""
 symio[0x84]: "" >>> "\n"
+---
+# stats
+instructions: 11
+sections: 91 bytes
+code/data: 91 bytes (0..90)
+effective memory: 91 / 4096 bytes
+

--- a/test/golden/generated/get_put_char/6.f32a.result
+++ b/test/golden/generated/get_put_char/6.f32a.result
@@ -4,3 +4,12 @@ numio[0x80]: [] >>> []
 numio[0x84]: [] >>> [10]
 symio[0x80]: "" >>> ""
 symio[0x84]: "" >>> "\n"
+---
+# stats
+instructions: 25
+sections: 78 bytes
+code/data: 78 bytes (0..77)
+dstack depth: 4 (16 bytes)
+rstack depth: 1 (4 bytes)
+effective memory: 98 / 4096 bytes
+

--- a/test/golden/generated/get_put_char/6.f32a.result
+++ b/test/golden/generated/get_put_char/6.f32a.result
@@ -6,10 +6,9 @@ symio[0x80]: "" >>> ""
 symio[0x84]: "" >>> "\n"
 ---
 # stats
-instructions: 25
 sections: 78 bytes
 code/data: 78 bytes (0..77)
+instructions: 25
 dstack depth: 4 (16 bytes)
 rstack depth: 1 (4 bytes)
-effective memory: 98 / 4096 bytes
 

--- a/test/golden/generated/get_put_char/6.m68k.result
+++ b/test/golden/generated/get_put_char/6.m68k.result
@@ -4,3 +4,11 @@ numio[0x80]: [] >>> []
 numio[0x84]: [] >>> [10]
 symio[0x80]: "" >>> ""
 symio[0x84]: "" >>> "\n"
+---
+# stats
+instructions: 13
+sections: 98 bytes
+code/data: 98 bytes (0..97)
+stack: 0 bytes (no push observed)
+effective memory: 98 / 4096 bytes
+

--- a/test/golden/generated/get_put_char/6.m68k.result
+++ b/test/golden/generated/get_put_char/6.m68k.result
@@ -6,9 +6,8 @@ symio[0x80]: "" >>> ""
 symio[0x84]: "" >>> "\n"
 ---
 # stats
-instructions: 13
 sections: 98 bytes
 code/data: 98 bytes (0..97)
+instructions: 13
 stack: 0 bytes (no push observed)
-effective memory: 98 / 4096 bytes
 

--- a/test/golden/generated/get_put_char/6.risc-iv-32.result
+++ b/test/golden/generated/get_put_char/6.risc-iv-32.result
@@ -4,3 +4,11 @@ numio[0x80]: [] >>> []
 numio[0x84]: [] >>> [10]
 symio[0x80]: "" >>> ""
 symio[0x84]: "" >>> "\n"
+---
+# stats
+instructions: 13
+sections: 88 bytes
+code/data: 88 bytes (0..87)
+stack: 0 bytes (uninitialised)
+effective memory: 88 / 4096 bytes
+

--- a/test/golden/generated/get_put_char/6.risc-iv-32.result
+++ b/test/golden/generated/get_put_char/6.risc-iv-32.result
@@ -6,9 +6,8 @@ symio[0x80]: "" >>> ""
 symio[0x84]: "" >>> "\n"
 ---
 # stats
-instructions: 13
 sections: 88 bytes
 code/data: 88 bytes (0..87)
+instructions: 13
 stack: 0 bytes (uninitialised)
-effective memory: 88 / 4096 bytes
 

--- a/test/golden/generated/get_put_char/6.vliw-iv.result
+++ b/test/golden/generated/get_put_char/6.vliw-iv.result
@@ -4,3 +4,11 @@ numio[0x80]: [] >>> []
 numio[0x84]: [] >>> [10]
 symio[0x80]: "" >>> ""
 symio[0x84]: "" >>> "\n"
+---
+# stats
+instructions: 13
+sections: 228 bytes
+code/data: 476 bytes (0..475)
+stack: 0 bytes (uninitialised)
+effective memory: 476 / 4096 bytes
+

--- a/test/golden/generated/get_put_char/6.vliw-iv.result
+++ b/test/golden/generated/get_put_char/6.vliw-iv.result
@@ -6,9 +6,8 @@ symio[0x80]: "" >>> ""
 symio[0x84]: "" >>> "\n"
 ---
 # stats
-instructions: 13
 sections: 228 bytes
 code/data: 476 bytes (0..475)
+instructions: 13
 stack: 0 bytes (uninitialised)
-effective memory: 476 / 4096 bytes
 

--- a/test/golden/generated/get_put_char/7.acc32.result
+++ b/test/golden/generated/get_put_char/7.acc32.result
@@ -6,8 +6,7 @@ symio[0x80]: "\n" >>> ""
 symio[0x84]: "" >>> "\0"
 ---
 # stats
-instructions: 11
 sections: 91 bytes
 code/data: 91 bytes (0..90)
-effective memory: 91 / 4096 bytes
+instructions: 11
 

--- a/test/golden/generated/get_put_char/7.acc32.result
+++ b/test/golden/generated/get_put_char/7.acc32.result
@@ -4,3 +4,10 @@ numio[0x80]: [10] >>> []
 numio[0x84]: [] >>> [0]
 symio[0x80]: "\n" >>> ""
 symio[0x84]: "" >>> "\0"
+---
+# stats
+instructions: 11
+sections: 91 bytes
+code/data: 91 bytes (0..90)
+effective memory: 91 / 4096 bytes
+

--- a/test/golden/generated/get_put_char/7.f32a.result
+++ b/test/golden/generated/get_put_char/7.f32a.result
@@ -4,3 +4,12 @@ numio[0x80]: [10] >>> []
 numio[0x84]: [] >>> [0]
 symio[0x80]: "\n" >>> ""
 symio[0x84]: "" >>> "\0"
+---
+# stats
+instructions: 25
+sections: 78 bytes
+code/data: 78 bytes (0..77)
+dstack depth: 4 (16 bytes)
+rstack depth: 1 (4 bytes)
+effective memory: 98 / 4096 bytes
+

--- a/test/golden/generated/get_put_char/7.f32a.result
+++ b/test/golden/generated/get_put_char/7.f32a.result
@@ -6,10 +6,9 @@ symio[0x80]: "\n" >>> ""
 symio[0x84]: "" >>> "\0"
 ---
 # stats
-instructions: 25
 sections: 78 bytes
 code/data: 78 bytes (0..77)
+instructions: 25
 dstack depth: 4 (16 bytes)
 rstack depth: 1 (4 bytes)
-effective memory: 98 / 4096 bytes
 

--- a/test/golden/generated/get_put_char/7.m68k.result
+++ b/test/golden/generated/get_put_char/7.m68k.result
@@ -4,3 +4,11 @@ numio[0x80]: [10] >>> []
 numio[0x84]: [] >>> [0]
 symio[0x80]: "\n" >>> ""
 symio[0x84]: "" >>> "\0"
+---
+# stats
+instructions: 13
+sections: 98 bytes
+code/data: 98 bytes (0..97)
+stack: 0 bytes (no push observed)
+effective memory: 98 / 4096 bytes
+

--- a/test/golden/generated/get_put_char/7.m68k.result
+++ b/test/golden/generated/get_put_char/7.m68k.result
@@ -6,9 +6,8 @@ symio[0x80]: "\n" >>> ""
 symio[0x84]: "" >>> "\0"
 ---
 # stats
-instructions: 13
 sections: 98 bytes
 code/data: 98 bytes (0..97)
+instructions: 13
 stack: 0 bytes (no push observed)
-effective memory: 98 / 4096 bytes
 

--- a/test/golden/generated/get_put_char/7.risc-iv-32.result
+++ b/test/golden/generated/get_put_char/7.risc-iv-32.result
@@ -6,9 +6,8 @@ symio[0x80]: "\n" >>> ""
 symio[0x84]: "" >>> "\0"
 ---
 # stats
-instructions: 13
 sections: 88 bytes
 code/data: 88 bytes (0..87)
+instructions: 13
 stack: 0 bytes (uninitialised)
-effective memory: 88 / 4096 bytes
 

--- a/test/golden/generated/get_put_char/7.risc-iv-32.result
+++ b/test/golden/generated/get_put_char/7.risc-iv-32.result
@@ -4,3 +4,11 @@ numio[0x80]: [10] >>> []
 numio[0x84]: [] >>> [0]
 symio[0x80]: "\n" >>> ""
 symio[0x84]: "" >>> "\0"
+---
+# stats
+instructions: 13
+sections: 88 bytes
+code/data: 88 bytes (0..87)
+stack: 0 bytes (uninitialised)
+effective memory: 88 / 4096 bytes
+

--- a/test/golden/generated/get_put_char/7.vliw-iv.result
+++ b/test/golden/generated/get_put_char/7.vliw-iv.result
@@ -4,3 +4,11 @@ numio[0x80]: [10] >>> []
 numio[0x84]: [] >>> [0]
 symio[0x80]: "\n" >>> ""
 symio[0x84]: "" >>> "\0"
+---
+# stats
+instructions: 13
+sections: 228 bytes
+code/data: 476 bytes (0..475)
+stack: 0 bytes (uninitialised)
+effective memory: 476 / 4096 bytes
+

--- a/test/golden/generated/get_put_char/7.vliw-iv.result
+++ b/test/golden/generated/get_put_char/7.vliw-iv.result
@@ -6,9 +6,8 @@ symio[0x80]: "\n" >>> ""
 symio[0x84]: "" >>> "\0"
 ---
 # stats
-instructions: 13
 sections: 228 bytes
 code/data: 476 bytes (0..475)
+instructions: 13
 stack: 0 bytes (uninitialised)
-effective memory: 476 / 4096 bytes
 

--- a/test/golden/generated/get_put_char/8.acc32.result
+++ b/test/golden/generated/get_put_char/8.acc32.result
@@ -4,3 +4,10 @@ numio[0x80]: [0] >>> []
 numio[0x84]: [] >>> [10]
 symio[0x80]: "\0" >>> ""
 symio[0x84]: "" >>> "\n"
+---
+# stats
+instructions: 11
+sections: 91 bytes
+code/data: 91 bytes (0..90)
+effective memory: 91 / 4096 bytes
+

--- a/test/golden/generated/get_put_char/8.acc32.result
+++ b/test/golden/generated/get_put_char/8.acc32.result
@@ -6,8 +6,7 @@ symio[0x80]: "\0" >>> ""
 symio[0x84]: "" >>> "\n"
 ---
 # stats
-instructions: 11
 sections: 91 bytes
 code/data: 91 bytes (0..90)
-effective memory: 91 / 4096 bytes
+instructions: 11
 

--- a/test/golden/generated/get_put_char/8.f32a.result
+++ b/test/golden/generated/get_put_char/8.f32a.result
@@ -4,3 +4,12 @@ numio[0x80]: [0] >>> []
 numio[0x84]: [] >>> [10]
 symio[0x80]: "\0" >>> ""
 symio[0x84]: "" >>> "\n"
+---
+# stats
+instructions: 25
+sections: 78 bytes
+code/data: 78 bytes (0..77)
+dstack depth: 4 (16 bytes)
+rstack depth: 1 (4 bytes)
+effective memory: 98 / 4096 bytes
+

--- a/test/golden/generated/get_put_char/8.f32a.result
+++ b/test/golden/generated/get_put_char/8.f32a.result
@@ -6,10 +6,9 @@ symio[0x80]: "\0" >>> ""
 symio[0x84]: "" >>> "\n"
 ---
 # stats
-instructions: 25
 sections: 78 bytes
 code/data: 78 bytes (0..77)
+instructions: 25
 dstack depth: 4 (16 bytes)
 rstack depth: 1 (4 bytes)
-effective memory: 98 / 4096 bytes
 

--- a/test/golden/generated/get_put_char/8.m68k.result
+++ b/test/golden/generated/get_put_char/8.m68k.result
@@ -6,9 +6,8 @@ symio[0x80]: "\0" >>> ""
 symio[0x84]: "" >>> "\n"
 ---
 # stats
-instructions: 13
 sections: 98 bytes
 code/data: 98 bytes (0..97)
+instructions: 13
 stack: 0 bytes (no push observed)
-effective memory: 98 / 4096 bytes
 

--- a/test/golden/generated/get_put_char/8.m68k.result
+++ b/test/golden/generated/get_put_char/8.m68k.result
@@ -4,3 +4,11 @@ numio[0x80]: [0] >>> []
 numio[0x84]: [] >>> [10]
 symio[0x80]: "\0" >>> ""
 symio[0x84]: "" >>> "\n"
+---
+# stats
+instructions: 13
+sections: 98 bytes
+code/data: 98 bytes (0..97)
+stack: 0 bytes (no push observed)
+effective memory: 98 / 4096 bytes
+

--- a/test/golden/generated/get_put_char/8.risc-iv-32.result
+++ b/test/golden/generated/get_put_char/8.risc-iv-32.result
@@ -6,9 +6,8 @@ symio[0x80]: "\0" >>> ""
 symio[0x84]: "" >>> "\n"
 ---
 # stats
-instructions: 13
 sections: 88 bytes
 code/data: 88 bytes (0..87)
+instructions: 13
 stack: 0 bytes (uninitialised)
-effective memory: 88 / 4096 bytes
 

--- a/test/golden/generated/get_put_char/8.risc-iv-32.result
+++ b/test/golden/generated/get_put_char/8.risc-iv-32.result
@@ -4,3 +4,11 @@ numio[0x80]: [0] >>> []
 numio[0x84]: [] >>> [10]
 symio[0x80]: "\0" >>> ""
 symio[0x84]: "" >>> "\n"
+---
+# stats
+instructions: 13
+sections: 88 bytes
+code/data: 88 bytes (0..87)
+stack: 0 bytes (uninitialised)
+effective memory: 88 / 4096 bytes
+

--- a/test/golden/generated/get_put_char/8.vliw-iv.result
+++ b/test/golden/generated/get_put_char/8.vliw-iv.result
@@ -6,9 +6,8 @@ symio[0x80]: "\0" >>> ""
 symio[0x84]: "" >>> "\n"
 ---
 # stats
-instructions: 13
 sections: 228 bytes
 code/data: 476 bytes (0..475)
+instructions: 13
 stack: 0 bytes (uninitialised)
-effective memory: 476 / 4096 bytes
 

--- a/test/golden/generated/get_put_char/8.vliw-iv.result
+++ b/test/golden/generated/get_put_char/8.vliw-iv.result
@@ -4,3 +4,11 @@ numio[0x80]: [0] >>> []
 numio[0x84]: [] >>> [10]
 symio[0x80]: "\0" >>> ""
 symio[0x84]: "" >>> "\n"
+---
+# stats
+instructions: 13
+sections: 228 bytes
+code/data: 476 bytes (0..475)
+stack: 0 bytes (uninitialised)
+effective memory: 476 / 4096 bytes
+

--- a/test/golden/generated/get_put_char/9.acc32.result
+++ b/test/golden/generated/get_put_char/9.acc32.result
@@ -6,8 +6,7 @@ symio[0x80]: "" >>> ""
 symio[0x84]: "" >>> "?"
 ---
 # stats
-instructions: 8
 sections: 91 bytes
 code/data: 91 bytes (0..90)
-effective memory: 91 / 4096 bytes
+instructions: 8
 

--- a/test/golden/generated/get_put_char/9.acc32.result
+++ b/test/golden/generated/get_put_char/9.acc32.result
@@ -4,3 +4,10 @@ numio[0x80]: [] >>> []
 numio[0x84]: [] >>> [-1]
 symio[0x80]: "" >>> ""
 symio[0x84]: "" >>> "?"
+---
+# stats
+instructions: 8
+sections: 91 bytes
+code/data: 91 bytes (0..90)
+effective memory: 91 / 4096 bytes
+

--- a/test/golden/generated/get_put_char/9.f32a.result
+++ b/test/golden/generated/get_put_char/9.f32a.result
@@ -4,3 +4,12 @@ numio[0x80]: [] >>> []
 numio[0x84]: [] >>> [-1]
 symio[0x80]: "" >>> ""
 symio[0x84]: "" >>> "?"
+---
+# stats
+instructions: 17
+sections: 78 bytes
+code/data: 78 bytes (0..77)
+dstack depth: 4 (16 bytes)
+rstack depth: 1 (4 bytes)
+effective memory: 98 / 4096 bytes
+

--- a/test/golden/generated/get_put_char/9.f32a.result
+++ b/test/golden/generated/get_put_char/9.f32a.result
@@ -6,10 +6,9 @@ symio[0x80]: "" >>> ""
 symio[0x84]: "" >>> "?"
 ---
 # stats
-instructions: 17
 sections: 78 bytes
 code/data: 78 bytes (0..77)
+instructions: 17
 dstack depth: 4 (16 bytes)
 rstack depth: 1 (4 bytes)
-effective memory: 98 / 4096 bytes
 

--- a/test/golden/generated/get_put_char/9.m68k.result
+++ b/test/golden/generated/get_put_char/9.m68k.result
@@ -4,3 +4,11 @@ numio[0x80]: [] >>> []
 numio[0x84]: [] >>> [-1]
 symio[0x80]: "" >>> ""
 symio[0x84]: "" >>> "?"
+---
+# stats
+instructions: 11
+sections: 98 bytes
+code/data: 98 bytes (0..97)
+stack: 0 bytes (no push observed)
+effective memory: 98 / 4096 bytes
+

--- a/test/golden/generated/get_put_char/9.m68k.result
+++ b/test/golden/generated/get_put_char/9.m68k.result
@@ -6,9 +6,8 @@ symio[0x80]: "" >>> ""
 symio[0x84]: "" >>> "?"
 ---
 # stats
-instructions: 11
 sections: 98 bytes
 code/data: 98 bytes (0..97)
+instructions: 11
 stack: 0 bytes (no push observed)
-effective memory: 98 / 4096 bytes
 

--- a/test/golden/generated/get_put_char/9.risc-iv-32.result
+++ b/test/golden/generated/get_put_char/9.risc-iv-32.result
@@ -6,9 +6,8 @@ symio[0x80]: "" >>> ""
 symio[0x84]: "" >>> "?"
 ---
 # stats
-instructions: 12
 sections: 88 bytes
 code/data: 88 bytes (0..87)
+instructions: 12
 stack: 0 bytes (uninitialised)
-effective memory: 88 / 4096 bytes
 

--- a/test/golden/generated/get_put_char/9.risc-iv-32.result
+++ b/test/golden/generated/get_put_char/9.risc-iv-32.result
@@ -4,3 +4,11 @@ numio[0x80]: [] >>> []
 numio[0x84]: [] >>> [-1]
 symio[0x80]: "" >>> ""
 symio[0x84]: "" >>> "?"
+---
+# stats
+instructions: 12
+sections: 88 bytes
+code/data: 88 bytes (0..87)
+stack: 0 bytes (uninitialised)
+effective memory: 88 / 4096 bytes
+

--- a/test/golden/generated/get_put_char/9.vliw-iv.result
+++ b/test/golden/generated/get_put_char/9.vliw-iv.result
@@ -4,3 +4,11 @@ numio[0x80]: [] >>> []
 numio[0x84]: [] >>> [-1]
 symio[0x80]: "" >>> ""
 symio[0x84]: "" >>> "?"
+---
+# stats
+instructions: 12
+sections: 228 bytes
+code/data: 476 bytes (0..475)
+stack: 0 bytes (uninitialised)
+effective memory: 476 / 4096 bytes
+

--- a/test/golden/generated/get_put_char/9.vliw-iv.result
+++ b/test/golden/generated/get_put_char/9.vliw-iv.result
@@ -6,9 +6,8 @@ symio[0x80]: "" >>> ""
 symio[0x84]: "" >>> "?"
 ---
 # stats
-instructions: 12
 sections: 228 bytes
 code/data: 476 bytes (0..475)
+instructions: 12
 stack: 0 bytes (uninitialised)
-effective memory: 476 / 4096 bytes
 

--- a/test/golden/generated/hello/1.acc32.result
+++ b/test/golden/generated/hello/1.acc32.result
@@ -7,8 +7,7 @@ symio[0x84]: "" >>> "?Hello\n\0World!"
 mem[0..16]: 	1f 48 65 6c 6c 6f 0a 00 57 6f 72 6c 64 21 00 00 00
 ---
 # stats
-instructions: 174
 sections: 104 bytes
 code/data: 104 bytes (0..103)
-effective memory: 104 / 4096 bytes
+instructions: 174
 

--- a/test/golden/generated/hello/1.acc32.result
+++ b/test/golden/generated/hello/1.acc32.result
@@ -5,3 +5,10 @@ numio[0x84]: [] >>> [31,72,101,108,108,111,10,0,87,111,114,108,100,33]
 symio[0x80]: "" >>> ""
 symio[0x84]: "" >>> "?Hello\n\0World!"
 mem[0..16]: 	1f 48 65 6c 6c 6f 0a 00 57 6f 72 6c 64 21 00 00 00
+---
+# stats
+instructions: 174
+sections: 104 bytes
+code/data: 104 bytes (0..103)
+effective memory: 104 / 4096 bytes
+

--- a/test/golden/generated/hello/1.f32a.result
+++ b/test/golden/generated/hello/1.f32a.result
@@ -7,10 +7,9 @@ symio[0x84]: "" >>> "?Hello\n\0World!"
 mem[0..16]: 	1f 48 65 6c 6c 6f 0a 00 57 6f 72 6c 64 21 00 00 00
 ---
 # stats
-instructions: 134
 sections: 64 bytes
 code/data: 64 bytes (0..63)
+instructions: 134
 dstack depth: 3 (12 bytes)
 rstack depth: 0 (0 bytes)
-effective memory: 76 / 4096 bytes
 

--- a/test/golden/generated/hello/1.f32a.result
+++ b/test/golden/generated/hello/1.f32a.result
@@ -5,3 +5,12 @@ numio[0x84]: [] >>> [31,72,101,108,108,111,10,0,87,111,114,108,100,33]
 symio[0x80]: "" >>> ""
 symio[0x84]: "" >>> "?Hello\n\0World!"
 mem[0..16]: 	1f 48 65 6c 6c 6f 0a 00 57 6f 72 6c 64 21 00 00 00
+---
+# stats
+instructions: 134
+sections: 64 bytes
+code/data: 64 bytes (0..63)
+dstack depth: 3 (12 bytes)
+rstack depth: 0 (0 bytes)
+effective memory: 76 / 4096 bytes
+

--- a/test/golden/generated/hello/1.m68k.result
+++ b/test/golden/generated/hello/1.m68k.result
@@ -7,9 +7,8 @@ symio[0x84]: "" >>> "?Hello\n\0World!"
 mem[0..16]: 	1f 48 65 6c 6c 6f 0a 00 57 6f 72 6c 64 21 00 00 00
 ---
 # stats
-instructions: 103
 sections: 79 bytes
 code/data: 314 bytes (0..313)
+instructions: 103
 stack: 0 bytes (uninitialised)
-effective memory: 314 / 4096 bytes
 

--- a/test/golden/generated/hello/1.m68k.result
+++ b/test/golden/generated/hello/1.m68k.result
@@ -5,3 +5,11 @@ numio[0x84]: [] >>> [31,72,101,108,108,111,10,0,87,111,114,108,100,33]
 symio[0x80]: "" >>> ""
 symio[0x84]: "" >>> "?Hello\n\0World!"
 mem[0..16]: 	1f 48 65 6c 6c 6f 0a 00 57 6f 72 6c 64 21 00 00 00
+---
+# stats
+instructions: 103
+sections: 79 bytes
+code/data: 314 bytes (0..313)
+stack: 0 bytes (uninitialised)
+effective memory: 314 / 4096 bytes
+

--- a/test/golden/generated/hello/1.risc-iv-32.result
+++ b/test/golden/generated/hello/1.risc-iv-32.result
@@ -7,9 +7,8 @@ symio[0x84]: "" >>> "?Hello\n\0World!"
 mem[0..16]: 	1f 48 65 6c 6c 6f 0a 00 57 6f 72 6c 64 21 00 00 00
 ---
 # stats
-instructions: 91
 sections: 69 bytes
 code/data: 69 bytes (0..68)
+instructions: 91
 stack: 0 bytes (uninitialised)
-effective memory: 69 / 4096 bytes
 

--- a/test/golden/generated/hello/1.risc-iv-32.result
+++ b/test/golden/generated/hello/1.risc-iv-32.result
@@ -5,3 +5,11 @@ numio[0x84]: [] >>> [31,72,101,108,108,111,10,0,87,111,114,108,100,33]
 symio[0x80]: "" >>> ""
 symio[0x84]: "" >>> "?Hello\n\0World!"
 mem[0..16]: 	1f 48 65 6c 6c 6f 0a 00 57 6f 72 6c 64 21 00 00 00
+---
+# stats
+instructions: 91
+sections: 69 bytes
+code/data: 69 bytes (0..68)
+stack: 0 bytes (uninitialised)
+effective memory: 69 / 4096 bytes
+

--- a/test/golden/generated/hello/1.vliw-iv.result
+++ b/test/golden/generated/hello/1.vliw-iv.result
@@ -7,9 +7,8 @@ symio[0x84]: "" >>> "?Hello\n\0World!"
 mem[0..16]: 	1f 48 65 6c 6c 6f 0a 00 57 6f 72 6c 64 21 00 00 00
 ---
 # stats
-instructions: 33
 sections: 87 bytes
 code/data: 322 bytes (0..321)
+instructions: 33
 stack: 0 bytes (uninitialised)
-effective memory: 322 / 4096 bytes
 

--- a/test/golden/generated/hello/1.vliw-iv.result
+++ b/test/golden/generated/hello/1.vliw-iv.result
@@ -5,3 +5,11 @@ numio[0x84]: [] >>> [31,72,101,108,108,111,10,0,87,111,114,108,100,33]
 symio[0x80]: "" >>> ""
 symio[0x84]: "" >>> "?Hello\n\0World!"
 mem[0..16]: 	1f 48 65 6c 6c 6f 0a 00 57 6f 72 6c 64 21 00 00 00
+---
+# stats
+instructions: 33
+sections: 87 bytes
+code/data: 322 bytes (0..321)
+stack: 0 bytes (uninitialised)
+effective memory: 322 / 4096 bytes
+

--- a/test/golden/generated/logical_not/1.acc32.result
+++ b/test/golden/generated/logical_not/1.acc32.result
@@ -4,8 +4,7 @@ numio[0x80]: [] >>> []
 numio[0x84]: [] >>> [0]
 ---
 # stats
-instructions: 6
 sections: 26 bytes
 code/data: 26 bytes (0..25)
-effective memory: 26 / 4096 bytes
+instructions: 6
 

--- a/test/golden/generated/logical_not/1.acc32.result
+++ b/test/golden/generated/logical_not/1.acc32.result
@@ -2,3 +2,10 @@
 # Check results
 numio[0x80]: [] >>> []
 numio[0x84]: [] >>> [0]
+---
+# stats
+instructions: 6
+sections: 26 bytes
+code/data: 26 bytes (0..25)
+effective memory: 26 / 4096 bytes
+

--- a/test/golden/generated/logical_not/1.f32a.result
+++ b/test/golden/generated/logical_not/1.f32a.result
@@ -2,3 +2,12 @@
 # Check results
 numio[0x80]: [] >>> []
 numio[0x84]: [] >>> [0]
+---
+# stats
+instructions: 9
+sections: 33 bytes
+code/data: 33 bytes (0..32)
+dstack depth: 2 (8 bytes)
+rstack depth: 0 (0 bytes)
+effective memory: 41 / 4096 bytes
+

--- a/test/golden/generated/logical_not/1.f32a.result
+++ b/test/golden/generated/logical_not/1.f32a.result
@@ -4,10 +4,9 @@ numio[0x80]: [] >>> []
 numio[0x84]: [] >>> [0]
 ---
 # stats
-instructions: 9
 sections: 33 bytes
 code/data: 33 bytes (0..32)
+instructions: 9
 dstack depth: 2 (8 bytes)
 rstack depth: 0 (0 bytes)
-effective memory: 41 / 4096 bytes
 

--- a/test/golden/generated/logical_not/1.m68k.result
+++ b/test/golden/generated/logical_not/1.m68k.result
@@ -4,9 +4,8 @@ numio[0x80]: [] >>> []
 numio[0x84]: [] >>> [0]
 ---
 # stats
-instructions: 10
 sections: 48 bytes
 code/data: 48 bytes (0..47)
+instructions: 10
 stack: 0 bytes (uninitialised)
-effective memory: 48 / 4096 bytes
 

--- a/test/golden/generated/logical_not/1.m68k.result
+++ b/test/golden/generated/logical_not/1.m68k.result
@@ -2,3 +2,11 @@
 # Check results
 numio[0x80]: [] >>> []
 numio[0x84]: [] >>> [0]
+---
+# stats
+instructions: 10
+sections: 48 bytes
+code/data: 48 bytes (0..47)
+stack: 0 bytes (uninitialised)
+effective memory: 48 / 4096 bytes
+

--- a/test/golden/generated/logical_not/1.risc-iv-32.result
+++ b/test/golden/generated/logical_not/1.risc-iv-32.result
@@ -4,9 +4,8 @@ numio[0x80]: [] >>> []
 numio[0x84]: [] >>> [0]
 ---
 # stats
-instructions: 11
 sections: 52 bytes
 code/data: 52 bytes (0..51)
+instructions: 11
 stack: 0 bytes (uninitialised)
-effective memory: 52 / 4096 bytes
 

--- a/test/golden/generated/logical_not/1.risc-iv-32.result
+++ b/test/golden/generated/logical_not/1.risc-iv-32.result
@@ -2,3 +2,11 @@
 # Check results
 numio[0x80]: [] >>> []
 numio[0x84]: [] >>> [0]
+---
+# stats
+instructions: 11
+sections: 52 bytes
+code/data: 52 bytes (0..51)
+stack: 0 bytes (uninitialised)
+effective memory: 52 / 4096 bytes
+

--- a/test/golden/generated/logical_not/1.vliw-iv.result
+++ b/test/golden/generated/logical_not/1.vliw-iv.result
@@ -2,3 +2,11 @@
 # Check results
 numio[0x80]: [] >>> []
 numio[0x84]: [] >>> [0]
+---
+# stats
+instructions: 11
+sections: 129 bytes
+code/data: 377 bytes (0..376)
+stack: 0 bytes (uninitialised)
+effective memory: 377 / 4096 bytes
+

--- a/test/golden/generated/logical_not/1.vliw-iv.result
+++ b/test/golden/generated/logical_not/1.vliw-iv.result
@@ -4,9 +4,8 @@ numio[0x80]: [] >>> []
 numio[0x84]: [] >>> [0]
 ---
 # stats
-instructions: 11
 sections: 129 bytes
 code/data: 377 bytes (0..376)
+instructions: 11
 stack: 0 bytes (uninitialised)
-effective memory: 377 / 4096 bytes
 

--- a/test/golden/generated/logical_not/2.acc32.result
+++ b/test/golden/generated/logical_not/2.acc32.result
@@ -4,8 +4,7 @@ numio[0x80]: [] >>> []
 numio[0x84]: [] >>> [1]
 ---
 # stats
-instructions: 6
 sections: 26 bytes
 code/data: 26 bytes (0..25)
-effective memory: 26 / 4096 bytes
+instructions: 6
 

--- a/test/golden/generated/logical_not/2.acc32.result
+++ b/test/golden/generated/logical_not/2.acc32.result
@@ -2,3 +2,10 @@
 # Check results
 numio[0x80]: [] >>> []
 numio[0x84]: [] >>> [1]
+---
+# stats
+instructions: 6
+sections: 26 bytes
+code/data: 26 bytes (0..25)
+effective memory: 26 / 4096 bytes
+

--- a/test/golden/generated/logical_not/2.f32a.result
+++ b/test/golden/generated/logical_not/2.f32a.result
@@ -2,3 +2,12 @@
 # Check results
 numio[0x80]: [] >>> []
 numio[0x84]: [] >>> [1]
+---
+# stats
+instructions: 9
+sections: 33 bytes
+code/data: 33 bytes (0..32)
+dstack depth: 2 (8 bytes)
+rstack depth: 0 (0 bytes)
+effective memory: 41 / 4096 bytes
+

--- a/test/golden/generated/logical_not/2.f32a.result
+++ b/test/golden/generated/logical_not/2.f32a.result
@@ -4,10 +4,9 @@ numio[0x80]: [] >>> []
 numio[0x84]: [] >>> [1]
 ---
 # stats
-instructions: 9
 sections: 33 bytes
 code/data: 33 bytes (0..32)
+instructions: 9
 dstack depth: 2 (8 bytes)
 rstack depth: 0 (0 bytes)
-effective memory: 41 / 4096 bytes
 

--- a/test/golden/generated/logical_not/2.m68k.result
+++ b/test/golden/generated/logical_not/2.m68k.result
@@ -4,9 +4,8 @@ numio[0x80]: [] >>> []
 numio[0x84]: [] >>> [1]
 ---
 # stats
-instructions: 10
 sections: 48 bytes
 code/data: 48 bytes (0..47)
+instructions: 10
 stack: 0 bytes (uninitialised)
-effective memory: 48 / 4096 bytes
 

--- a/test/golden/generated/logical_not/2.m68k.result
+++ b/test/golden/generated/logical_not/2.m68k.result
@@ -2,3 +2,11 @@
 # Check results
 numio[0x80]: [] >>> []
 numio[0x84]: [] >>> [1]
+---
+# stats
+instructions: 10
+sections: 48 bytes
+code/data: 48 bytes (0..47)
+stack: 0 bytes (uninitialised)
+effective memory: 48 / 4096 bytes
+

--- a/test/golden/generated/logical_not/2.risc-iv-32.result
+++ b/test/golden/generated/logical_not/2.risc-iv-32.result
@@ -4,9 +4,8 @@ numio[0x80]: [] >>> []
 numio[0x84]: [] >>> [1]
 ---
 # stats
-instructions: 11
 sections: 52 bytes
 code/data: 52 bytes (0..51)
+instructions: 11
 stack: 0 bytes (uninitialised)
-effective memory: 52 / 4096 bytes
 

--- a/test/golden/generated/logical_not/2.risc-iv-32.result
+++ b/test/golden/generated/logical_not/2.risc-iv-32.result
@@ -2,3 +2,11 @@
 # Check results
 numio[0x80]: [] >>> []
 numio[0x84]: [] >>> [1]
+---
+# stats
+instructions: 11
+sections: 52 bytes
+code/data: 52 bytes (0..51)
+stack: 0 bytes (uninitialised)
+effective memory: 52 / 4096 bytes
+

--- a/test/golden/generated/logical_not/2.vliw-iv.result
+++ b/test/golden/generated/logical_not/2.vliw-iv.result
@@ -4,9 +4,8 @@ numio[0x80]: [] >>> []
 numio[0x84]: [] >>> [1]
 ---
 # stats
-instructions: 11
 sections: 129 bytes
 code/data: 377 bytes (0..376)
+instructions: 11
 stack: 0 bytes (uninitialised)
-effective memory: 377 / 4096 bytes
 

--- a/test/golden/generated/logical_not/2.vliw-iv.result
+++ b/test/golden/generated/logical_not/2.vliw-iv.result
@@ -2,3 +2,11 @@
 # Check results
 numio[0x80]: [] >>> []
 numio[0x84]: [] >>> [1]
+---
+# stats
+instructions: 11
+sections: 129 bytes
+code/data: 377 bytes (0..376)
+stack: 0 bytes (uninitialised)
+effective memory: 377 / 4096 bytes
+

--- a/test/golden/m68k/factorial_recursive.m68k.result
+++ b/test/golden/m68k/factorial_recursive.m68k.result
@@ -2,3 +2,11 @@
 # Check results
 numio[0x80]: [] >>> []
 numio[0x84]: [] >>> [120]
+---
+# stats
+instructions: 56
+sections: 110 bytes
+code/data: 110 bytes (0..109)
+stack: 60 bytes (452..511)
+effective memory: 170 / 4096 bytes
+

--- a/test/golden/m68k/factorial_recursive.m68k.result
+++ b/test/golden/m68k/factorial_recursive.m68k.result
@@ -4,9 +4,8 @@ numio[0x80]: [] >>> []
 numio[0x84]: [] >>> [120]
 ---
 # stats
-instructions: 56
 sections: 110 bytes
 code/data: 110 bytes (0..109)
+instructions: 56
 stack: 60 bytes (452..511)
-effective memory: 170 / 4096 bytes
 

--- a/test/golden/m68k/hello.m68k.result
+++ b/test/golden/m68k/hello.m68k.result
@@ -4,3 +4,11 @@ numio[0x80]: [] >>> []
 numio[0x84]: [] >>> [72,101,108,108,111,10,0,87,111,114,108,100]
 symio[0x80]: "" >>> ""
 symio[0x84]: "" >>> "Hello\n\0World"
+---
+# stats
+instructions: 77
+sections: 69 bytes
+code/data: 308 bytes (0..307)
+stack: 0 bytes (uninitialised)
+effective memory: 308 / 4096 bytes
+

--- a/test/golden/m68k/hello.m68k.result
+++ b/test/golden/m68k/hello.m68k.result
@@ -6,9 +6,8 @@ symio[0x80]: "" >>> ""
 symio[0x84]: "" >>> "Hello\n\0World"
 ---
 # stats
-instructions: 77
 sections: 69 bytes
 code/data: 308 bytes (0..307)
+instructions: 77
 stack: 0 bytes (uninitialised)
-effective memory: 308 / 4096 bytes
 

--- a/test/golden/m68k/shift_commands.m68k.result
+++ b/test/golden/m68k/shift_commands.m68k.result
@@ -4,9 +4,8 @@ numio[0x80]: [] >>> []
 numio[0x84]: [] >>> [10,256,16,10]
 ---
 # stats
-instructions: 17
 sections: 86 bytes
 code/data: 86 bytes (0..85)
+instructions: 17
 stack: 0 bytes (no push observed)
-effective memory: 86 / 4096 bytes
 

--- a/test/golden/m68k/shift_commands.m68k.result
+++ b/test/golden/m68k/shift_commands.m68k.result
@@ -2,3 +2,11 @@
 # Check results
 numio[0x80]: [] >>> []
 numio[0x84]: [] >>> [10,256,16,10]
+---
+# stats
+instructions: 17
+sections: 86 bytes
+code/data: 86 bytes (0..85)
+stack: 0 bytes (no push observed)
+effective memory: 86 / 4096 bytes
+

--- a/test/golden/risc-iv-32/ble_bleu.risc-iv-32.result
+++ b/test/golden/risc-iv-32/ble_bleu.risc-iv-32.result
@@ -18,3 +18,11 @@ A0 1 A1 -1
 32:	Bleu {rs1 = A1, rs2 = Zero, k = -12}	
 A0 1 A1 -1
 36:	Halt
+---
+# stats
+instructions: 9
+sections: 40 bytes
+code/data: 40 bytes (0..39)
+stack: 0 bytes (uninitialised)
+effective memory: 40 / 4096 bytes
+

--- a/test/golden/risc-iv-32/ble_bleu.risc-iv-32.result
+++ b/test/golden/risc-iv-32/ble_bleu.risc-iv-32.result
@@ -20,9 +20,8 @@ A0 1 A1 -1
 36:	Halt
 ---
 # stats
-instructions: 9
 sections: 40 bytes
 code/data: 40 bytes (0..39)
+instructions: 9
 stack: 0 bytes (uninitialised)
-effective memory: 40 / 4096 bytes
 

--- a/test/golden/risc-iv-32/count.risc-iv-32.result
+++ b/test/golden/risc-iv-32/count.risc-iv-32.result
@@ -75,9 +75,8 @@ mem[4..7]: 	02 00 00 00
 "" >>> "????\n??????"
 ---
 # stats
-instructions: 67
 sections: 88 bytes
 code/data: 88 bytes (0..87)
+instructions: 67
 stack: 0 bytes (uninitialised)
-effective memory: 88 / 144 bytes
 

--- a/test/golden/risc-iv-32/count.risc-iv-32.result
+++ b/test/golden/risc-iv-32/count.risc-iv-32.result
@@ -73,3 +73,11 @@ mem[4..7]: 	02 00 00 00
 [] >>> [2,4,6,8,10,12,14,16,18,20,22]
 [] >>> [0x00000002,0x00000004,0x00000006,0x00000008,0x0000000a,0x0000000c,0x0000000e,0x00000010,0x00000012,0x00000014,0x00000016]
 "" >>> "????\n??????"
+---
+# stats
+instructions: 67
+sections: 88 bytes
+code/data: 88 bytes (0..87)
+stack: 0 bytes (uninitialised)
+effective memory: 88 / 144 bytes
+

--- a/test/golden/risc-iv-32/factorial_input_5.risc-iv-32.result
+++ b/test/golden/risc-iv-32/factorial_input_5.risc-iv-32.result
@@ -88,3 +88,11 @@
 # result
 numio[0x80]: [] >>> []
 numio[0x84]: [] >>> [120]
+---
+# stats
+instructions: 42
+sections: 128 bytes
+code/data: 128 bytes (0..127)
+stack: 0 bytes (uninitialised)
+effective memory: 128 / 144 bytes
+

--- a/test/golden/risc-iv-32/factorial_input_5.risc-iv-32.result
+++ b/test/golden/risc-iv-32/factorial_input_5.risc-iv-32.result
@@ -90,9 +90,8 @@ numio[0x80]: [] >>> []
 numio[0x84]: [] >>> [120]
 ---
 # stats
-instructions: 42
 sections: 128 bytes
 code/data: 128 bytes (0..127)
+instructions: 42
 stack: 0 bytes (uninitialised)
-effective memory: 128 / 144 bytes
 

--- a/test/golden/risc-iv-32/factorial_input_5_fail_assert.risc-iv-32.result
+++ b/test/golden/risc-iv-32/factorial_input_5_fail_assert.risc-iv-32.result
@@ -92,9 +92,8 @@ ASSERTION FAIL, expect:
 bla=bla
 ---
 # stats
-instructions: 42
 sections: 128 bytes
 code/data: 128 bytes (0..127)
+instructions: 42
 stack: 0 bytes (uninitialised)
-effective memory: 128 / 144 bytes
 

--- a/test/golden/risc-iv-32/factorial_input_5_fail_assert.risc-iv-32.result
+++ b/test/golden/risc-iv-32/factorial_input_5_fail_assert.risc-iv-32.result
@@ -90,3 +90,11 @@ numio[0x80]: [] >>> []
 numio[0x84]: [] >>> [120]
 ASSERTION FAIL, expect:
 bla=bla
+---
+# stats
+instructions: 42
+sections: 128 bytes
+code/data: 128 bytes (0..127)
+stack: 0 bytes (uninitialised)
+effective memory: 128 / 144 bytes
+

--- a/test/golden/risc-iv-32/factorial_input_7.risc-iv-32.result
+++ b/test/golden/risc-iv-32/factorial_input_7.risc-iv-32.result
@@ -114,9 +114,8 @@ numio[0x80]: [] >>> []
 numio[0x84]: [] >>> [5040]
 ---
 # stats
-instructions: 54
 sections: 128 bytes
 code/data: 128 bytes (0..127)
+instructions: 54
 stack: 0 bytes (uninitialised)
-effective memory: 128 / 144 bytes
 

--- a/test/golden/risc-iv-32/factorial_input_7.risc-iv-32.result
+++ b/test/golden/risc-iv-32/factorial_input_7.risc-iv-32.result
@@ -112,3 +112,11 @@
 # result
 numio[0x80]: [] >>> []
 numio[0x84]: [] >>> [5040]
+---
+# stats
+instructions: 54
+sections: 128 bytes
+code/data: 128 bytes (0..127)
+stack: 0 bytes (uninitialised)
+effective memory: 128 / 144 bytes
+

--- a/test/golden/risc-iv-32/factorial_rec_input_5.risc-iv-32.result
+++ b/test/golden/risc-iv-32/factorial_rec_input_5.risc-iv-32.result
@@ -91,3 +91,11 @@
 # result
 numio[0x80]: [] >>> []
 numio[0x84]: [] >>> [120]
+---
+# stats
+instructions: 87
+sections: 160 bytes
+code/data: 192 bytes (0..191)
+stack: 32 bytes (566..597)
+effective memory: 224 / 768 bytes
+

--- a/test/golden/risc-iv-32/factorial_rec_input_5.risc-iv-32.result
+++ b/test/golden/risc-iv-32/factorial_rec_input_5.risc-iv-32.result
@@ -93,9 +93,8 @@ numio[0x80]: [] >>> []
 numio[0x84]: [] >>> [120]
 ---
 # stats
-instructions: 87
 sections: 160 bytes
 code/data: 192 bytes (0..191)
+instructions: 87
 stack: 32 bytes (566..597)
-effective memory: 224 / 768 bytes
 

--- a/test/golden/risc-iv-32/get_put_char_87.risc-iv-32.result
+++ b/test/golden/risc-iv-32/get_put_char_87.risc-iv-32.result
@@ -6,9 +6,8 @@ symio[0x80]: "" >>> ""
 symio[0x84]: "" >>> "W"
 ---
 # stats
-instructions: 13
 sections: 88 bytes
 code/data: 88 bytes (0..87)
+instructions: 13
 stack: 0 bytes (uninitialised)
-effective memory: 88 / 4096 bytes
 

--- a/test/golden/risc-iv-32/get_put_char_87.risc-iv-32.result
+++ b/test/golden/risc-iv-32/get_put_char_87.risc-iv-32.result
@@ -4,3 +4,11 @@ numio[0x80]: [] >>> []
 numio[0x84]: [] >>> [87]
 symio[0x80]: "" >>> ""
 symio[0x84]: "" >>> "W"
+---
+# stats
+instructions: 13
+sections: 88 bytes
+code/data: 88 bytes (0..87)
+stack: 0 bytes (uninitialised)
+effective memory: 88 / 4096 bytes
+

--- a/test/golden/risc-iv-32/get_put_char_abcd.risc-iv-32.result
+++ b/test/golden/risc-iv-32/get_put_char_abcd.risc-iv-32.result
@@ -4,3 +4,11 @@ numio[0x80]: [66,67,68] >>> []
 numio[0x84]: [] >>> [65]
 symio[0x80]: "BCD" >>> ""
 symio[0x84]: "" >>> "A"
+---
+# stats
+instructions: 13
+sections: 88 bytes
+code/data: 88 bytes (0..87)
+stack: 0 bytes (uninitialised)
+effective memory: 88 / 4096 bytes
+

--- a/test/golden/risc-iv-32/get_put_char_abcd.risc-iv-32.result
+++ b/test/golden/risc-iv-32/get_put_char_abcd.risc-iv-32.result
@@ -6,9 +6,8 @@ symio[0x80]: "BCD" >>> ""
 symio[0x84]: "" >>> "A"
 ---
 # stats
-instructions: 13
 sections: 88 bytes
 code/data: 88 bytes (0..87)
+instructions: 13
 stack: 0 bytes (uninitialised)
-effective memory: 88 / 4096 bytes
 

--- a/test/golden/risc-iv-32/get_put_char_nothing.risc-iv-32.result
+++ b/test/golden/risc-iv-32/get_put_char_nothing.risc-iv-32.result
@@ -3,9 +3,8 @@
 ERROR: memory access error: iomemory[128]: input is depleted
 ---
 # stats
-instructions: 7
 sections: 88 bytes
 code/data: 88 bytes (0..87)
+instructions: 7
 stack: 0 bytes (uninitialised)
-effective memory: 88 / 4096 bytes
 

--- a/test/golden/risc-iv-32/get_put_char_nothing.risc-iv-32.result
+++ b/test/golden/risc-iv-32/get_put_char_nothing.risc-iv-32.result
@@ -1,3 +1,11 @@
 ---
 # Check results
 ERROR: memory access error: iomemory[128]: input is depleted
+---
+# stats
+instructions: 7
+sections: 88 bytes
+code/data: 88 bytes (0..87)
+stack: 0 bytes (uninitialised)
+effective memory: 88 / 4096 bytes
+

--- a/test/golden/risc-iv-32/get_put_char_null.risc-iv-32.result
+++ b/test/golden/risc-iv-32/get_put_char_null.risc-iv-32.result
@@ -4,3 +4,11 @@ numio[0x80]: [] >>> []
 numio[0x84]: [] >>> [0]
 symio[0x80]: "" >>> ""
 symio[0x84]: "" >>> "\0"
+---
+# stats
+instructions: 13
+sections: 88 bytes
+code/data: 88 bytes (0..87)
+stack: 0 bytes (uninitialised)
+effective memory: 88 / 4096 bytes
+

--- a/test/golden/risc-iv-32/get_put_char_null.risc-iv-32.result
+++ b/test/golden/risc-iv-32/get_put_char_null.risc-iv-32.result
@@ -6,9 +6,8 @@ symio[0x80]: "" >>> ""
 symio[0x84]: "" >>> "\0"
 ---
 # stats
-instructions: 13
 sections: 88 bytes
 code/data: 88 bytes (0..87)
+instructions: 13
 stack: 0 bytes (uninitialised)
-effective memory: 88 / 4096 bytes
 

--- a/test/golden/risc-iv-32/lui_addi.risc-iv-32.result
+++ b/test/golden/risc-iv-32/lui_addi.risc-iv-32.result
@@ -13,9 +13,8 @@ mem[4..7]: 	Addi {rd = T1, rs1 = T1, k = 1656}
 "" >>> ""
 ---
 # stats
-instructions: 5
 sections: 20 bytes
 code/data: 20 bytes (0..19)
+instructions: 5
 stack: 0 bytes (uninitialised)
-effective memory: 20 / 144 bytes
 

--- a/test/golden/risc-iv-32/lui_addi.risc-iv-32.result
+++ b/test/golden/risc-iv-32/lui_addi.risc-iv-32.result
@@ -11,3 +11,11 @@ mem[4..7]: 	Addi {rd = T1, rs1 = T1, k = 1656}
 [] >>> []
 [] >>> []
 "" >>> ""
+---
+# stats
+instructions: 5
+sections: 20 bytes
+code/data: 20 bytes (0..19)
+stack: 0 bytes (uninitialised)
+effective memory: 20 / 144 bytes
+

--- a/test/golden/risc-iv-32/sb.risc-iv-32.result
+++ b/test/golden/risc-iv-32/sb.risc-iv-32.result
@@ -12,9 +12,8 @@
 mem[0..5]: 	ff 32 33 34 ff 00
 ---
 # stats
-instructions: 7
 sections: 33 bytes
 code/data: 164 bytes (0..163)
+instructions: 7
 stack: 0 bytes (uninitialised)
-effective memory: 164 / 4096 bytes
 

--- a/test/golden/risc-iv-32/sb.risc-iv-32.result
+++ b/test/golden/risc-iv-32/sb.risc-iv-32.result
@@ -10,3 +10,11 @@
 ---
 # Check results
 mem[0..5]: 	ff 32 33 34 ff 00
+---
+# stats
+instructions: 7
+sections: 33 bytes
+code/data: 164 bytes (0..163)
+stack: 0 bytes (uninitialised)
+effective memory: 164 / 4096 bytes
+

--- a/test/golden/vliw-iv/ble_bleu.vliw-iv.result
+++ b/test/golden/vliw-iv/ble_bleu.vliw-iv.result
@@ -18,3 +18,11 @@ A0 1 A1 -1
 88:	Isa {memOp = NopM, alu1Op = NopA, alu2Op = NopA, ctrlOp = Bleu {bleuRs1 = A1, bleuRs2 = Zero, bleuK = -33}}	
 A0 1 A1 -1
 99:	Isa {memOp = NopM, alu1Op = NopA, alu2Op = NopA, ctrlOp = Halt}
+---
+# stats
+instructions: 9
+sections: 110 bytes
+code/data: 110 bytes (0..109)
+stack: 0 bytes (uninitialised)
+effective memory: 110 / 4096 bytes
+

--- a/test/golden/vliw-iv/ble_bleu.vliw-iv.result
+++ b/test/golden/vliw-iv/ble_bleu.vliw-iv.result
@@ -20,9 +20,8 @@ A0 1 A1 -1
 99:	Isa {memOp = NopM, alu1Op = NopA, alu2Op = NopA, ctrlOp = Halt}
 ---
 # stats
-instructions: 9
 sections: 110 bytes
 code/data: 110 bytes (0..109)
+instructions: 9
 stack: 0 bytes (uninitialised)
-effective memory: 110 / 4096 bytes
 

--- a/test/golden/vliw-iv/count.vliw-iv.result
+++ b/test/golden/vliw-iv/count.vliw-iv.result
@@ -51,3 +51,11 @@ mem[4..7]: 	02 00 00 00
 [] >>> [2,4,6,8,10,12,14,16,18,20,22]
 [] >>> [0x00000002,0x00000004,0x00000006,0x00000008,0x0000000a,0x0000000c,0x0000000e,0x00000010,0x00000012,0x00000014,0x00000016]
 "" >>> "????\n??????"
+---
+# stats
+instructions: 45
+sections: 192 bytes
+code/data: 432 bytes (0..431)
+stack: 0 bytes (uninitialised)
+effective memory: 432 / 512 bytes
+

--- a/test/golden/vliw-iv/count.vliw-iv.result
+++ b/test/golden/vliw-iv/count.vliw-iv.result
@@ -53,9 +53,8 @@ mem[4..7]: 	02 00 00 00
 "" >>> "????\n??????"
 ---
 # stats
-instructions: 45
 sections: 192 bytes
 code/data: 432 bytes (0..431)
+instructions: 45
 stack: 0 bytes (uninitialised)
-effective memory: 432 / 512 bytes
 

--- a/test/golden/vliw-iv/factorial_input_5.vliw-iv.result
+++ b/test/golden/vliw-iv/factorial_input_5.vliw-iv.result
@@ -88,3 +88,11 @@
 # result
 numio[0x80]: [] >>> []
 numio[0x84]: [] >>> [120]
+---
+# stats
+instructions: 42
+sections: 338 bytes
+code/data: 474 bytes (0..473)
+stack: 0 bytes (uninitialised)
+effective memory: 474 / 4096 bytes
+

--- a/test/golden/vliw-iv/factorial_input_5.vliw-iv.result
+++ b/test/golden/vliw-iv/factorial_input_5.vliw-iv.result
@@ -90,9 +90,8 @@ numio[0x80]: [] >>> []
 numio[0x84]: [] >>> [120]
 ---
 # stats
-instructions: 42
 sections: 338 bytes
 code/data: 474 bytes (0..473)
+instructions: 42
 stack: 0 bytes (uninitialised)
-effective memory: 474 / 4096 bytes
 

--- a/test/golden/vliw-iv/factorial_input_5_fail_assert.vliw-iv.result
+++ b/test/golden/vliw-iv/factorial_input_5_fail_assert.vliw-iv.result
@@ -91,3 +91,11 @@ numio[0x84]: [] >>> [120]
 ASSERTION FAIL, expect:
 numio[0x80]: [] >>> []
 numio[0x84]: [] >>> [100]
+---
+# stats
+instructions: 42
+sections: 338 bytes
+code/data: 474 bytes (0..473)
+stack: 0 bytes (uninitialised)
+effective memory: 474 / 4096 bytes
+

--- a/test/golden/vliw-iv/factorial_input_5_fail_assert.vliw-iv.result
+++ b/test/golden/vliw-iv/factorial_input_5_fail_assert.vliw-iv.result
@@ -93,9 +93,8 @@ numio[0x80]: [] >>> []
 numio[0x84]: [] >>> [100]
 ---
 # stats
-instructions: 42
 sections: 338 bytes
 code/data: 474 bytes (0..473)
+instructions: 42
 stack: 0 bytes (uninitialised)
-effective memory: 474 / 4096 bytes
 

--- a/test/golden/vliw-iv/factorial_input_7.vliw-iv.result
+++ b/test/golden/vliw-iv/factorial_input_7.vliw-iv.result
@@ -112,3 +112,11 @@
 # result
 numio[0x80]: [] >>> []
 numio[0x84]: [] >>> [5040]
+---
+# stats
+instructions: 54
+sections: 338 bytes
+code/data: 474 bytes (0..473)
+stack: 0 bytes (uninitialised)
+effective memory: 474 / 4096 bytes
+

--- a/test/golden/vliw-iv/factorial_input_7.vliw-iv.result
+++ b/test/golden/vliw-iv/factorial_input_7.vliw-iv.result
@@ -114,9 +114,8 @@ numio[0x80]: [] >>> []
 numio[0x84]: [] >>> [5040]
 ---
 # stats
-instructions: 54
 sections: 338 bytes
 code/data: 474 bytes (0..473)
+instructions: 54
 stack: 0 bytes (uninitialised)
-effective memory: 474 / 4096 bytes
 

--- a/test/golden/vliw-iv/factorial_rec_input_5.vliw-iv.result
+++ b/test/golden/vliw-iv/factorial_rec_input_5.vliw-iv.result
@@ -93,9 +93,8 @@ numio[0x80]: [] >>> []
 numio[0x84]: [] >>> [120]
 ---
 # stats
-instructions: 87
 sections: 426 bytes
 code/data: 674 bytes (0..673)
+instructions: 87
 stack: 32 bytes (1266..1297)
-effective memory: 706 / 4096 bytes
 

--- a/test/golden/vliw-iv/factorial_rec_input_5.vliw-iv.result
+++ b/test/golden/vliw-iv/factorial_rec_input_5.vliw-iv.result
@@ -91,3 +91,11 @@
 # result
 numio[0x80]: [] >>> []
 numio[0x84]: [] >>> [120]
+---
+# stats
+instructions: 87
+sections: 426 bytes
+code/data: 674 bytes (0..673)
+stack: 32 bytes (1266..1297)
+effective memory: 706 / 4096 bytes
+

--- a/test/golden/vliw-iv/get_put_char_87.vliw-iv.result
+++ b/test/golden/vliw-iv/get_put_char_87.vliw-iv.result
@@ -4,3 +4,11 @@ numio[0x80]: [] >>> []
 numio[0x84]: [] >>> [87]
 symio[0x80]: "" >>> ""
 symio[0x84]: "" >>> "W"
+---
+# stats
+instructions: 13
+sections: 228 bytes
+code/data: 476 bytes (0..475)
+stack: 0 bytes (uninitialised)
+effective memory: 476 / 4096 bytes
+

--- a/test/golden/vliw-iv/get_put_char_87.vliw-iv.result
+++ b/test/golden/vliw-iv/get_put_char_87.vliw-iv.result
@@ -6,9 +6,8 @@ symio[0x80]: "" >>> ""
 symio[0x84]: "" >>> "W"
 ---
 # stats
-instructions: 13
 sections: 228 bytes
 code/data: 476 bytes (0..475)
+instructions: 13
 stack: 0 bytes (uninitialised)
-effective memory: 476 / 4096 bytes
 

--- a/test/golden/vliw-iv/get_put_char_abcd.vliw-iv.result
+++ b/test/golden/vliw-iv/get_put_char_abcd.vliw-iv.result
@@ -6,9 +6,8 @@ symio[0x80]: "BCD" >>> ""
 symio[0x84]: "" >>> "A"
 ---
 # stats
-instructions: 13
 sections: 228 bytes
 code/data: 476 bytes (0..475)
+instructions: 13
 stack: 0 bytes (uninitialised)
-effective memory: 476 / 4096 bytes
 

--- a/test/golden/vliw-iv/get_put_char_abcd.vliw-iv.result
+++ b/test/golden/vliw-iv/get_put_char_abcd.vliw-iv.result
@@ -4,3 +4,11 @@ numio[0x80]: [66,67,68] >>> []
 numio[0x84]: [] >>> [65]
 symio[0x80]: "BCD" >>> ""
 symio[0x84]: "" >>> "A"
+---
+# stats
+instructions: 13
+sections: 228 bytes
+code/data: 476 bytes (0..475)
+stack: 0 bytes (uninitialised)
+effective memory: 476 / 4096 bytes
+

--- a/test/golden/vliw-iv/get_put_char_nothing.vliw-iv.result
+++ b/test/golden/vliw-iv/get_put_char_nothing.vliw-iv.result
@@ -3,9 +3,8 @@
 ERROR: memory access error: iomemory[128]: input is depleted
 ---
 # stats
-instructions: 7
 sections: 228 bytes
 code/data: 476 bytes (0..475)
+instructions: 7
 stack: 0 bytes (uninitialised)
-effective memory: 476 / 4096 bytes
 

--- a/test/golden/vliw-iv/get_put_char_nothing.vliw-iv.result
+++ b/test/golden/vliw-iv/get_put_char_nothing.vliw-iv.result
@@ -1,3 +1,11 @@
 ---
 # Check results
 ERROR: memory access error: iomemory[128]: input is depleted
+---
+# stats
+instructions: 7
+sections: 228 bytes
+code/data: 476 bytes (0..475)
+stack: 0 bytes (uninitialised)
+effective memory: 476 / 4096 bytes
+

--- a/test/golden/vliw-iv/get_put_char_null.vliw-iv.result
+++ b/test/golden/vliw-iv/get_put_char_null.vliw-iv.result
@@ -6,9 +6,8 @@ symio[0x80]: "" >>> ""
 symio[0x84]: "" >>> "\0"
 ---
 # stats
-instructions: 13
 sections: 228 bytes
 code/data: 476 bytes (0..475)
+instructions: 13
 stack: 0 bytes (uninitialised)
-effective memory: 476 / 4096 bytes
 

--- a/test/golden/vliw-iv/get_put_char_null.vliw-iv.result
+++ b/test/golden/vliw-iv/get_put_char_null.vliw-iv.result
@@ -4,3 +4,11 @@ numio[0x80]: [] >>> []
 numio[0x84]: [] >>> [0]
 symio[0x80]: "" >>> ""
 symio[0x84]: "" >>> "\0"
+---
+# stats
+instructions: 13
+sections: 228 bytes
+code/data: 476 bytes (0..475)
+stack: 0 bytes (uninitialised)
+effective memory: 476 / 4096 bytes
+

--- a/test/golden/vliw-iv/hello.vliw-iv.result
+++ b/test/golden/vliw-iv/hello.vliw-iv.result
@@ -4,3 +4,11 @@ numio[0x80]: [] >>> []
 numio[0x84]: [] >>> [31,72,101,108,108,111,10,0,87,111,114,108,100,33]
 symio[0x80]: "" >>> ""
 symio[0x84]: "" >>> "?Hello\n\0World!"
+---
+# stats
+instructions: 33
+sections: 87 bytes
+code/data: 322 bytes (0..321)
+stack: 0 bytes (uninitialised)
+effective memory: 322 / 4096 bytes
+

--- a/test/golden/vliw-iv/hello.vliw-iv.result
+++ b/test/golden/vliw-iv/hello.vliw-iv.result
@@ -6,9 +6,8 @@ symio[0x80]: "" >>> ""
 symio[0x84]: "" >>> "?Hello\n\0World!"
 ---
 # stats
-instructions: 33
 sections: 87 bytes
 code/data: 322 bytes (0..321)
+instructions: 33
 stack: 0 bytes (uninitialised)
-effective memory: 322 / 4096 bytes
 

--- a/test/golden/vliw-iv/lui_addi.vliw-iv.result
+++ b/test/golden/vliw-iv/lui_addi.vliw-iv.result
@@ -16,9 +16,8 @@
 "" >>> ""
 ---
 # stats
-instructions: 5
 sections: 55 bytes
 code/data: 55 bytes (0..54)
+instructions: 5
 stack: 0 bytes (uninitialised)
-effective memory: 55 / 144 bytes
 

--- a/test/golden/vliw-iv/lui_addi.vliw-iv.result
+++ b/test/golden/vliw-iv/lui_addi.vliw-iv.result
@@ -14,3 +14,11 @@
 [] >>> []
 [] >>> []
 "" >>> ""
+---
+# stats
+instructions: 5
+sections: 55 bytes
+code/data: 55 bytes (0..54)
+stack: 0 bytes (uninitialised)
+effective memory: 55 / 144 bytes
+

--- a/test/golden/vliw-iv/sb.vliw-iv.result
+++ b/test/golden/vliw-iv/sb.vliw-iv.result
@@ -12,9 +12,8 @@
 mem[0..5]: 	ff 32 33 34 ff 00
 ---
 # stats
-instructions: 7
 sections: 82 bytes
 code/data: 333 bytes (0..332)
+instructions: 7
 stack: 0 bytes (uninitialised)
-effective memory: 333 / 4096 bytes
 

--- a/test/golden/vliw-iv/sb.vliw-iv.result
+++ b/test/golden/vliw-iv/sb.vliw-iv.result
@@ -10,3 +10,11 @@
 ---
 # Check results
 mem[0..5]: 	ff 32 33 34 ff 00
+---
+# stats
+instructions: 7
+sections: 82 bytes
+code/data: 333 bytes (0..332)
+stack: 0 bytes (uninitialised)
+effective memory: 333 / 4096 bytes
+


### PR DESCRIPTION
## Summary
- Appends a `# stats` section to every simulation report covering instructions executed, section bytes, code/data extent, stack usage, and effective memory (code/data + stack, gap excluded).
- Adds a new `StackInfo` shape on `StateInterspector` so each ISA declares its stack architecture (`NoStack` for acc32, `SpStack` for risc-iv-32/vliw-iv/m68k, `ListStack` for f32a).
- For SP-based ISAs the simulator tracks the SP value just before the first decrease as the "settled top," skipping multi-step init transients (RiscIv `lui sp, 0; addi sp, sp, _` and M68k `movea.l label, A7; movea.l (A7), A7`).

## Example output
```
---
# stats
instructions: 87
sections: 160 bytes
code/data: 192 bytes (0..191)
stack: 32 bytes (566..597)
effective memory: 224 / 768 bytes
```

f32a uses `dstack depth: N (M bytes)` / `rstack depth: N (M bytes)` instead; acc32 omits the stack line. wrench-serv picks the block up automatically since the report HTML passes the CLI stdout through verbatim.

## Notable test changes
- All `*.result` golden files re-accepted with the trailing stats block.
- The `generated/factorial/*.yaml` configs were previously shared between `factorial.s` and `factorial_rec.s`; with stats the two now diverge, so `test/Spec.hs` disambiguates by tagging the recursive variant's golden files with `*.factorial_rec.<isa>.result`.

## Test plan
- [ ] `stack test` (all 523 golden + unit tests pass on a clean re-run)
- [ ] Spot-check `stack exec wrench -- test/golden/risc-iv-32/factorial_rec.s --isa risc-iv-32 -c test/golden/risc-iv-32/factorial_rec_input_5.yaml` shows non-zero stack bytes
- [ ] Spot-check f32a factorial run shows `dstack depth` / `rstack depth`
- [ ] Spot-check acc32 run shows no stack line
- [ ] Manual smoke via wrench-serv to confirm the stats block appears in the HTML report

Closes #83.