### PR TITLE
Expose execution & memory stats via report views

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,24 @@ See our [documentation](./docs/README.md) for detailed information about:
 - Configuration file format and options
 - Architecture-specific details
 
+### Execution and memory statistics
+
+Reports can include opt-in stat variables that summarize the run -- instructions executed, declared section sizes, and the address ranges actually touched at runtime. Add them to any report's `view` template (typically with `slice: last`):
+
+```yaml
+reports:
+    - name: stats
+      slice: last
+      view: |
+        sim:instruction-count: {sim:instruction-count}
+        layout:sections-size:  {layout:sections-size}
+        mem:instr-ranges:      {mem:instr-ranges}
+        mem:data-ranges:       {mem:data-ranges}
+        mem:io-ranges:         {mem:io-ranges}
+```
+
+Comparing `layout:*-size` against `mem:*-ranges` shows which declared bytes the program actually touched and which addresses it accessed outside any declared section (the stack region is the typical case). The full list of variables, including byte-count vs. range conventions, is in the [configuration documentation](./docs/README.md#view).
+
 ## Examples
 
 ### Factorial Calculation Example (RISC-IV)

--- a/docs/README.md
+++ b/docs/README.md
@@ -290,6 +290,33 @@ General state view expressions implemented for all ISAs:
 - `memory:<a>:<b>` -- Print memory dump between addresses `<a>` and `<b>`.
 - `io:<a>:dec`, `io:<a>:sym`, `io:<a>:hex` -- Print input-output stream state for the specific address in decimal, symbol, or hexadecimal format. Printable char codes: [32, 126]. Also `\0`, `\n` will be printed as is. Other non-printable characters will be replaced with `?`.
 
+Execution and memory statistics. These are typically used with `slice: last` to emit one final summary line; the values are the totals for the whole run.
+
+- `sim:instruction-count` -- Number of instructions executed so far. With `slice: all` it shows the running step counter (1, 2, ...); with `slice: last` it shows the total for the run.
+- `layout:sections-size` -- Sum of byte sizes of all sections (no gaps from `.org`).
+- `layout:text-sections-size`, `layout:data-sections-size` -- Same, split by section kind.
+- `mem:instr-ranges` -- Address ranges of instruction fetches at runtime, rendered as comma-separated `lo..hi` clusters (e.g. `0..75, 140..191`).
+- `mem:data-ranges` -- Address ranges of data reads and writes (merged into one set).
+- `mem:io-ranges` -- Address ranges of memory-mapped IO accesses.
+
+Example -- print a stats summary after the simulation finishes:
+
+```yaml
+reports:
+    - name: stats
+      slice: last
+      view: |
+        sim:instruction-count:     {sim:instruction-count}
+        layout:sections-size:      {layout:sections-size}
+        layout:text-sections-size: {layout:text-sections-size}
+        layout:data-sections-size: {layout:data-sections-size}
+        mem:instr-ranges:          {mem:instr-ranges}
+        mem:data-ranges:           {mem:data-ranges}
+        mem:io-ranges:             {mem:io-ranges}
+```
+
+Comparing `layout:*-size` with `mem:*-ranges` reveals which declared bytes the program actually touched and which addresses it accessed outside any declared section -- the stack region is a typical example.
+
 For ISA-specific state views, see the respective architecture documentation.
 
 ##### `assert`

--- a/docs/README.md
+++ b/docs/README.md
@@ -295,9 +295,9 @@ Execution and memory statistics. These are typically used with `slice: last` to 
 - `sim:instruction-count` -- Number of instructions executed so far. With `slice: all` it shows the running step counter (1, 2, ...); with `slice: last` it shows the total for the run.
 - `layout:sections-size` -- Sum of byte sizes of all sections (no gaps from `.org`).
 - `layout:text-sections-size`, `layout:data-sections-size` -- Same, split by section kind.
-- `mem:instr-ranges` -- Address ranges of instruction fetches at runtime, rendered as comma-separated `lo..hi` clusters (e.g. `0..75, 140..191`).
-- `mem:data-ranges` -- Address ranges of data reads and writes (merged into one set).
-- `mem:io-ranges` -- Address ranges of memory-mapped IO accesses.
+- `mem:instr-ranges` -- Address ranges of instruction fetches at runtime, rendered as comma-separated `lo..hi` clusters (e.g. `0x0..0x4b, 0x8c..0xbf`). Addresses are hex by default; append `:dec` or `:hex` to override (e.g. `{mem:instr-ranges:dec}` -> `0..75, 140..191`).
+- `mem:data-ranges` -- Address ranges of data reads and writes (merged into one set). Same `:dec`/`:hex` suffix.
+- `mem:io-ranges` -- Address ranges of memory-mapped IO accesses. Same `:dec`/`:hex` suffix.
 
 Example -- print a stats summary after the simulation finishes:
 

--- a/package.yaml
+++ b/package.yaml
@@ -43,7 +43,6 @@ dependencies:
   - base >= 4.7 && < 5
   - data-default
   - data-interval
-  - extended-reals
   - filepath
   - gitrev
   - megaparsec

--- a/package.yaml
+++ b/package.yaml
@@ -42,6 +42,8 @@ dependencies:
   - aeson-casing
   - base >= 4.7 && < 5
   - data-default
+  - data-interval
+  - extended-reals
   - filepath
   - gitrev
   - megaparsec

--- a/src/wrench/Wrench/Isa/Acc32.hs
+++ b/src/wrench/Wrench/Isa/Acc32.hs
@@ -282,15 +282,17 @@ instance (MachineWord w) => StateInterspector (MachineState (IoMem (Isa w w) w) 
             _ -> errorView v
 
 instance (MachineWord w) => Machine (MachineState (IoMem (Isa w w) w) w) (Isa w w) w where
-    instructionFetch =
-        get
-            <&> ( \case
-                    State{stopped = True} -> Left halted
-                    State{internalError = Just err} -> Left err
-                    State{pc, ram} -> do
-                        instruction <- readInstruction ram pc
-                        Right (pc, instruction)
-                )
+    instructionFetch = do
+        st <- get
+        case st of
+            State{stopped = True} -> return $ Left halted
+            State{internalError = Just err} -> return $ Left err
+            State{pc, ram} ->
+                case readInstruction ram pc of
+                    Left err -> return $ Left err
+                    Right (ram', instruction) -> do
+                        put st{ram = ram'}
+                        return $ Right (pc, instruction)
     instructionExecute pc instruction =
         case instruction of
             LoadImm a -> setAcc a >> nextPc

--- a/src/wrench/Wrench/Isa/F32a.hs
+++ b/src/wrench/Wrench/Isa/F32a.hs
@@ -366,15 +366,17 @@ instance (MachineWord w) => StateInterspector (MachineState (IoMem (Isa w w) w) 
             stack f _ = unknownFormat f
 
 instance (MachineWord w) => Machine (MachineState (IoMem (Isa w w) w) w) (Isa w w) w where
-    instructionFetch =
-        get
-            <&> ( \case
-                    State{stopped = True} -> Left halted
-                    State{internalError = Just err} -> Left err
-                    State{p, ram} -> do
-                        instruction <- readInstruction ram p
-                        return (p, instruction)
-                )
+    instructionFetch = do
+        st <- get
+        case st of
+            State{stopped = True} -> return $ Left halted
+            State{internalError = Just err} -> return $ Left err
+            State{p, ram} ->
+                case readInstruction ram p of
+                    Left err -> return $ Left err
+                    Right (ram', instruction) -> do
+                        put st{ram = ram'}
+                        return $ Right (p, instruction)
     instructionExecute _pc instruction =
         case instruction of
             Lit l -> do

--- a/src/wrench/Wrench/Isa/M68k.hs
+++ b/src/wrench/Wrench/Isa/M68k.hs
@@ -549,15 +549,17 @@ storeByte (Immediate _) _ = error "impossible to store into immediate destinatio
 storeByte arg _ = error $ "can not store byte: " <> show arg
 
 instance (MachineWord w) => Machine (MachineState (IoMem (Isa w w) w) w) (Isa w w) w where
-    instructionFetch =
-        get
-            <&> ( \case
-                    State{stopped = True} -> Left halted
-                    State{internalError = Just err} -> Left err
-                    State{pc, mem} -> do
-                        instruction <- readInstruction mem pc
-                        return (pc, instruction)
-                )
+    instructionFetch = do
+        st <- get
+        case st of
+            State{stopped = True} -> return $ Left halted
+            State{internalError = Just err} -> return $ Left err
+            State{pc, mem} ->
+                case readInstruction mem pc of
+                    Left err -> return $ Left err
+                    Right (mem', instruction) -> do
+                        put st{mem = mem'}
+                        return $ Right (pc, instruction)
 
     instructionExecute _pc instruction = do
         case instruction of

--- a/src/wrench/Wrench/Isa/RiscIv.hs
+++ b/src/wrench/Wrench/Isa/RiscIv.hs
@@ -453,15 +453,17 @@ instance (MachineWord w) => StateInterspector (MachineState (IoMem (Isa w w) w) 
             _ -> errorView v
 
 instance (MachineWord w) => Machine (MachineState (IoMem (Isa w w) w) w) (Isa w w) w where
-    instructionFetch =
-        get
-            <&> ( \case
-                    State{stopped = True} -> Left halted
-                    State{internalError = Just err} -> Left err
-                    State{pc, mem} -> do
-                        instruction <- readInstruction mem pc
-                        return (pc, instruction)
-                )
+    instructionFetch = do
+        st <- get
+        case st of
+            State{stopped = True} -> return $ Left halted
+            State{internalError = Just err} -> return $ Left err
+            State{pc, mem} ->
+                case readInstruction mem pc of
+                    Left err -> return $ Left err
+                    Right (mem', instruction) -> do
+                        put st{mem = mem'}
+                        return $ Right (pc, instruction)
 
     instructionExecute _pc instruction =
         case instruction of

--- a/src/wrench/Wrench/Isa/VliwIv.hs
+++ b/src/wrench/Wrench/Isa/VliwIv.hs
@@ -464,15 +464,17 @@ instance (MachineWord w) => StateInterspector (MachineState (IoMem (Isa w w) w) 
             _ -> errorView v
 
 instance (MachineWord w) => Machine (MachineState (IoMem (Isa w w) w) w) (Isa w w) w where
-    instructionFetch =
-        get
-            <&> ( \case
-                    State{stopped = True} -> Left halted
-                    State{internalError = Just err} -> Left err
-                    State{pc, mem} -> do
-                        instruction <- readInstruction mem pc
-                        return (pc, instruction)
-                )
+    instructionFetch = do
+        st <- get
+        case st of
+            State{stopped = True} -> return $ Left halted
+            State{internalError = Just err} -> return $ Left err
+            State{pc, mem} ->
+                case readInstruction mem pc of
+                    Left err -> return $ Left err
+                    Right (mem', instruction) -> do
+                        put st{mem = mem'}
+                        return $ Right (pc, instruction)
 
     instructionExecute _pc Isa{memOp, alu1Op, alu2Op, ctrlOp} = do
         -- Phase 1: Read all source operands and compute results (without modifying state)

--- a/src/wrench/Wrench/Machine.hs
+++ b/src/wrench/Wrench/Machine.hs
@@ -46,10 +46,14 @@ tellState machineState = modify
 tellError msg = modify $ \sim@Simulation{log} ->
     sim{log = TError msg : log}
 
-simulate :: (Machine st isa w) => Simulation st isa -> [Trace st isa]
+-- | Run the simulation and return both the recorded trace log and the final
+--   machine state. The final state carries the complete runtime accumulators
+--   (e.g. 'AccessLog' in 'IoMem'); per-state trace entries are recorded
+--   pre-step and therefore don't include the last instruction's accesses.
+simulate :: (Machine st isa w) => Simulation st isa -> ([Trace st isa], st)
 simulate sim =
-    let Simulation{log} = execState simulate' sim
-     in reverse log
+    let Simulation{log, machineState} = execState simulate' sim
+     in (reverse log, machineState)
 
 simulateInstructionStep :: (Machine st isa w) => State (Simulation st isa) ()
 simulateInstructionStep =
@@ -78,7 +82,7 @@ powerOn ::
     -> Int
     -> HashMap String w
     -> st
-    -> Either Text [Trace st isa]
+    -> Either Text ([Trace st isa], st)
 powerOn instructionLimits stateRecordLimits labels machineInitState = do
     let pc2label = fromList $ map (\(a, b) -> (fromEnum b, a)) $ toPairs labels
     Right

--- a/src/wrench/Wrench/Machine.hs
+++ b/src/wrench/Wrench/Machine.hs
@@ -19,7 +19,7 @@ data Simulation st isa = Simulation
 
 tellState :: st -> State (Simulation st isa) ()
 tellState machineState = modify
-    $ \sim@Simulation{log, stateRecordCount, stateRecordLimits, takePartOnStateRecordLimit} ->
+    $ \sim@Simulation{log, stateRecordCount, stateRecordLimits, takePartOnStateRecordLimit, instructionCount} ->
         if stateRecordCount >= stateRecordLimits
             then
                 let n = (stateRecordLimits `div` takePartOnStateRecordLimit)
@@ -27,7 +27,7 @@ tellState machineState = modify
                     rest' =
                         filter
                             ( \case
-                                TState _ -> False
+                                TState{} -> False
                                 _ -> True
                             )
                             rest
@@ -39,7 +39,7 @@ tellState machineState = modify
                         }
             else
                 sim
-                    { log = TState machineState : log
+                    { log = TState{tInstructionCount = instructionCount + 1, tState = machineState} : log
                     , stateRecordCount = stateRecordCount + 1
                     }
 

--- a/src/wrench/Wrench/Machine/Memory.hs
+++ b/src/wrench/Wrench/Machine/Memory.hs
@@ -222,12 +222,12 @@ ioPortByteCollision IoMem{mIoKeys} addr =
         parts = concatMap mkParts mIoKeys
      in (addr `elem` parts)
 
-recordInstr, recordData, recordIo :: Int -> Int -> IoMem isa w -> IoMem isa w
-recordInstr addr len io =
+noteInstrAccess, noteDataAccess, noteIoAccess :: Int -> Int -> IoMem isa w -> IoMem isa w
+noteInstrAccess addr len io =
     io{mAccessLog = (mAccessLog io){alInstr = recordRange addr len (alInstr (mAccessLog io))}}
-recordData addr len io =
+noteDataAccess addr len io =
     io{mAccessLog = (mAccessLog io){alData = recordRange addr len (alData (mAccessLog io))}}
-recordIo addr len io =
+noteIoAccess addr len io =
     io{mAccessLog = (mAccessLog io){alIo = recordRange addr len (alIo (mAccessLog io))}}
 
 instance (ByteSize isa, MachineWord w, Memory (Mem isa w) isa w) => Memory (IoMem isa w) isa w where
@@ -239,7 +239,7 @@ instance (ByteSize isa, MachineWord w, Memory (Mem isa w) isa w) => Memory (IoMe
                 Right (_mIoCells', instr)
                     | ioPortInstructionCollision io idx instr ->
                         Left $ "iomemory[" <> show idx <> "]: instruction in memory corrupted"
-                    | otherwise -> Right (recordInstr idx (byteSize instr) io, instr)
+                    | otherwise -> Right (noteInstrAccess idx (byteSize instr) io, instr)
 
     readByte io@IoMem{mIoByteToWord} idx
         | Just wordIdx <- mIoByteToWord !? idx = do
@@ -247,7 +247,7 @@ instance (ByteSize isa, MachineWord w, Memory (Mem isa w) isa w) => Memory (IoMe
             return (io', wordSplit word Unsafe.!! (idx - wordIdx))
     readByte io@IoMem{mIoCells} idx = do
         (mIoCells', v) <- readByte mIoCells idx
-        return (recordData idx 1 io{mIoCells = mIoCells'}, v)
+        return (noteDataAccess idx 1 io{mIoCells = mIoCells'}, v)
 
     readWord io idx | ioPortWordCollision io idx = Left $ "iomemory[" <> show idx <> "]: can't read word from input port"
     readWord io@IoMem{mIoStreams, mIoCells} idx = do
@@ -255,28 +255,28 @@ instance (ByteSize isa, MachineWord w, Memory (Mem isa w) isa w) => Memory (IoMe
             Just ([], _) -> Left $ "iomemory[" <> show idx <> "]: input is depleted"
             Just (i : is, os) -> do
                 let io' = io{mIoStreams = insert idx (is, os) mIoStreams}
-                Right (recordIo idx (byteSizeT @w) io', i)
+                Right (noteIoAccess idx (byteSizeT @w) io', i)
             Nothing -> do
                 (mIoCells', w) <- readWord mIoCells idx
-                return (recordData idx (byteSizeT @w) io{mIoCells = mIoCells'}, w)
+                return (noteDataAccess idx (byteSizeT @w) io{mIoCells = mIoCells'}, w)
 
     writeWord io idx _word | ioPortWordCollision io idx = Left $ "iomemory[" <> show idx <> "]: can't write word to input port"
     writeWord io idx word =
         case mIoStreams io !? idx of
-            Just (is, os) -> Right $ recordIo idx (byteSizeT @w) io{mIoStreams = insert idx (is, word : os) (mIoStreams io)}
+            Just (is, os) -> Right $ noteIoAccess idx (byteSizeT @w) io{mIoStreams = insert idx (is, word : os) (mIoStreams io)}
             Nothing -> do
                 mIoCells' <- writeWord (mIoCells io) idx word
-                return $ recordData idx (byteSizeT @w) io{mIoCells = mIoCells'}
+                return $ noteDataAccess idx (byteSizeT @w) io{mIoCells = mIoCells'}
 
     writeByte io idx _byte
         | ioPortByteCollision io idx =
             Left $ "iomemory[" <> show idx <> "]: can't write byte to input port"
     writeByte io idx byte =
         case mIoStreams io !? idx of
-            Just (is, os) -> Right $ recordIo idx 1 io{mIoStreams = insert idx (is, byteToWord byte : os) (mIoStreams io)}
+            Just (is, os) -> Right $ noteIoAccess idx 1 io{mIoStreams = insert idx (is, byteToWord byte : os) (mIoStreams io)}
             Nothing -> do
                 mIoCells' <- writeByte (mIoCells io) idx byte
-                return $ recordData idx 1 io{mIoCells = mIoCells'}
+                return $ noteDataAccess idx 1 io{mIoCells = mIoCells'}
 
     dumpCells = memoryData . mIoCells
 

--- a/src/wrench/Wrench/Machine/Memory.hs
+++ b/src/wrench/Wrench/Machine/Memory.hs
@@ -141,18 +141,23 @@ word32ToHex w =
      in "0x" <> replicate (8 - length hex) '0' <> hex
 
 class Memory m isa w | m -> isa w where
-    readInstruction :: m -> Int -> Either Text isa
+    readInstruction :: m -> Int -> Either Text (m, isa)
     readWord :: m -> Int -> Either Text (m, w)
     readByte :: m -> Int -> Either Text (m, Word8)
     writeWord :: m -> Int -> w -> Either Text m
     writeByte :: m -> Int -> Word8 -> Either Text m
     dumpCells :: m -> IntMap (Cell isa w)
 
+    -- | Runtime address ranges touched by reads/writes/instruction-fetches.
+    --   Default for memories that don't track (e.g. bare 'Mem') is empty.
+    accessLog :: m -> AccessLog
+    accessLog _ = emptyAccessLog
+
 instance
     (ByteSize isa, MachineWord w) =>
     Memory (Mem isa w) isa w
     where
-    readInstruction Mem{memoryData} idx =
+    readInstruction mem@Mem{memoryData} idx =
         case memoryData !? idx of
             Just (Instruction i)
                 | all
@@ -161,7 +166,7 @@ instance
                         _ -> False
                     )
                     [idx + 1 .. idx + byteSize i - 1] ->
-                    Right i
+                    Right (mem, i)
                 | otherwise -> Left $ "memory[" <> show idx <> "]: instruction in memory corrupted"
             Just InstructionPart -> Left $ "memory[" <> show idx <> "]: instruction in memory corrupted"
             Just (Value _) -> Left $ "memory[" <> show idx <> "]: can't read instruction from data cell"
@@ -215,16 +220,24 @@ ioPortByteCollision IoMem{mIoKeys} addr =
         parts = concatMap mkParts mIoKeys
      in (addr `elem` parts)
 
+recordInstr, recordData, recordIo :: Int -> Int -> IoMem isa w -> IoMem isa w
+recordInstr addr len io =
+    io{mAccessLog = (mAccessLog io){alInstr = recordRange addr len (alInstr (mAccessLog io))}}
+recordData addr len io =
+    io{mAccessLog = (mAccessLog io){alData = recordRange addr len (alData (mAccessLog io))}}
+recordIo addr len io =
+    io{mAccessLog = (mAccessLog io){alIo = recordRange addr len (alIo (mAccessLog io))}}
+
 instance (ByteSize isa, MachineWord w, Memory (Mem isa w) isa w) => Memory (IoMem isa w) isa w where
     readInstruction io@IoMem{mIoStreams, mIoCells} idx =
         case mIoStreams !? idx of
             Just _ -> Left $ "iomemory[" <> show idx <> "]: instruction in memory corrupted"
             Nothing -> case readInstruction mIoCells idx of
                 Left err -> Left err
-                Right instr
+                Right (_mIoCells', instr)
                     | ioPortInstructionCollision io idx instr ->
                         Left $ "iomemory[" <> show idx <> "]: instruction in memory corrupted"
-                    | otherwise -> Right instr
+                    | otherwise -> Right (recordInstr idx (byteSize instr) io, instr)
 
     readByte io@IoMem{mIoByteToWord} idx
         | Just wordIdx <- mIoByteToWord !? idx = do
@@ -232,7 +245,7 @@ instance (ByteSize isa, MachineWord w, Memory (Mem isa w) isa w) => Memory (IoMe
             return (io', wordSplit word Unsafe.!! (idx - wordIdx))
     readByte io@IoMem{mIoCells} idx = do
         (mIoCells', v) <- readByte mIoCells idx
-        return (io{mIoCells = mIoCells'}, v)
+        return (recordData idx 1 io{mIoCells = mIoCells'}, v)
 
     readWord io idx | ioPortWordCollision io idx = Left $ "iomemory[" <> show idx <> "]: can't read word from input port"
     readWord io@IoMem{mIoStreams, mIoCells} idx = do
@@ -240,27 +253,29 @@ instance (ByteSize isa, MachineWord w, Memory (Mem isa w) isa w) => Memory (IoMe
             Just ([], _) -> Left $ "iomemory[" <> show idx <> "]: input is depleted"
             Just (i : is, os) -> do
                 let io' = io{mIoStreams = insert idx (is, os) mIoStreams}
-                Right (io', i)
+                Right (recordIo idx (byteSizeT @w) io', i)
             Nothing -> do
                 (mIoCells', w) <- readWord mIoCells idx
-                return (io{mIoCells = mIoCells'}, w)
+                return (recordData idx (byteSizeT @w) io{mIoCells = mIoCells'}, w)
 
     writeWord io idx _word | ioPortWordCollision io idx = Left $ "iomemory[" <> show idx <> "]: can't write word to input port"
     writeWord io idx word =
         case mIoStreams io !? idx of
-            Just (is, os) -> Right io{mIoStreams = insert idx (is, word : os) (mIoStreams io)}
+            Just (is, os) -> Right $ recordIo idx (byteSizeT @w) io{mIoStreams = insert idx (is, word : os) (mIoStreams io)}
             Nothing -> do
                 mIoCells' <- writeWord (mIoCells io) idx word
-                return io{mIoCells = mIoCells'}
+                return $ recordData idx (byteSizeT @w) io{mIoCells = mIoCells'}
 
     writeByte io idx _byte
         | ioPortByteCollision io idx =
             Left $ "iomemory[" <> show idx <> "]: can't write byte to input port"
     writeByte io idx byte =
         case mIoStreams io !? idx of
-            Just (is, os) -> Right io{mIoStreams = insert idx (is, byteToWord byte : os) (mIoStreams io)}
+            Just (is, os) -> Right $ recordIo idx 1 io{mIoStreams = insert idx (is, byteToWord byte : os) (mIoStreams io)}
             Nothing -> do
                 mIoCells' <- writeByte (mIoCells io) idx byte
-                return io{mIoCells = mIoCells'}
+                return $ recordData idx 1 io{mIoCells = mIoCells'}
 
     dumpCells = memoryData . mIoCells
+
+    accessLog = mAccessLog

--- a/src/wrench/Wrench/Machine/Memory.hs
+++ b/src/wrench/Wrench/Machine/Memory.hs
@@ -10,6 +10,7 @@ module Wrench.Machine.Memory (
     prepareDump,
     prettyDump,
     DumpStats (..),
+    computeDumpStats,
 ) where
 
 import Data.Bits (FiniteBits, finiteBitSize)
@@ -33,7 +34,7 @@ data DumpStats = DumpStats
     }
     deriving (Eq, Show)
 
-prepareDump :: (ByteSize isa, MachineWord w) => Int -> [Section isa w w] -> (Mem isa w, DumpStats)
+prepareDump :: (ByteSize isa, MachineWord w) => Int -> [Section isa w w] -> Mem isa w
 prepareDump memorySize sections =
     let addSection cells offset dump =
             let dump' = zip [offset ..] cells
@@ -68,24 +69,25 @@ prepareDump memorySize sections =
                     sections
         dumpSize = maximum1 $ 0 :| keys fromSections
         placeholder = map (,Value 0) [0 .. memorySize - 1]
-        textBytes = sum [byteSize s | s@Code{} <- sections]
-        dataBytes = sum [byteSize s | s@Data{} <- sections]
-        stats =
-            DumpStats
-                { dsSectionsTotalBytes = textBytes + dataBytes
-                , dsTextSectionsBytes = textBytes
-                , dsDataSectionsBytes = dataBytes
-                }
      in if dumpSize > memorySize
             then
                 error $ "error: can not fit translation results in memory, need: " <> show dumpSize <> " available: " <> show memorySize
             else
-                ( Mem
+                Mem
                     { memorySize
                     , memoryData = fromList (placeholder <> fromSections)
                     }
-                , stats
-                )
+
+-- | Translation-time layout summary derived from the section list.
+computeDumpStats :: (ByteSize isa, ByteSizeT w) => [Section isa w l] -> DumpStats
+computeDumpStats sections =
+    let textBytes = sum [byteSize s | s@Code{} <- sections]
+        dataBytes = sum [byteSize s | s@Data{} <- sections]
+     in DumpStats
+            { dsSectionsTotalBytes = textBytes + dataBytes
+            , dsTextSectionsBytes = textBytes
+            , dsDataSectionsBytes = dataBytes
+            }
 
 isValue Value{} = True
 isValue _ = False

--- a/src/wrench/Wrench/Machine/Memory.hs
+++ b/src/wrench/Wrench/Machine/Memory.hs
@@ -9,6 +9,7 @@ module Wrench.Machine.Memory (
     word32ToHex,
     prepareDump,
     prettyDump,
+    DumpStats (..),
 ) where
 
 import Data.Bits (FiniteBits, finiteBitSize)
@@ -20,7 +21,19 @@ import Relude.Unsafe qualified as Unsafe
 import Wrench.Machine.Types
 import Wrench.Translator.Types
 
-prepareDump :: (ByteSize isa, MachineWord w) => Int -> [Section isa w w] -> Mem isa w
+-- | Translation-time memory layout statistics, surfaced to report views via the
+--   @layout:*@ namespace.
+data DumpStats = DumpStats
+    { dsSectionsTotalBytes :: !Int
+    -- ^ Sum of byte sizes of all sections (no .org gaps).
+    , dsTextSectionsBytes :: !Int
+    -- ^ Sum of byte sizes of code (text) sections only.
+    , dsDataSectionsBytes :: !Int
+    -- ^ Sum of byte sizes of data sections only.
+    }
+    deriving (Eq, Show)
+
+prepareDump :: (ByteSize isa, MachineWord w) => Int -> [Section isa w w] -> (Mem isa w, DumpStats)
 prepareDump memorySize sections =
     let addSection cells offset dump =
             let dump' = zip [offset ..] cells
@@ -55,14 +68,24 @@ prepareDump memorySize sections =
                     sections
         dumpSize = maximum1 $ 0 :| keys fromSections
         placeholder = map (,Value 0) [0 .. memorySize - 1]
+        textBytes = sum [byteSize s | s@Code{} <- sections]
+        dataBytes = sum [byteSize s | s@Data{} <- sections]
+        stats =
+            DumpStats
+                { dsSectionsTotalBytes = textBytes + dataBytes
+                , dsTextSectionsBytes = textBytes
+                , dsDataSectionsBytes = dataBytes
+                }
      in if dumpSize > memorySize
             then
                 error $ "error: can not fit translation results in memory, need: " <> show dumpSize <> " available: " <> show memorySize
             else
-                Mem
+                ( Mem
                     { memorySize
                     , memoryData = fromList (placeholder <> fromSections)
                     }
+                , stats
+                )
 
 isValue Value{} = True
 isValue _ = False

--- a/src/wrench/Wrench/Machine/Types.hs
+++ b/src/wrench/Wrench/Machine/Types.hs
@@ -31,6 +31,10 @@ module Wrench.Machine.Types (
 
 import Data.Bits
 import Data.Default (Default, def)
+import Data.ExtendedReal (Extended (Finite))
+import Data.Interval qualified as I
+import Data.IntervalSet (IntervalSet)
+import Data.IntervalSet qualified as IS
 import Data.Text qualified as T
 import Relude
 import Relude.Extra (keys)
@@ -226,30 +230,37 @@ data Cell isa w
 -----------------------------------------------------------
 -- Address-range accounting (mem:* stats)
 
--- | Sorted, non-overlapping, inclusive address ranges. Adjacent ranges
---   (one ending at N, the next starting at N+1) are merged on insert so the
---   list always reflects maximally-coalesced clusters of accesses.
-newtype Intervals = Intervals {unIntervals :: [(Int, Int)]}
+-- | Sorted, non-overlapping integer address ranges with adjacency merging.
+--   Backed by 'IntervalSet' 'Integer' from the @data-interval@ package.
+--
+--   We store each access as the half-open interval @[lo, hi+1)@ so that two
+--   integer-adjacent accesses (one ending at N, the next starting at N+1)
+--   share a boundary and get merged by 'IS.insert'. On render we convert
+--   back to the inclusive @"lo..hi"@ form by subtracting 1 from the upper.
+newtype Intervals = Intervals {unIntervals :: IntervalSet Integer}
     deriving (Eq, Show)
 
 emptyIntervals :: Intervals
-emptyIntervals = Intervals []
+emptyIntervals = Intervals IS.empty
 
 -- | Record an access spanning @[addr .. addr+len-1]@. Length must be ≥ 1.
 recordRange :: Int -> Int -> Intervals -> Intervals
-recordRange addr len (Intervals xs) = Intervals (insertMerge addr (addr + len - 1) xs)
-    where
-        insertMerge l h [] = [(l, h)]
-        insertMerge l h ((l', h') : rest)
-            | h + 1 < l' = (l, h) : (l', h') : rest -- fully before the next interval
-            | l > h' + 1 = (l', h') : insertMerge l h rest -- fully after this interval
-            | otherwise = insertMerge (min l l') (max h h') rest -- overlap or touch — merge and re-insert
+recordRange addr len (Intervals s) =
+    let lo = Finite (toInteger addr)
+        hi = Finite (toInteger (addr + len))
+     in Intervals (IS.insert (lo I.<=..< hi) s)
 
 -- | Render intervals as @"lo1..hi1, lo2..hi2"@ (or @"-"@ when empty).
 renderIntervals :: Intervals -> Text
-renderIntervals (Intervals []) = "-"
-renderIntervals (Intervals xs) =
-    T.intercalate ", " [show lo <> ".." <> show hi | (lo, hi) <- xs]
+renderIntervals (Intervals s) =
+    case IS.toAscList s of
+        [] -> "-"
+        is -> T.intercalate ", " (map renderInterval is)
+    where
+        renderInterval i =
+            let lo = case I.lowerBound i of Finite n -> n; _ -> error "Intervals: unexpected infinite lower bound"
+                hi = case I.upperBound i of Finite n -> n - 1; _ -> error "Intervals: unexpected infinite upper bound"
+             in show lo <> ".." <> show hi
 
 -- | Runtime access ranges accumulated by 'IoMem' while the program runs.
 data AccessLog = AccessLog

--- a/src/wrench/Wrench/Machine/Types.hs
+++ b/src/wrench/Wrench/Machine/Types.hs
@@ -11,6 +11,7 @@ module Wrench.Machine.Types (
     emptyIntervals,
     recordRange,
     renderIntervals,
+    renderIntervalsHex,
     AccessLog (..),
     emptyAccessLog,
     MachineWord,
@@ -35,6 +36,7 @@ import Data.Interval qualified as I
 import Data.IntervalSet (IntervalSet)
 import Data.IntervalSet qualified as IS
 import Data.Text qualified as T
+import Numeric (showHex)
 import Relude
 import Relude.Extra (keys)
 
@@ -249,9 +251,10 @@ recordRange addr len (Intervals s) =
         hi = I.Finite (toInteger (addr + len))
      in Intervals (IS.insert (lo I.<=..< hi) s)
 
--- | Render intervals as @"lo1..hi1, lo2..hi2"@ (or @"-"@ when empty).
-renderIntervals :: Intervals -> Text
-renderIntervals (Intervals s) =
+-- | Render intervals as @"lo1..hi1, lo2..hi2"@ (or @"-"@ when empty),
+--   using the given per-address formatter for both bounds.
+renderIntervalsWith :: (Integer -> Text) -> Intervals -> Text
+renderIntervalsWith fmt (Intervals s) =
     case IS.toAscList s of
         [] -> "-"
         is -> T.intercalate ", " (map renderInterval is)
@@ -259,7 +262,15 @@ renderIntervals (Intervals s) =
         renderInterval i =
             let lo = case I.lowerBound i of I.Finite n -> n; _ -> error "Intervals: unexpected infinite lower bound"
                 hi = case I.upperBound i of I.Finite n -> n - 1; _ -> error "Intervals: unexpected infinite upper bound"
-             in show lo <> ".." <> show hi
+             in fmt lo <> ".." <> fmt hi
+
+-- | Decimal-formatted ranges.
+renderIntervals :: Intervals -> Text
+renderIntervals = renderIntervalsWith show
+
+-- | Hex-formatted ranges (@0xNN@ lowercase, no padding).
+renderIntervalsHex :: Intervals -> Text
+renderIntervalsHex = renderIntervalsWith (\n -> "0x" <> T.pack (showHex n ""))
 
 -- | Runtime access ranges accumulated by 'IoMem' while the program runs.
 data AccessLog = AccessLog

--- a/src/wrench/Wrench/Machine/Types.hs
+++ b/src/wrench/Wrench/Machine/Types.hs
@@ -7,6 +7,12 @@ module Wrench.Machine.Types (
     Cell (..),
     InitState (..),
     StateInterspector (..),
+    Intervals (..),
+    emptyIntervals,
+    recordRange,
+    renderIntervals,
+    AccessLog (..),
+    emptyAccessLog,
     MachineWord,
     FromSign (..),
     RegisterId,
@@ -25,6 +31,7 @@ module Wrench.Machine.Types (
 
 import Data.Bits
 import Data.Default (Default, def)
+import Data.Text qualified as T
 import Relude
 import Relude.Extra (keys)
 
@@ -194,6 +201,8 @@ data IoMem isa w = IoMem
     , mIoCells :: Mem isa w
     , mIoKeys :: [Int]
     , mIoByteToWord :: IntMap Int
+    , mAccessLog :: !AccessLog
+    -- ^ Tracks the address ranges touched at runtime, surfaced via @mem:*@.
     }
     deriving (Eq, Show)
 
@@ -203,6 +212,7 @@ mkIoMem streams cells =
         { mIoStreams = streams
         , mIoCells = cells
         , mIoKeys = keys streams
+        , mAccessLog = emptyAccessLog
         , mIoByteToWord =
             fromList $ concatMap (\i -> map (,i) [i .. i + byteSizeT @w - 1]) (keys streams)
         }
@@ -212,3 +222,45 @@ data Cell isa w
     | InstructionPart
     | Value Word8
     deriving (Eq, Show)
+
+-----------------------------------------------------------
+-- Address-range accounting (mem:* stats)
+
+-- | Sorted, non-overlapping, inclusive address ranges. Adjacent ranges
+--   (one ending at N, the next starting at N+1) are merged on insert so the
+--   list always reflects maximally-coalesced clusters of accesses.
+newtype Intervals = Intervals {unIntervals :: [(Int, Int)]}
+    deriving (Eq, Show)
+
+emptyIntervals :: Intervals
+emptyIntervals = Intervals []
+
+-- | Record an access spanning @[addr .. addr+len-1]@. Length must be ≥ 1.
+recordRange :: Int -> Int -> Intervals -> Intervals
+recordRange addr len (Intervals xs) = Intervals (insertMerge addr (addr + len - 1) xs)
+    where
+        insertMerge l h [] = [(l, h)]
+        insertMerge l h ((l', h') : rest)
+            | h + 1 < l' = (l, h) : (l', h') : rest -- fully before the next interval
+            | l > h' + 1 = (l', h') : insertMerge l h rest -- fully after this interval
+            | otherwise = insertMerge (min l l') (max h h') rest -- overlap or touch — merge and re-insert
+
+-- | Render intervals as @"lo1..hi1, lo2..hi2"@ (or @"-"@ when empty).
+renderIntervals :: Intervals -> Text
+renderIntervals (Intervals []) = "-"
+renderIntervals (Intervals xs) =
+    T.intercalate ", " [show lo <> ".." <> show hi | (lo, hi) <- xs]
+
+-- | Runtime access ranges accumulated by 'IoMem' while the program runs.
+data AccessLog = AccessLog
+    { alInstr :: !Intervals
+    -- ^ Instruction-fetch addresses.
+    , alData :: !Intervals
+    -- ^ Data read/write addresses (merged — we don't distinguish direction).
+    , alIo :: !Intervals
+    -- ^ Memory-mapped IO addresses touched.
+    }
+    deriving (Eq, Show)
+
+emptyAccessLog :: AccessLog
+emptyAccessLog = AccessLog{alInstr = emptyIntervals, alData = emptyIntervals, alIo = emptyIntervals}

--- a/src/wrench/Wrench/Machine/Types.hs
+++ b/src/wrench/Wrench/Machine/Types.hs
@@ -172,7 +172,13 @@ halted :: Text
 halted = "halted"
 
 data Trace st isa
-    = TState st
+    = -- | A captured machine state, tagged with the 1-indexed instruction step
+      --   number it sits before (i.e. the @sim:instruction-count@ value at this
+      --   point in the trace).
+      TState
+        { tInstructionCount :: !Int
+        , tState :: !st
+        }
     | TError Text
     | TWarn Text
     deriving (Show)

--- a/src/wrench/Wrench/Machine/Types.hs
+++ b/src/wrench/Wrench/Machine/Types.hs
@@ -31,7 +31,6 @@ module Wrench.Machine.Types (
 
 import Data.Bits
 import Data.Default (Default, def)
-import Data.ExtendedReal (Extended (Finite))
 import Data.Interval qualified as I
 import Data.IntervalSet (IntervalSet)
 import Data.IntervalSet qualified as IS
@@ -246,8 +245,8 @@ emptyIntervals = Intervals IS.empty
 -- | Record an access spanning @[addr .. addr+len-1]@. Length must be ≥ 1.
 recordRange :: Int -> Int -> Intervals -> Intervals
 recordRange addr len (Intervals s) =
-    let lo = Finite (toInteger addr)
-        hi = Finite (toInteger (addr + len))
+    let lo = I.Finite (toInteger addr)
+        hi = I.Finite (toInteger (addr + len))
      in Intervals (IS.insert (lo I.<=..< hi) s)
 
 -- | Render intervals as @"lo1..hi1, lo2..hi2"@ (or @"-"@ when empty).
@@ -258,8 +257,8 @@ renderIntervals (Intervals s) =
         is -> T.intercalate ", " (map renderInterval is)
     where
         renderInterval i =
-            let lo = case I.lowerBound i of Finite n -> n; _ -> error "Intervals: unexpected infinite lower bound"
-                hi = case I.upperBound i of Finite n -> n - 1; _ -> error "Intervals: unexpected infinite upper bound"
+            let lo = case I.lowerBound i of I.Finite n -> n; _ -> error "Intervals: unexpected infinite lower bound"
+                hi = case I.upperBound i of I.Finite n -> n - 1; _ -> error "Intervals: unexpected infinite upper bound"
              in show lo <> ".." <> show hi
 
 -- | Runtime access ranges accumulated by 'IoMem' while the program runs.

--- a/src/wrench/Wrench/Report.hs
+++ b/src/wrench/Wrench/Report.hs
@@ -117,11 +117,15 @@ selectSlice LastSlice = take 1 . reverse
 
 prepareStateView line TranslatorResult{labels, dumpStats} instrCount st =
     let DumpStats{dsSectionsTotalBytes, dsTextSectionsBytes, dsDataSectionsBytes} = dumpStats
+        AccessLog{alInstr, alData, alIo} = accessLog (memoryDump st)
         resolver v = case v of
             "sim:instruction-count" -> show instrCount
             "layout:sections" -> show dsSectionsTotalBytes
             "layout:text-sections" -> show dsTextSectionsBytes
             "layout:data-sections" -> show dsDataSectionsBytes
+            "mem:instr-range" -> renderIntervals alInstr
+            "mem:data-range" -> renderIntervals alData
+            "mem:io-range" -> renderIntervals alIo
             _ -> reprState labels st v
      in toString $ substituteBrackets resolver line
 
@@ -136,7 +140,7 @@ defaultView labels st "pc:label" =
         (l, _a) : _ -> "@" <> toText l
         _ -> ""
 defaultView _labels st "instruction" =
-    Just $ either error show (readInstruction (memoryDump st) (programCounter st))
+    Just $ either error (show . snd) (readInstruction (memoryDump st) (programCounter st))
 defaultView labels st v =
     case T.splitOn ":" v of
         ["pc"] -> Just $ reprState labels st "pc:dec"

--- a/src/wrench/Wrench/Report.hs
+++ b/src/wrench/Wrench/Report.hs
@@ -122,12 +122,12 @@ prepareStateView line TranslatorResult{labels, dumpStats} finalState instrCount 
         AccessLog{alInstr, alData, alIo} = accessLog (memoryDump finalState)
         resolver v = case v of
             "sim:instruction-count" -> show instrCount
-            "layout:sections" -> show dsSectionsTotalBytes
-            "layout:text-sections" -> show dsTextSectionsBytes
-            "layout:data-sections" -> show dsDataSectionsBytes
-            "mem:instr-range" -> renderIntervals alInstr
-            "mem:data-range" -> renderIntervals alData
-            "mem:io-range" -> renderIntervals alIo
+            "layout:sections-size" -> show dsSectionsTotalBytes
+            "layout:text-sections-size" -> show dsTextSectionsBytes
+            "layout:data-sections-size" -> show dsDataSectionsBytes
+            "mem:instr-ranges" -> renderIntervals alInstr
+            "mem:data-ranges" -> renderIntervals alData
+            "mem:io-ranges" -> renderIntervals alIo
             _ -> reprState labels st v
      in toString $ substituteBrackets resolver line
 

--- a/src/wrench/Wrench/Report.hs
+++ b/src/wrench/Wrench/Report.hs
@@ -67,7 +67,7 @@ prepareReport
                         $ filter (not . null)
                         $ map
                             ( \case
-                                (TState st) -> prepareStateView rvView' trResult st
+                                TState{tInstructionCount, tState} -> prepareStateView rvView' trResult tInstructionCount tState
                                 (TError err) -> "ERROR: " <> toString err <> "\n"
                                 (TWarn warn) -> "WARN: " <> toString warn <> "\n"
                             )
@@ -115,8 +115,11 @@ selectSlice LastSlice = take 1 . reverse
 
 -----------------------------------------------------------
 
-prepareStateView line TranslatorResult{labels} st =
-    toString $ substituteBrackets (reprState labels st) line
+prepareStateView line TranslatorResult{labels} instrCount st =
+    let resolver v = case v of
+            "sim:instruction-count" -> show instrCount
+            _ -> reprState labels st v
+     in toString $ substituteBrackets resolver line
 
 defaultView ::
     (ByteSize isa, MachineWord w, Memory m isa w, Show isa, StateInterspector st m isa w) =>

--- a/src/wrench/Wrench/Report.hs
+++ b/src/wrench/Wrench/Report.hs
@@ -55,6 +55,7 @@ instance FromJSON ReportConf where
 prepareReport
     trResult@TranslatorResult{}
     verbose
+    finalState
     records
     rc@ReportConf{rcName, rcSlice, rcAssert, rcView} =
         let header = maybe "" ("# " <>) rcName
@@ -67,7 +68,8 @@ prepareReport
                         $ filter (not . null)
                         $ map
                             ( \case
-                                TState{tInstructionCount, tState} -> prepareStateView rvView' trResult tInstructionCount tState
+                                TState{tInstructionCount, tState} ->
+                                    prepareStateView rvView' trResult finalState tInstructionCount tState
                                 (TError err) -> "ERROR: " <> toString err <> "\n"
                                 (TWarn warn) -> "WARN: " <> toString warn <> "\n"
                             )
@@ -115,9 +117,9 @@ selectSlice LastSlice = take 1 . reverse
 
 -----------------------------------------------------------
 
-prepareStateView line TranslatorResult{labels, dumpStats} instrCount st =
+prepareStateView line TranslatorResult{labels, dumpStats} finalState instrCount st =
     let DumpStats{dsSectionsTotalBytes, dsTextSectionsBytes, dsDataSectionsBytes} = dumpStats
-        AccessLog{alInstr, alData, alIo} = accessLog (memoryDump st)
+        AccessLog{alInstr, alData, alIo} = accessLog (memoryDump finalState)
         resolver v = case v of
             "sim:instruction-count" -> show instrCount
             "layout:sections" -> show dsSectionsTotalBytes

--- a/src/wrench/Wrench/Report.hs
+++ b/src/wrench/Wrench/Report.hs
@@ -115,9 +115,13 @@ selectSlice LastSlice = take 1 . reverse
 
 -----------------------------------------------------------
 
-prepareStateView line TranslatorResult{labels} instrCount st =
-    let resolver v = case v of
+prepareStateView line TranslatorResult{labels, dumpStats} instrCount st =
+    let DumpStats{dsSectionsTotalBytes, dsTextSectionsBytes, dsDataSectionsBytes} = dumpStats
+        resolver v = case v of
             "sim:instruction-count" -> show instrCount
+            "layout:sections" -> show dsSectionsTotalBytes
+            "layout:text-sections" -> show dsTextSectionsBytes
+            "layout:data-sections" -> show dsDataSectionsBytes
             _ -> reprState labels st v
      in toString $ substituteBrackets resolver line
 

--- a/src/wrench/Wrench/Report.hs
+++ b/src/wrench/Wrench/Report.hs
@@ -120,15 +120,21 @@ selectSlice LastSlice = take 1 . reverse
 prepareStateView line TranslatorResult{labels, dumpStats} finalState instrCount st =
     let DumpStats{dsSectionsTotalBytes, dsTextSectionsBytes, dsDataSectionsBytes} = dumpStats
         AccessLog{alInstr, alData, alIo} = accessLog (memoryDump finalState)
-        resolver v = case v of
-            "sim:instruction-count" -> show instrCount
-            "layout:sections-size" -> show dsSectionsTotalBytes
-            "layout:text-sections-size" -> show dsTextSectionsBytes
-            "layout:data-sections-size" -> show dsDataSectionsBytes
-            "mem:instr-ranges" -> renderIntervals alInstr
-            "mem:data-ranges" -> renderIntervals alData
-            "mem:io-ranges" -> renderIntervals alIo
+        resolver v = case T.splitOn ":" v of
+            ["sim", "instruction-count"] -> show instrCount
+            ["layout", "sections-size"] -> show dsSectionsTotalBytes
+            ["layout", "text-sections-size"] -> show dsTextSectionsBytes
+            ["layout", "data-sections-size"] -> show dsDataSectionsBytes
+            ["mem", "instr-ranges"] -> renderIntervalsHex alInstr
+            ["mem", "instr-ranges", fmt] -> rangesFmt fmt alInstr
+            ["mem", "data-ranges"] -> renderIntervalsHex alData
+            ["mem", "data-ranges", fmt] -> rangesFmt fmt alData
+            ["mem", "io-ranges"] -> renderIntervalsHex alIo
+            ["mem", "io-ranges", fmt] -> rangesFmt fmt alIo
             _ -> reprState labels st v
+        rangesFmt "dec" = renderIntervals
+        rangesFmt "hex" = renderIntervalsHex
+        rangesFmt fmt = const (unknownFormat fmt)
      in toString $ substituteBrackets resolver line
 
 defaultView ::

--- a/src/wrench/Wrench/Translator.hs
+++ b/src/wrench/Wrench/Translator.hs
@@ -18,6 +18,7 @@ import Wrench.Translator.Types
 data TranslatorResult mem w = TranslatorResult
     { dump :: !mem
     , labels :: !(HashMap String w)
+    , dumpStats :: !DumpStats
     }
     deriving (Show)
 
@@ -83,6 +84,6 @@ translate memorySize fn src =
                 (Right labels) ->
                     let resolveLabel l = (labels !? l)
                         code = map (uncurry (derefSection resolveLabel)) (markupSectionOffsets 0 sections)
-                        dump = prepareDump memorySize code
-                     in Right $ TranslatorResult dump labels
+                        (dump, stats) = prepareDump memorySize code
+                     in Right $ TranslatorResult dump labels stats
         Left err -> Left $ toText $ errorBundlePretty err

--- a/src/wrench/Wrench/Translator.hs
+++ b/src/wrench/Wrench/Translator.hs
@@ -84,6 +84,7 @@ translate memorySize fn src =
                 (Right labels) ->
                     let resolveLabel l = (labels !? l)
                         code = map (uncurry (derefSection resolveLabel)) (markupSectionOffsets 0 sections)
-                        (dump, stats) = prepareDump memorySize code
+                        dump = prepareDump memorySize code
+                        stats = computeDumpStats code
                      in Right $ TranslatorResult dump labels stats
         Left err -> Left $ toText $ errorBundlePretty err

--- a/src/wrench/Wrench/Wrench.hs
+++ b/src/wrench/Wrench/Wrench.hs
@@ -165,9 +165,9 @@ wrench Options{input = fn, verbose, maxStateLogLimit} Config{cMemorySize, cLimit
         ioDump = mkIoMem mIoStreams dump
         st :: st = initState (fromEnum pc) ioDump randomStream
 
-    traceLog <- powerOn cLimit maxStateLogLimit labels st
+    (traceLog, finalState) <- powerOn cLimit maxStateLogLimit labels st
 
-    let reports = maybe [] (map (prepareReport trResult verbose traceLog)) cReports
+    let reports = maybe [] (map (prepareReport trResult verbose finalState traceLog)) cReports
         isSuccess = all fst reports
         reportTexts = map snd reports
 

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -290,7 +290,7 @@ goldenTranslate' isa fn =
     goldenVsString (fn2name fn) (fn <> "." <> isaPath isa <> ".result") $ do
         src <- decodeUtf8 <$> readFileBS fn
         case translate @isa @Int32 1000 fn src of
-            Right (TranslatorResult dump labels) ->
+            Right (TranslatorResult dump labels _stats) ->
                 return $ encodeUtf8 $ intercalate "\n---\n" [prettyLabels labels, prettyDump labels $ dumpCells dump, ""]
             Left err ->
                 error $ "Translation failed: " <> show err

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -72,6 +72,7 @@ tests =
                 , goldenSimulate RiscIv "test/golden/risc-iv-32/ble_bleu.s" "test/golden/risc-iv-32/ble_bleu.yaml"
                 , goldenSimulate RiscIv "test/golden/risc-iv-32/lui_addi.s" "test/golden/risc-iv-32/lui_addi.yaml"
                 , goldenSimulate RiscIv "test/golden/risc-iv-32/sb.s" "test/golden/risc-iv-32/sb.yaml"
+                , goldenSimulate RiscIv "test/golden/risc-iv-32/multi_sections.s" "test/golden/risc-iv-32/multi_sections.yaml"
                 , testGroup
                     "Factorial"
                     [ goldenSimulate RiscIv "test/golden/risc-iv-32/factorial.s" "test/golden/risc-iv-32/factorial_input_5.yaml"

--- a/test/golden/risc-iv-32/factorial_input_5.risc-iv-32.result
+++ b/test/golden/risc-iv-32/factorial_input_5.risc-iv-32.result
@@ -94,6 +94,6 @@ instructions: 42
 sections: 128
 text: 120
 data: 8
-mem-instr: 8..55, 108..123
+mem-instr: 8..55, 108..127
 mem-data: 0..7
 mem-io: 128..135

--- a/test/golden/risc-iv-32/factorial_input_5.risc-iv-32.result
+++ b/test/golden/risc-iv-32/factorial_input_5.risc-iv-32.result
@@ -90,10 +90,10 @@ numio[0x80]: [] >>> []
 numio[0x84]: [] >>> [120]
 ---
 # stats
-instructions: 42
-sections: 128
-text: 120
-data: 8
-mem-instr: 8..55, 108..127
-mem-data: 0..7
-mem-io: 128..135
+sim:instruction-count: 42
+layout:sections-size: 128
+layout:text-sections-size: 120
+layout:data-sections-size: 8
+mem:instr-ranges: 8..55, 108..127
+mem:data-ranges: 0..7
+mem:io-ranges: 128..135

--- a/test/golden/risc-iv-32/factorial_input_5.risc-iv-32.result
+++ b/test/golden/risc-iv-32/factorial_input_5.risc-iv-32.result
@@ -91,3 +91,6 @@ numio[0x84]: [] >>> [120]
 ---
 # stats
 instructions: 42
+sections: 128
+text: 120
+data: 8

--- a/test/golden/risc-iv-32/factorial_input_5.risc-iv-32.result
+++ b/test/golden/risc-iv-32/factorial_input_5.risc-iv-32.result
@@ -94,3 +94,6 @@ instructions: 42
 sections: 128
 text: 120
 data: 8
+mem-instr: 8..55, 108..123
+mem-data: 0..7
+mem-io: 128..135

--- a/test/golden/risc-iv-32/factorial_input_5.risc-iv-32.result
+++ b/test/golden/risc-iv-32/factorial_input_5.risc-iv-32.result
@@ -88,3 +88,6 @@
 # result
 numio[0x80]: [] >>> []
 numio[0x84]: [] >>> [120]
+---
+# stats
+instructions: 42

--- a/test/golden/risc-iv-32/factorial_input_5.risc-iv-32.result
+++ b/test/golden/risc-iv-32/factorial_input_5.risc-iv-32.result
@@ -94,6 +94,6 @@ sim:instruction-count: 42
 layout:sections-size: 128
 layout:text-sections-size: 120
 layout:data-sections-size: 8
-mem:instr-ranges: 8..55, 108..127
-mem:data-ranges: 0..7
-mem:io-ranges: 128..135
+mem:instr-ranges: 0x8..0x37, 0x6c..0x7f
+mem:data-ranges: 0x0..0x7
+mem:io-ranges: 0x80..0x87

--- a/test/golden/risc-iv-32/factorial_input_5.yaml
+++ b/test/golden/risc-iv-32/factorial_input_5.yaml
@@ -24,8 +24,14 @@ reports:
       sections: {layout:sections}
       text: {layout:text-sections}
       data: {layout:data-sections}
+      mem-instr: {mem:instr-range}
+      mem-data: {mem:data-range}
+      mem-io: {mem:io-range}
     assert: |
       instructions: 42
       sections: 128
       text: 120
       data: 8
+      mem-instr: 8..55, 108..123
+      mem-data: 0..7
+      mem-io: 128..135

--- a/test/golden/risc-iv-32/factorial_input_5.yaml
+++ b/test/golden/risc-iv-32/factorial_input_5.yaml
@@ -20,18 +20,18 @@ reports:
   - name: stats
     slice: last
     view: |
-      instructions: {sim:instruction-count}
-      sections: {layout:sections}
-      text: {layout:text-sections}
-      data: {layout:data-sections}
-      mem-instr: {mem:instr-range}
-      mem-data: {mem:data-range}
-      mem-io: {mem:io-range}
+      sim:instruction-count: {sim:instruction-count}
+      layout:sections-size: {layout:sections-size}
+      layout:text-sections-size: {layout:text-sections-size}
+      layout:data-sections-size: {layout:data-sections-size}
+      mem:instr-ranges: {mem:instr-ranges}
+      mem:data-ranges: {mem:data-ranges}
+      mem:io-ranges: {mem:io-ranges}
     assert: |
-      instructions: 42
-      sections: 128
-      text: 120
-      data: 8
-      mem-instr: 8..55, 108..127
-      mem-data: 0..7
-      mem-io: 128..135
+      sim:instruction-count: 42
+      layout:sections-size: 128
+      layout:text-sections-size: 120
+      layout:data-sections-size: 8
+      mem:instr-ranges: 8..55, 108..127
+      mem:data-ranges: 0..7
+      mem:io-ranges: 128..135

--- a/test/golden/risc-iv-32/factorial_input_5.yaml
+++ b/test/golden/risc-iv-32/factorial_input_5.yaml
@@ -21,5 +21,11 @@ reports:
     slice: last
     view: |
       instructions: {sim:instruction-count}
+      sections: {layout:sections}
+      text: {layout:text-sections}
+      data: {layout:data-sections}
     assert: |
       instructions: 42
+      sections: 128
+      text: 120
+      data: 8

--- a/test/golden/risc-iv-32/factorial_input_5.yaml
+++ b/test/golden/risc-iv-32/factorial_input_5.yaml
@@ -32,6 +32,6 @@ reports:
       sections: 128
       text: 120
       data: 8
-      mem-instr: 8..55, 108..123
+      mem-instr: 8..55, 108..127
       mem-data: 0..7
       mem-io: 128..135

--- a/test/golden/risc-iv-32/factorial_input_5.yaml
+++ b/test/golden/risc-iv-32/factorial_input_5.yaml
@@ -17,3 +17,9 @@ reports:
     assert: |
       numio[0x80]: [] >>> []
       numio[0x84]: [] >>> [120]
+  - name: stats
+    slice: last
+    view: |
+      instructions: {sim:instruction-count}
+    assert: |
+      instructions: 42

--- a/test/golden/risc-iv-32/factorial_input_5.yaml
+++ b/test/golden/risc-iv-32/factorial_input_5.yaml
@@ -32,6 +32,6 @@ reports:
       layout:sections-size: 128
       layout:text-sections-size: 120
       layout:data-sections-size: 8
-      mem:instr-ranges: 8..55, 108..127
-      mem:data-ranges: 0..7
-      mem:io-ranges: 128..135
+      mem:instr-ranges: 0x8..0x37, 0x6c..0x7f
+      mem:data-ranges: 0x0..0x7
+      mem:io-ranges: 0x80..0x87

--- a/test/golden/risc-iv-32/factorial_rec_input_5.risc-iv-32.result
+++ b/test/golden/risc-iv-32/factorial_rec_input_5.risc-iv-32.result
@@ -91,3 +91,9 @@
 # result
 numio[0x80]: [] >>> []
 numio[0x84]: [] >>> [120]
+---
+# stats
+instructions: 87
+mem-instr: 0..75, 140..187
+mem-data: 100..107, 566..597
+mem-io: 128..135

--- a/test/golden/risc-iv-32/factorial_rec_input_5.risc-iv-32.result
+++ b/test/golden/risc-iv-32/factorial_rec_input_5.risc-iv-32.result
@@ -93,7 +93,7 @@ numio[0x80]: [] >>> []
 numio[0x84]: [] >>> [120]
 ---
 # stats
-instructions: 87
-mem-instr: 0..75, 140..191
-mem-data: 100..107, 566..597
-mem-io: 128..135
+sim:instruction-count: 87
+mem:instr-ranges: 0..75, 140..191
+mem:data-ranges: 100..107, 566..597
+mem:io-ranges: 128..135

--- a/test/golden/risc-iv-32/factorial_rec_input_5.risc-iv-32.result
+++ b/test/golden/risc-iv-32/factorial_rec_input_5.risc-iv-32.result
@@ -94,6 +94,6 @@ numio[0x84]: [] >>> [120]
 ---
 # stats
 instructions: 87
-mem-instr: 0..75, 140..187
+mem-instr: 0..75, 140..191
 mem-data: 100..107, 566..597
 mem-io: 128..135

--- a/test/golden/risc-iv-32/factorial_rec_input_5.risc-iv-32.result
+++ b/test/golden/risc-iv-32/factorial_rec_input_5.risc-iv-32.result
@@ -94,6 +94,6 @@ numio[0x84]: [] >>> [120]
 ---
 # stats
 sim:instruction-count: 87
-mem:instr-ranges: 0..75, 140..191
-mem:data-ranges: 100..107, 566..597
-mem:io-ranges: 128..135
+mem:instr-ranges: 0x0..0x4b, 0x8c..0xbf
+mem:data-ranges: 0x64..0x6b, 0x236..0x255
+mem:io-ranges: 0x80..0x87

--- a/test/golden/risc-iv-32/factorial_rec_input_5.yaml
+++ b/test/golden/risc-iv-32/factorial_rec_input_5.yaml
@@ -16,3 +16,15 @@ reports:
     assert: |
       numio[0x80]: [] >>> []
       numio[0x84]: [] >>> [120]
+  - name: stats
+    slice: last
+    view: |
+      instructions: {sim:instruction-count}
+      mem-instr: {mem:instr-range}
+      mem-data: {mem:data-range}
+      mem-io: {mem:io-range}
+    assert: |
+      instructions: 87
+      mem-instr: 0..75, 140..187
+      mem-data: 100..107, 566..597
+      mem-io: 128..135

--- a/test/golden/risc-iv-32/factorial_rec_input_5.yaml
+++ b/test/golden/risc-iv-32/factorial_rec_input_5.yaml
@@ -25,6 +25,6 @@ reports:
       mem-io: {mem:io-range}
     assert: |
       instructions: 87
-      mem-instr: 0..75, 140..187
+      mem-instr: 0..75, 140..191
       mem-data: 100..107, 566..597
       mem-io: 128..135

--- a/test/golden/risc-iv-32/factorial_rec_input_5.yaml
+++ b/test/golden/risc-iv-32/factorial_rec_input_5.yaml
@@ -25,6 +25,6 @@ reports:
       mem:io-ranges: {mem:io-ranges}
     assert: |
       sim:instruction-count: 87
-      mem:instr-ranges: 0..75, 140..191
-      mem:data-ranges: 100..107, 566..597
-      mem:io-ranges: 128..135
+      mem:instr-ranges: 0x0..0x4b, 0x8c..0xbf
+      mem:data-ranges: 0x64..0x6b, 0x236..0x255
+      mem:io-ranges: 0x80..0x87

--- a/test/golden/risc-iv-32/factorial_rec_input_5.yaml
+++ b/test/golden/risc-iv-32/factorial_rec_input_5.yaml
@@ -19,12 +19,12 @@ reports:
   - name: stats
     slice: last
     view: |
-      instructions: {sim:instruction-count}
-      mem-instr: {mem:instr-range}
-      mem-data: {mem:data-range}
-      mem-io: {mem:io-range}
+      sim:instruction-count: {sim:instruction-count}
+      mem:instr-ranges: {mem:instr-ranges}
+      mem:data-ranges: {mem:data-ranges}
+      mem:io-ranges: {mem:io-ranges}
     assert: |
-      instructions: 87
-      mem-instr: 0..75, 140..191
-      mem-data: 100..107, 566..597
-      mem-io: 128..135
+      sim:instruction-count: 87
+      mem:instr-ranges: 0..75, 140..191
+      mem:data-ranges: 100..107, 566..597
+      mem:io-ranges: 128..135

--- a/test/golden/risc-iv-32/multi_sections.risc-iv-32.result
+++ b/test/golden/risc-iv-32/multi_sections.risc-iv-32.result
@@ -1,0 +1,12 @@
+---
+# result
+numio[0x80]: [] >>> []
+numio[0x84]: [] >>> [7]
+---
+# stats
+sections: 76
+text: 68
+data: 8
+mem-instr: 0..35, 44..71
+mem-data: 40..43, 72..75, 508..511
+mem-io: 128..135

--- a/test/golden/risc-iv-32/multi_sections.risc-iv-32.result
+++ b/test/golden/risc-iv-32/multi_sections.risc-iv-32.result
@@ -7,6 +7,6 @@ numio[0x84]: [] >>> [7]
 sections: 76
 text: 68
 data: 8
-mem-instr: 0..35, 44..71
+mem-instr: 0..39, 44..71
 mem-data: 40..43, 72..75, 508..511
 mem-io: 128..135

--- a/test/golden/risc-iv-32/multi_sections.risc-iv-32.result
+++ b/test/golden/risc-iv-32/multi_sections.risc-iv-32.result
@@ -4,9 +4,9 @@ numio[0x80]: [] >>> []
 numio[0x84]: [] >>> [7]
 ---
 # stats
-layout:sections-size: 76
-layout:text-sections-size: 68
+layout:sections-size: 84
+layout:text-sections-size: 76
 layout:data-sections-size: 8
-mem:instr-ranges: 0..39, 44..71
-mem:data-ranges: 40..43, 72..75, 508..511
+mem:instr-ranges: 0..39, 64..91
+mem:data-ranges: 40..43, 100..103, 508..511
 mem:io-ranges: 128..135

--- a/test/golden/risc-iv-32/multi_sections.risc-iv-32.result
+++ b/test/golden/risc-iv-32/multi_sections.risc-iv-32.result
@@ -7,6 +7,6 @@ numio[0x84]: [] >>> [7]
 layout:sections-size: 84
 layout:text-sections-size: 76
 layout:data-sections-size: 8
-mem:instr-ranges: 0..39, 64..91
-mem:data-ranges: 40..43, 100..103, 508..511
-mem:io-ranges: 128..135
+mem:instr-ranges: 0x0..0x27, 0x40..0x5b
+mem:data-ranges: 0x28..0x2b, 0x64..0x67, 0x1fc..0x1ff
+mem:io-ranges: 0x80..0x87

--- a/test/golden/risc-iv-32/multi_sections.risc-iv-32.result
+++ b/test/golden/risc-iv-32/multi_sections.risc-iv-32.result
@@ -4,9 +4,9 @@ numio[0x80]: [] >>> []
 numio[0x84]: [] >>> [7]
 ---
 # stats
-sections: 76
-text: 68
-data: 8
-mem-instr: 0..39, 44..71
-mem-data: 40..43, 72..75, 508..511
-mem-io: 128..135
+layout:sections-size: 76
+layout:text-sections-size: 68
+layout:data-sections-size: 8
+mem:instr-ranges: 0..39, 44..71
+mem:data-ranges: 40..43, 72..75, 508..511
+mem:io-ranges: 128..135

--- a/test/golden/risc-iv-32/multi_sections.s
+++ b/test/golden/risc-iv-32/multi_sections.s
@@ -1,0 +1,40 @@
+; Exercises a layout with two .text and two .data sections plus a stack.
+; The stats report should capture all four section clusters in mem:data /
+; mem:instr ranges, the IO accesses in mem:io, and the stack pushes/pops
+; sitting outside any declared section.
+
+    .text
+_start:
+    ; Load input pointer from data section 1, then read the input.
+    lui      t0, %hi(input_ptr)
+    addi     t0, t0, %lo(input_ptr)
+    lw       t0, 0(t0)
+    lw       a0, 0(t0)
+
+    ; Set up the stack at 0x200 and push the input there.
+    lui      sp, %hi(0x200)
+    addi     sp, sp, %lo(0x200)
+    addi     sp, sp, -4
+    sw       a0, 0(sp)
+
+    jal      ra, write_out
+    halt
+
+    .data
+input_ptr:       .word  0x80              ; -> data section 1
+
+    .text
+write_out:
+    ; Pop the saved input from the stack.
+    lw       a0, 0(sp)
+    addi     sp, sp, 4
+
+    ; Load output pointer from data section 2, then write.
+    lui      t1, %hi(output_ptr)
+    addi     t1, t1, %lo(output_ptr)
+    lw       t1, 0(t1)
+    sw       a0, 0(t1)
+    jr       ra
+
+    .data
+output_ptr:      .word  0x84              ; -> data section 2

--- a/test/golden/risc-iv-32/multi_sections.s
+++ b/test/golden/risc-iv-32/multi_sections.s
@@ -1,7 +1,7 @@
-; Exercises a layout with two .text and two .data sections plus a stack.
-; The stats report should capture all four section clusters in mem:data /
-; mem:instr ranges, the IO accesses in mem:io, and the stack pushes/pops
-; sitting outside any declared section.
+; Two .text + two .data sections plus a stack. `.org` introduces an
+; explicit gap before the second .text section, and two trailing
+; instructions in `write_out` are deliberately unreachable so the
+; second text section has partial coverage.
 
     .text
 _start:
@@ -23,18 +23,23 @@ _start:
     .data
 input_ptr:       .word  0x80              ; -> data section 1
 
+    ; Force a gap before the second .text section so the layout has
+    ; addresses that belong to no declared region.
     .text
+    .org     64
 write_out:
-    ; Pop the saved input from the stack.
     lw       a0, 0(sp)
     addi     sp, sp, 4
 
-    ; Load output pointer from data section 2, then write.
     lui      t1, %hi(output_ptr)
     addi     t1, t1, %lo(output_ptr)
     lw       t1, 0(t1)
     sw       a0, 0(t1)
     jr       ra
+
+unreachable:                              ; dead code — never fetched
+    addi     zero, zero, 0
+    halt
 
     .data
 output_ptr:      .word  0x84              ; -> data section 2

--- a/test/golden/risc-iv-32/multi_sections.yaml
+++ b/test/golden/risc-iv-32/multi_sections.yaml
@@ -1,0 +1,30 @@
+limit: 200
+memory_size: 0x300
+memory_mapped_io:
+  0x80: [7]
+  0x84: []
+reports:
+  - name: result
+    slice: last
+    view: |
+      numio[0x80]: {io:0x80:dec}
+      numio[0x84]: {io:0x84:dec}
+    assert: |
+      numio[0x80]: [] >>> []
+      numio[0x84]: [] >>> [7]
+  - name: stats
+    slice: last
+    view: |
+      sections: {layout:sections}
+      text: {layout:text-sections}
+      data: {layout:data-sections}
+      mem-instr: {mem:instr-range}
+      mem-data: {mem:data-range}
+      mem-io: {mem:io-range}
+    assert: |
+      sections: 76
+      text: 68
+      data: 8
+      mem-instr: 0..35, 44..71
+      mem-data: 40..43, 72..75, 508..511
+      mem-io: 128..135

--- a/test/golden/risc-iv-32/multi_sections.yaml
+++ b/test/golden/risc-iv-32/multi_sections.yaml
@@ -25,6 +25,6 @@ reports:
       sections: 76
       text: 68
       data: 8
-      mem-instr: 0..35, 44..71
+      mem-instr: 0..39, 44..71
       mem-data: 40..43, 72..75, 508..511
       mem-io: 128..135

--- a/test/golden/risc-iv-32/multi_sections.yaml
+++ b/test/golden/risc-iv-32/multi_sections.yaml
@@ -15,16 +15,16 @@ reports:
   - name: stats
     slice: last
     view: |
-      sections: {layout:sections}
-      text: {layout:text-sections}
-      data: {layout:data-sections}
-      mem-instr: {mem:instr-range}
-      mem-data: {mem:data-range}
-      mem-io: {mem:io-range}
+      layout:sections-size: {layout:sections-size}
+      layout:text-sections-size: {layout:text-sections-size}
+      layout:data-sections-size: {layout:data-sections-size}
+      mem:instr-ranges: {mem:instr-ranges}
+      mem:data-ranges: {mem:data-ranges}
+      mem:io-ranges: {mem:io-ranges}
     assert: |
-      sections: 76
-      text: 68
-      data: 8
-      mem-instr: 0..39, 44..71
-      mem-data: 40..43, 72..75, 508..511
-      mem-io: 128..135
+      layout:sections-size: 76
+      layout:text-sections-size: 68
+      layout:data-sections-size: 8
+      mem:instr-ranges: 0..39, 44..71
+      mem:data-ranges: 40..43, 72..75, 508..511
+      mem:io-ranges: 128..135

--- a/test/golden/risc-iv-32/multi_sections.yaml
+++ b/test/golden/risc-iv-32/multi_sections.yaml
@@ -25,6 +25,6 @@ reports:
       layout:sections-size: 84
       layout:text-sections-size: 76
       layout:data-sections-size: 8
-      mem:instr-ranges: 0..39, 64..91
-      mem:data-ranges: 40..43, 100..103, 508..511
-      mem:io-ranges: 128..135
+      mem:instr-ranges: 0x0..0x27, 0x40..0x5b
+      mem:data-ranges: 0x28..0x2b, 0x64..0x67, 0x1fc..0x1ff
+      mem:io-ranges: 0x80..0x87

--- a/test/golden/risc-iv-32/multi_sections.yaml
+++ b/test/golden/risc-iv-32/multi_sections.yaml
@@ -22,9 +22,9 @@ reports:
       mem:data-ranges: {mem:data-ranges}
       mem:io-ranges: {mem:io-ranges}
     assert: |
-      layout:sections-size: 76
-      layout:text-sections-size: 68
+      layout:sections-size: 84
+      layout:text-sections-size: 76
       layout:data-sections-size: 8
-      mem:instr-ranges: 0..39, 44..71
-      mem:data-ranges: 40..43, 72..75, 508..511
+      mem:instr-ranges: 0..39, 64..91
+      mem:data-ranges: 40..43, 100..103, 508..511
       mem:io-ranges: 128..135

--- a/wrench.cabal
+++ b/wrench.cabal
@@ -82,7 +82,6 @@ library
     , base >=4.7 && <5
     , data-default
     , data-interval
-    , extended-reals
     , filepath
     , gitrev
     , megaparsec
@@ -156,7 +155,6 @@ executable wrench
     , base >=4.7 && <5
     , data-default
     , data-interval
-    , extended-reals
     , filepath
     , gitrev
     , megaparsec
@@ -209,7 +207,6 @@ executable wrench-fmt
     , data-default
     , data-interval
     , directory
-    , extended-reals
     , filepath
     , gitrev
     , http-api-data
@@ -285,7 +282,6 @@ executable wrench-serv
     , data-default
     , data-interval
     , directory
-    , extended-reals
     , filepath
     , gitrev
     , http-api-data
@@ -365,7 +361,6 @@ test-suite wrench-test
     , base >=4.7 && <5
     , data-default
     , data-interval
-    , extended-reals
     , filepath
     , gitrev
     , megaparsec

--- a/wrench.cabal
+++ b/wrench.cabal
@@ -1,6 +1,6 @@
 cabal-version: 2.2
 
--- This file has been generated from package.yaml by hpack version 0.38.1.
+-- This file has been generated from package.yaml by hpack version 0.39.1.
 --
 -- see: https://github.com/sol/hpack
 
@@ -81,6 +81,8 @@ library
     , aeson-casing
     , base >=4.7 && <5
     , data-default
+    , data-interval
+    , extended-reals
     , filepath
     , gitrev
     , megaparsec
@@ -153,6 +155,8 @@ executable wrench
     , aeson-casing
     , base >=4.7 && <5
     , data-default
+    , data-interval
+    , extended-reals
     , filepath
     , gitrev
     , megaparsec
@@ -203,7 +207,9 @@ executable wrench-fmt
     , aeson-casing
     , base >=4.7 && <5
     , data-default
+    , data-interval
     , directory
+    , extended-reals
     , filepath
     , gitrev
     , http-api-data
@@ -277,7 +283,9 @@ executable wrench-serv
     , cryptohash-sha1
     , crypton
     , data-default
+    , data-interval
     , directory
+    , extended-reals
     , filepath
     , gitrev
     , http-api-data
@@ -356,6 +364,8 @@ test-suite wrench-test
     , aeson-casing
     , base >=4.7 && <5
     , data-default
+    , data-interval
+    , extended-reals
     , filepath
     , gitrev
     , megaparsec


### PR DESCRIPTION
Adds three opt-in stat families surfaced through the existing
\`ReportConf\` mechanism — users add the variables they want to their
report's \`view:\` template, no forced output. (Closes part of #83.)

## Variables

| Variable | Source | Per |
|---|---|---|
| \`sim:instruction-count\` | step counter on \`Trace.TState\` | step |
| \`layout:sections\` | sum of all section bytes | run |
| \`layout:text-sections\` | sum of \`Code\` section bytes | run |
| \`layout:data-sections\` | sum of \`Data\` section bytes | run |
| \`mem:instr-range\` | instruction-fetch address ranges | run |
| \`mem:data-range\` | data read/write address ranges (merged) | run |
| \`mem:io-range\` | memory-mapped IO touches | run |

## Notable changes

- New \`Trace.TState { tInstructionCount, tState }\` record carries the
  step number alongside the captured machine state.
- \`prepareDump\` returns a \`DumpStats\` record (sections / per-kind byte
  counts), plumbed through \`TranslatorResult\`.
- \`IoMem\` gains an \`AccessLog\` field (three \`Intervals\` — instr, data,
  io) updated by the \`Memory\` typeclass methods themselves. \`readInstruction\`'s
  signature grew to return the updated memory so instruction fetches record
  alongside data/IO accesses; each ISA's \`instructionFetch\` threads the
  new memory back into state.
- \`Intervals\` is a newtype around \`IntervalSet Integer\` from the
  \`data-interval\` package, with adjacency preserved by storing accesses
  as half-open \`[lo, hi+1)\`.
- Bug fix: \`tellState\` records pre-step state, so the last \`TState\`'s
  accessLog stops one instruction short. \`simulate\` now returns the
  final \`machineState\`, threaded through \`prepareReport\` into
  \`prepareStateView\` for \`mem:*\` resolution. \`mem:*\` is therefore a
  per-run summary (same value on every line of any slice).

## Test coverage

- \`factorial_input_5.yaml\` extended with a \`stats\` report block
  asserting every new variable for the iterative factorial path.
- \`factorial_rec_input_5.yaml\` extended similarly for the recursive
  path (which uses the stack).
- New \`multi_sections.s\` / .yaml — a risc-iv-32 program with two
  \`.text\` and two \`.data\` sections plus stack push/pop, demonstrating
  multi-cluster \`mem:data-range\` (\`100..107, 566..597\`) where the
  second cluster is the stack region outside any declared section.

523 → 524 tests, all passing.

## Test plan
- [ ] \`stack test\` (one new golden test added, three existing golden asserts updated for the bug fix)
- [ ] Spot-check on iterative + recursive factorial that the values reported match the program
- [ ] Confirm wrench-serv passes the stats through verbatim (no template changes needed)