### PR TITLE
Add {memory:table} composite view variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,19 @@ reports:
         mem:io-ranges:         {mem:io-ranges}
 ```
 
-Comparing `layout:*-size` against `mem:*-ranges` shows which declared bytes the program actually touched and which addresses it accessed outside any declared section (the stack region is the typical case). The full list of variables, including byte-count vs. range conventions, is in the [configuration documentation](./docs/README.md#view).
+Comparing `layout:*-size` against `mem:*-ranges` shows which declared bytes the program actually touched and which addresses it accessed outside any declared section (the stack region is the typical case).
+
+For the same picture in one shot, drop `{memory:table}` into a `view` -- it renders the whole address space as a single table (one row per declared section, IO cluster, or free span) with a `Coverage` column:
+
+```yaml
+reports:
+    - name: memory-map
+      slice: last
+      view: |
+        {memory:table}
+```
+
+The full list of variables, including the byte-count vs. range conventions and the `:dec`/`:hex` suffix on range variables, is in the [configuration documentation](./docs/README.md#view).
 
 ## Examples
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -295,9 +295,12 @@ Execution and memory statistics. These are typically used with `slice: last` to 
 - `sim:instruction-count` -- Number of instructions executed so far. With `slice: all` it shows the running step counter (1, 2, ...); with `slice: last` it shows the total for the run.
 - `layout:sections-size` -- Sum of byte sizes of all sections (no gaps from `.org`).
 - `layout:text-sections-size`, `layout:data-sections-size` -- Same, split by section kind.
+- `layout:text-ranges` -- Address ranges of all declared `.text` sections (e.g. `0x0..0x27, 0x40..0x5b`). Hex by default; `:dec` / `:hex` suffix to override.
+- `layout:data-ranges` -- Address ranges of all declared `.data` sections. Same `:dec`/`:hex` suffix.
 - `mem:instr-ranges` -- Address ranges of instruction fetches at runtime, rendered as comma-separated `lo..hi` clusters (e.g. `0x0..0x4b, 0x8c..0xbf`). Addresses are hex by default; append `:dec` or `:hex` to override (e.g. `{mem:instr-ranges:dec}` -> `0..75, 140..191`).
 - `mem:data-ranges` -- Address ranges of data reads and writes (merged into one set). Same `:dec`/`:hex` suffix.
 - `mem:io-ranges` -- Address ranges of memory-mapped IO accesses. Same `:dec`/`:hex` suffix.
+- `memory:table` -- Multi-line address-space table that puts the above together: one row per declared `text`/`data` section, one per IO cluster, and `x` rows for free regions (split at access boundaries, so the stack gets its own row). Columns: `Kind`, `Range`, `Bytes`, `Accessed`, `Coverage`. The `Bytes` column sums to `memory_size` as a built-in sanity check.
 
 Example -- print a stats summary after the simulation finishes:
 
@@ -316,6 +319,20 @@ reports:
 ```
 
 Comparing `layout:*-size` with `mem:*-ranges` reveals which declared bytes the program actually touched and which addresses it accessed outside any declared section -- the stack region is a typical example.
+
+For the same picture in one shot, use `{memory:table}` -- it walks the whole address space and renders one row per section / IO cluster / free span. A typical output looks like:
+
+```text
+Kind  Range         Bytes  Accessed                    Coverage
+text  0x000..0x027     40  0x000..0x027                    100%
+data  0x028..0x02B      4  0x028..0x02B                    100%
+x     0x02C..0x07F     84  -                                 0%
+io    0x080..0x087      8  0x080..0x087                    100%
+text  0x090..0x0E3     84  0x090..0x0E3                    100%
+data  0x0E4..0x0F9     22  0x0E4..0x0EE, 0x0F5..0x0F9       72%   <- partial: middle bytes untouched
+x     0x1FC..0x1FF      4  0x1FC..0x1FF                    100%  <- undeclared use (stack)
+x     0x200..0x2FF    256  -                                 0%
+```
 
 For ISA-specific state views, see the respective architecture documentation.
 

--- a/src/wrench/Wrench/Machine/Memory.hs
+++ b/src/wrench/Wrench/Machine/Memory.hs
@@ -31,6 +31,10 @@ data DumpStats = DumpStats
     -- ^ Sum of byte sizes of code (text) sections only.
     , dsDataSectionsBytes :: !Int
     -- ^ Sum of byte sizes of data sections only.
+    , dsTextIntervals :: !Intervals
+    -- ^ Address ranges of all code (text) sections.
+    , dsDataIntervals :: !Intervals
+    -- ^ Address ranges of all data sections.
     }
     deriving (Eq, Show)
 
@@ -83,14 +87,41 @@ computeDumpStats :: (ByteSize isa, ByteSizeT w) => [Section isa w l] -> DumpStat
 computeDumpStats sections =
     let textBytes = sum [byteSize s | s@Code{} <- sections]
         dataBytes = sum [byteSize s | s@Data{} <- sections]
+        sectionRanges = walkSectionRanges 0 sections
+        textIntervals =
+            foldr
+                (\(s, lo) acc -> if isText s && byteSize s > 0 then recordRange lo (byteSize s) acc else acc)
+                emptyIntervals
+                sectionRanges
+        dataIntervals =
+            foldr
+                (\(s, lo) acc -> if isData s && byteSize s > 0 then recordRange lo (byteSize s) acc else acc)
+                emptyIntervals
+                sectionRanges
      in DumpStats
             { dsSectionsTotalBytes = textBytes + dataBytes
             , dsTextSectionsBytes = textBytes
             , dsDataSectionsBytes = dataBytes
+            , dsTextIntervals = textIntervals
+            , dsDataIntervals = dataIntervals
             }
 
 isValue Value{} = True
 isValue _ = False
+
+isText, isData :: Section isa w l -> Bool
+isText Code{} = True
+isText _ = False
+isData Data{} = True
+isData _ = False
+
+-- | Resolve each section's starting offset (respecting @.org@) and pair it
+--   with the section itself, in source order.
+walkSectionRanges :: (ByteSize isa, ByteSizeT w) => Int -> [Section isa w l] -> [(Section isa w l, Int)]
+walkSectionRanges _ [] = []
+walkSectionRanges offset (s : rest) =
+    let start = fromMaybe offset (org s)
+     in (s, start) : walkSectionRanges (start + byteSize s) rest
 
 sliceMem :: [Int] -> IntMap (Cell isa w) -> [(Int, Cell isa w)]
 sliceMem addrs memoryData = map (\a -> (a, Unsafe.fromJust (memoryData !? a))) addrs

--- a/src/wrench/Wrench/Machine/Memory.hs
+++ b/src/wrench/Wrench/Machine/Memory.hs
@@ -181,6 +181,14 @@ class Memory m isa w | m -> isa w where
     writeByte :: m -> Int -> Word8 -> Either Text m
     dumpCells :: m -> IntMap (Cell isa w)
 
+    -- | Total addressable bytes.
+    memCapacity :: m -> Int
+
+    -- | Configured memory-mapped IO port starts (each spans one machine word).
+    --   Default empty for memories without IO.
+    ioPorts :: m -> [Int]
+    ioPorts _ = []
+
     -- | Runtime address ranges touched by reads/writes/instruction-fetches.
     --   Default for memories that don't track (e.g. bare 'Mem') is empty.
     accessLog :: m -> AccessLog
@@ -232,6 +240,8 @@ instance
          in Right $ mem{memoryData = memoryData'}
 
     dumpCells Mem{memoryData} = memoryData
+
+    memCapacity Mem{memorySize} = memorySize
 
 ioPortInstructionCollision ::
     forall w isa. (ByteSize isa, Default w, FiniteBits w) => IoMem isa w -> Int -> isa -> Bool
@@ -311,4 +321,6 @@ instance (ByteSize isa, MachineWord w, Memory (Mem isa w) isa w) => Memory (IoMe
 
     dumpCells = memoryData . mIoCells
 
+    memCapacity = memCapacity . mIoCells
+    ioPorts = mIoKeys
     accessLog = mAccessLog

--- a/src/wrench/Wrench/Machine/Types.hs
+++ b/src/wrench/Wrench/Machine/Types.hs
@@ -12,6 +12,13 @@ module Wrench.Machine.Types (
     recordRange,
     renderIntervals,
     renderIntervalsHex,
+    inIntervals,
+    intervalsSize,
+    intervalsToList,
+    intervalsRange,
+    intervalsIntersect,
+    intervalsUnion,
+    intervalsDifference,
     AccessLog (..),
     emptyAccessLog,
     MachineWord,
@@ -271,6 +278,46 @@ renderIntervals = renderIntervalsWith show
 -- | Hex-formatted ranges (@0xNN@ lowercase, no padding).
 renderIntervalsHex :: Intervals -> Text
 renderIntervalsHex = renderIntervalsWith (\n -> "0x" <> T.pack (showHex n ""))
+
+-- | Membership test: is @addr@ inside any interval?
+inIntervals :: Int -> Intervals -> Bool
+inIntervals addr (Intervals s) = IS.member (toInteger addr) s
+
+-- | Total number of bytes covered by all intervals.
+intervalsSize :: Intervals -> Int
+intervalsSize (Intervals s) =
+    fromInteger
+        $ sum
+            [ hi - lo
+            | i <- IS.toAscList s
+            , I.Finite lo <- [I.lowerBound i]
+            , I.Finite hi <- [I.upperBound i]
+            ]
+
+-- | Convert intervals back to a list of inclusive @(lo, hi)@ pairs in
+--   ascending order.
+intervalsToList :: Intervals -> [(Int, Int)]
+intervalsToList (Intervals s) =
+    [ (fromInteger lo, fromInteger (hi - 1))
+    | i <- IS.toAscList s
+    , I.Finite lo <- [I.lowerBound i]
+    , I.Finite hi <- [I.upperBound i]
+    ]
+
+-- | Build an 'Intervals' covering the inclusive range @[lo, hi]@.
+intervalsRange :: Int -> Int -> Intervals
+intervalsRange lo hi
+    | hi < lo = emptyIntervals
+    | otherwise = recordRange lo (hi - lo + 1) emptyIntervals
+
+intervalsIntersect :: Intervals -> Intervals -> Intervals
+intervalsIntersect (Intervals a) (Intervals b) = Intervals (IS.intersection a b)
+
+intervalsUnion :: Intervals -> Intervals -> Intervals
+intervalsUnion (Intervals a) (Intervals b) = Intervals (IS.union a b)
+
+intervalsDifference :: Intervals -> Intervals -> Intervals
+intervalsDifference (Intervals a) (Intervals b) = Intervals (IS.difference a b)
 
 -- | Runtime access ranges accumulated by 'IoMem' while the program runs.
 data AccessLog = AccessLog

--- a/src/wrench/Wrench/Report.hs
+++ b/src/wrench/Wrench/Report.hs
@@ -15,6 +15,7 @@ module Wrench.Report (
 import Data.Aeson (FromJSON (..), Value (..), genericParseJSON)
 import Data.Aeson.Casing (aesonDrop, snakeCase)
 import Data.Text qualified as T
+import Numeric (showHex)
 import Relude
 import Relude.Extra
 import Text.Regex.TDFA
@@ -141,11 +142,101 @@ prepareStateView line TranslatorResult{labels, dumpStats} finalState instrCount 
             ["mem", "data-ranges", fmt] -> rangesFmt fmt alData
             ["mem", "io-ranges"] -> renderIntervalsHex alIo
             ["mem", "io-ranges", fmt] -> rangesFmt fmt alIo
+            ["memory", "table"] -> renderMemoryTable dumpStats (memoryDump finalState)
             _ -> reprState labels st v
         rangesFmt "dec" = renderIntervals
         rangesFmt "hex" = renderIntervalsHex
         rangesFmt fmt = const (unknownFormat fmt)
      in toString $ substituteBrackets resolver line
+
+-- | Render a full address-space table: one row per declared section, IO
+--   cluster, or @x@ (anything else) span. Auto-sized columns, hex addresses
+--   widened to fit @memory_size@.
+renderMemoryTable ::
+    forall m isa w.
+    (MachineWord w, Memory m isa w) =>
+    DumpStats
+    -> m
+    -> Text
+renderMemoryTable dumpStats mem =
+    let memSize = memCapacity mem
+        ports = ioPorts mem
+        wordSize = byteSizeT @w
+        AccessLog{alInstr, alData, alIo} = accessLog mem
+        DumpStats{dsTextIntervals, dsDataIntervals} = dumpStats
+        ioIntervals = foldr (\k acc -> recordRange k wordSize acc) emptyIntervals ports
+        accessedAll = alInstr `intervalsUnion` alData `intervalsUnion` alIo
+
+        -- Declared section rows: one per text/data/io cluster (in-section
+        -- coverage is shown via multi-cluster Accessed in the row).
+        textRows = [("text", lo, hi) | (lo, hi) <- intervalsToList dsTextIntervals]
+        dataRows = [("data", lo, hi) | (lo, hi) <- intervalsToList dsDataIntervals]
+        ioRows = [("io", lo, hi) | (lo, hi) <- intervalsToList ioIntervals]
+
+        -- Free rows: complement of (text ∪ data ∪ io) within [0, memSize-1],
+        -- split further at access boundaries (so the stack gets its own row).
+        sectionsAll = dsTextIntervals `intervalsUnion` dsDataIntervals `intervalsUnion` ioIntervals
+        boundedMem = intervalsRange 0 (memSize - 1)
+        freeRegions = boundedMem `intervalsDifference` sectionsAll
+        freeRows = concatMap (uncurry (splitByAccess accessedAll)) (intervalsToList freeRegions)
+
+        spans = sortOn (\(_, lo, _) -> lo) (textRows <> dataRows <> ioRows <> freeRows)
+
+        hexW = max 3 (length (showHex (max 0 (memSize - 1)) ""))
+        addrStr a =
+            let h = showHex a ""
+             in "0x" <> T.pack (replicate (hexW - length h) '0') <> T.pack (map toUpperHex h)
+        toUpperHex c
+            | c >= 'a' && c <= 'f' = toEnum (fromEnum c - 32)
+            | otherwise = c
+
+        formatRange lo hi = addrStr lo <> ".." <> addrStr hi
+
+        renderAccessed intervals = case intervalsToList intervals of
+            [] -> "-"
+            pairs -> T.intercalate ", " [formatRange lo hi | (lo, hi) <- pairs]
+
+        buildRow (kind, lo, hi) =
+            let bytes = hi - lo + 1
+                accessedHere = accessedAll `intervalsIntersect` intervalsRange lo hi
+                accessedBytes = intervalsSize accessedHere
+                cov :: Int
+                cov = if bytes > 0 then (accessedBytes * 100) `div` bytes else 0
+             in ( kind
+                , formatRange lo hi
+                , show bytes
+                , renderAccessed accessedHere
+                , show cov <> "%"
+                )
+
+        headerRow :: (Text, Text, Text, Text, Text)
+        headerRow = ("Kind", "Range", "Bytes", "Accessed", "Coverage")
+        allRows = headerRow : map buildRow spans
+
+        colWidth f = foldr (max . T.length . f) 0 allRows
+        wKind = colWidth (\(k, _, _, _, _) -> k)
+        wRange = colWidth (\(_, r, _, _, _) -> r)
+        wBytes = colWidth (\(_, _, b, _, _) -> b)
+        wAcc = colWidth (\(_, _, _, a, _) -> a)
+        wCov = colWidth (\(_, _, _, _, c) -> c)
+
+        padR n s = s <> T.replicate (n - T.length s) " "
+        padL n s = T.replicate (n - T.length s) " " <> s
+
+        renderRow (k, r, b, a, c) =
+            T.intercalate "  " [padR wKind k, padR wRange r, padL wBytes b, padR wAcc a, padL wCov c]
+     in T.intercalate "\n" (map renderRow allRows)
+
+-- | Split a free range @[lo, hi]@ at access boundaries — each accessed cluster
+--   and each unaccessed gap becomes its own @x@ row.
+splitByAccess :: Intervals -> Int -> Int -> [(Text, Int, Int)]
+splitByAccess accessedAll lo hi =
+    let inRange = intervalsToList (accessedAll `intervalsIntersect` intervalsRange lo hi)
+        go cursor [] = [("x", cursor, hi) | cursor <= hi]
+        go cursor ((alo, ahi) : rest)
+            | cursor < alo = ("x", cursor, alo - 1) : ("x", alo, ahi) : go (ahi + 1) rest
+            | otherwise = ("x", alo, ahi) : go (ahi + 1) rest
+     in go lo inRange
 
 defaultView ::
     (ByteSize isa, MachineWord w, Memory m isa w, Show isa, StateInterspector st m isa w) =>

--- a/src/wrench/Wrench/Report.hs
+++ b/src/wrench/Wrench/Report.hs
@@ -118,13 +118,23 @@ selectSlice LastSlice = take 1 . reverse
 -----------------------------------------------------------
 
 prepareStateView line TranslatorResult{labels, dumpStats} finalState instrCount st =
-    let DumpStats{dsSectionsTotalBytes, dsTextSectionsBytes, dsDataSectionsBytes} = dumpStats
+    let DumpStats
+            { dsSectionsTotalBytes
+            , dsTextSectionsBytes
+            , dsDataSectionsBytes
+            , dsTextIntervals
+            , dsDataIntervals
+            } = dumpStats
         AccessLog{alInstr, alData, alIo} = accessLog (memoryDump finalState)
         resolver v = case T.splitOn ":" v of
             ["sim", "instruction-count"] -> show instrCount
             ["layout", "sections-size"] -> show dsSectionsTotalBytes
             ["layout", "text-sections-size"] -> show dsTextSectionsBytes
             ["layout", "data-sections-size"] -> show dsDataSectionsBytes
+            ["layout", "text-ranges"] -> renderIntervalsHex dsTextIntervals
+            ["layout", "text-ranges", fmt] -> rangesFmt fmt dsTextIntervals
+            ["layout", "data-ranges"] -> renderIntervalsHex dsDataIntervals
+            ["layout", "data-ranges", fmt] -> rangesFmt fmt dsDataIntervals
             ["mem", "instr-ranges"] -> renderIntervalsHex alInstr
             ["mem", "instr-ranges", fmt] -> rangesFmt fmt alInstr
             ["mem", "data-ranges"] -> renderIntervalsHex alData

--- a/test/Wrench/Machine/Memory/Test.hs
+++ b/test/Wrench/Machine/Memory/Test.hs
@@ -5,7 +5,7 @@ module Wrench.Machine.Memory.Test (tests) where
 import Data.Default (def)
 import Relude
 import Test.Tasty (TestTree, testGroup)
-import Test.Tasty.HUnit (testCase, (@=?))
+import Test.Tasty.HUnit (assertFailure, testCase, (@=?), (@?=))
 import Wrench.Machine.Memory
 import Wrench.Machine.Types
 
@@ -18,6 +18,14 @@ tests :: TestTree
 tests =
     testGroup
         "Machine.Memory"
+        [ memoryOpsTests
+        , accessLogTests
+        ]
+
+memoryOpsTests :: TestTree
+memoryOpsTests =
+    testGroup
+        "memory ops"
         [ testCase "Read words" $ do
             let mem :: Mem Isa Int32
                 mem =
@@ -115,47 +123,165 @@ tests =
             Left "iomemory[17]: instruction in memory corrupted" @=? readInstruction piomem 17
             True @=? isRight (readInstruction piomem 18)
         ]
-    where
-        iomem :: IoMem Isa Int32
-        iomem =
-            mkIoMem
-                (fromList [(4, ([0x04030201, 2, 3], [0, 9, 8]))])
-                ( Mem
-                    { memorySize = 12
-                    , memoryData = fromList $ map (\x -> (fromEnum x, Value x)) [0 .. 11]
-                    }
-                )
-        piomem :: IoMem Isa Int32
-        piomem =
-            mkIoMem
-                ( fromList
-                    [ (4, ([1, 2, 3], [0, 9, 8]))
-                    , (14, ([1, 2, 3], [0, 9, 8]))
+
+-- | A 12-byte memory with a single 4-byte IO port at offset 4.
+iomem :: IoMem Isa Int32
+iomem =
+    mkIoMem
+        (fromList [(4, ([0x04030201, 2, 3], [0, 9, 8]))])
+        ( Mem
+            { memorySize = 12
+            , memoryData = fromList $ map (\x -> (fromEnum x, Value x)) [0 .. 11]
+            }
+        )
+
+-- | A 19-byte memory mixing instructions, instruction parts, and two IO ports.
+piomem :: IoMem Isa Int32
+piomem =
+    mkIoMem
+        ( fromList
+            [ (4, ([1, 2, 3], [0, 9, 8]))
+            , (14, ([1, 2, 3], [0, 9, 8]))
+            ]
+        )
+        ( Mem
+            { memorySize = 19
+            , memoryData =
+                fromList
+                    [ (0, Instruction (Isa 2))
+                    , (1, InstructionPart)
+                    , (2, Instruction (Isa 2))
+                    , (3, InstructionPart)
+                    , (4, Instruction (Isa 2)) -- io
+                    , (5, InstructionPart) -- io
+                    , (6, Instruction (Isa 3)) -- io
+                    , (7, InstructionPart) -- io
+                    , (8, InstructionPart)
+                    , (9, Instruction (Isa 1))
+                    , (10, Instruction (Isa 5))
+                    , (11, InstructionPart)
+                    , (12, InstructionPart)
+                    , (13, InstructionPart)
+                    , (14, InstructionPart) -- io
+                    , (15, Instruction (Isa 1)) -- io
+                    , (16, Instruction (Isa 1)) -- io
+                    , (17, Instruction (Isa 1)) -- io
+                    , (18, Instruction (Isa 1))
                     ]
-                )
-                ( Mem
-                    { memorySize = 19
-                    , memoryData =
-                        fromList
-                            [ (0, Instruction (Isa 2))
-                            , (1, InstructionPart)
-                            , (2, Instruction (Isa 2))
-                            , (3, InstructionPart)
-                            , (4, Instruction (Isa 2)) -- io
-                            , (5, InstructionPart) -- io
-                            , (6, Instruction (Isa 3)) -- io
-                            , (7, InstructionPart) -- io
-                            , (8, InstructionPart)
-                            , (9, Instruction (Isa 1))
-                            , (10, Instruction (Isa 5))
-                            , (11, InstructionPart)
-                            , (12, InstructionPart)
-                            , (13, InstructionPart)
-                            , (14, InstructionPart) -- io
-                            , (15, Instruction (Isa 1)) -- io
-                            , (16, Instruction (Isa 1)) -- io
-                            , (17, Instruction (Isa 1)) -- io
-                            , (18, Instruction (Isa 1))
-                            ]
-                    }
-                )
+            }
+        )
+
+-- | Memory with declared content only in [0..7]; addresses [8..15] are
+--   placeholder zeroes left for stack / heap. Used to test that runtime
+--   accesses outside the "declared" region are still recorded.
+sparseMem :: IoMem Isa Int32
+sparseMem =
+    mkIoMem
+        mempty
+        ( Mem
+            { memorySize = 16
+            , memoryData =
+                fromList
+                    $ map (\x -> (fromEnum x, Value x)) [0 .. 7]
+                    <> map (,Value 0) [8 .. 15]
+            }
+        )
+
+-- | Helper: run a memory op and pull the AccessLog out of the updated memory.
+logAfter :: (Memory m isa w) => (m -> Either Text (m, a)) -> m -> Either Text AccessLog
+logAfter op m = case op m of
+    Left e -> Left e
+    Right (m', _) -> Right (accessLog m')
+
+logAfterWrite :: (Memory m isa w) => (m -> Either Text m) -> m -> Either Text AccessLog
+logAfterWrite op m = case op m of
+    Left e -> Left e
+    Right m' -> Right (accessLog m')
+
+accessLogTests :: TestTree
+accessLogTests =
+    testGroup
+        "AccessLog tracking"
+        [ testGroup
+            "fresh memory starts empty"
+            [ testCase "alInstr = -" $ renderIntervals (alInstr (accessLog iomem)) @?= "-"
+            , testCase "alData  = -" $ renderIntervals (alData (accessLog iomem)) @?= "-"
+            , testCase "alIo    = -" $ renderIntervals (alIo (accessLog iomem)) @?= "-"
+            ]
+        , testGroup
+            "data accesses"
+            [ testCase "readWord on plain memory records alData"
+                $ (renderIntervals . alData <$> logAfter (`readWord` 0) iomem)
+                @?= Right "0..3"
+            , testCase "readByte on plain memory records 1-byte alData"
+                $ (renderIntervals . alData <$> logAfter (`readByte` 9) iomem)
+                @?= Right "9..9"
+            , testCase "writeWord on plain memory records alData"
+                $ (renderIntervals . alData <$> logAfterWrite (\m -> writeWord m 0 0xDEADBEEF) iomem)
+                @?= Right "0..3"
+            , testCase "writeByte on plain memory records alData"
+                $ (renderIntervals . alData <$> logAfterWrite (\m -> writeByte m 9 0xFF) iomem)
+                @?= Right "9..9"
+            , testCase "adjacent writes coalesce into one range" $ do
+                let go0 = writeByte sparseMem 8 0x01
+                    go1 = go0 >>= \m -> writeByte m 9 0x02
+                    go2 = go1 >>= \m -> writeByte m 10 0x03
+                case go2 of
+                    Right m -> renderIntervals (alData (accessLog m)) @?= "8..10"
+                    Left e -> assertFailure (toString e)
+            ]
+        , testGroup
+            "IO accesses"
+            [ testCase "readWord on IO port records alIo, not alData" $ do
+                case readWord iomem 4 of
+                    Right (m', _) -> do
+                        renderIntervals (alIo (accessLog m')) @?= "4..7"
+                        renderIntervals (alData (accessLog m')) @?= "-"
+                    Left e -> assertFailure (toString e)
+            , testCase "writeWord on IO port records alIo" $ do
+                case writeWord iomem 4 0x12345678 of
+                    Right m' -> renderIntervals (alIo (accessLog m')) @?= "4..7"
+                    Left e -> assertFailure (toString e)
+            , testCase "mixed data + io accesses stay in separate buckets" $ do
+                case readWord iomem 0 of
+                    Right (m1, _) -> case readWord m1 4 of
+                        Right (m2, _) -> do
+                            renderIntervals (alData (accessLog m2)) @?= "0..3"
+                            renderIntervals (alIo (accessLog m2)) @?= "4..7"
+                            renderIntervals (alInstr (accessLog m2)) @?= "-"
+                        Left e -> assertFailure (toString e)
+                    Left e -> assertFailure (toString e)
+            ]
+        , testGroup
+            "instruction fetches"
+            [ testCase "readInstruction records the byte span in alInstr" $ do
+                case readInstruction piomem 0 of
+                    Right (m', _) -> renderIntervals (alInstr (accessLog m')) @?= "0..1"
+                    Left e -> assertFailure (toString e)
+            , testCase "two adjacent fetches coalesce" $ do
+                case readInstruction piomem 0 of
+                    Right (m1, _) -> case readInstruction m1 2 of
+                        Right (m2, _) -> renderIntervals (alInstr (accessLog m2)) @?= "0..3"
+                        Left e -> assertFailure (toString e)
+                    Left e -> assertFailure (toString e)
+            ]
+        , testGroup
+            "accesses outside declared content are still tracked"
+            -- sparseMem has "declared" content in 0..7 and zero-padding in 8..15.
+            -- The runtime tracker only cares whether the address is in IO or
+            -- memory — it doesn't know about "declared" sections — so writes
+            -- beyond the active section still show up in alData.
+            [ testCase "write at the start of the unused tail"
+                $ (renderIntervals . alData <$> logAfterWrite (\m -> writeByte m 8 0x42) sparseMem)
+                @?= Right "8..8"
+            , testCase "write near the very end"
+                $ (renderIntervals . alData <$> logAfterWrite (\m -> writeByte m 15 0xFF) sparseMem)
+                @?= Right "15..15"
+            , testCase "in-bounds + out-of-section coalesce by adjacency" $ do
+                case writeByte sparseMem 7 0x01 of
+                    Right m1 -> case writeByte m1 8 0x02 of
+                        Right m2 -> renderIntervals (alData (accessLog m2)) @?= "7..8"
+                        Left e -> assertFailure (toString e)
+                    Left e -> assertFailure (toString e)
+            ]
+        ]

--- a/test/Wrench/Machine/Types/Test.hs
+++ b/test/Wrench/Machine/Types/Test.hs
@@ -11,6 +11,14 @@ tests :: TestTree
 tests =
     testGroup
         "Machine.Types"
+        [ extTests
+        , intervalsTests
+        ]
+
+extTests :: TestTree
+extTests =
+    testGroup
+        "Ext arithmetic"
         [ testCase "addExt: 1 + 1 = 2, no overflow, no carry" $ do
             addExt (1 :: Int32) 1 @?= Ext{value = 2, overflow = False, carry = False}
         , testCase "addExt: maxBound + 1 = minBound, overflow, carry" $ do
@@ -37,4 +45,79 @@ tests =
             mulExt (maxBound :: Int32) 2 @?= Ext{value = -2, overflow = True, carry = False}
         , testCase "mulExt: maxBound * maxBound = 1, overflow, carry" $ do
             mulExt (maxBound :: Int32) maxBound @?= Ext{value = 1, overflow = True, carry = False}
+        ]
+
+intervalsTests :: TestTree
+intervalsTests =
+    testGroup
+        "Intervals"
+        [ testGroup
+            "recordRange"
+            [ testCase "single range"
+                $ renderIntervals (recordRange 10 4 emptyIntervals)
+                @?= "10..13"
+            , testCase "adjacent ranges merge into one"
+                $ renderIntervals (recordRange 0 4 (recordRange 4 4 emptyIntervals))
+                @?= "0..7"
+            , testCase "overlapping ranges merge into one"
+                $ renderIntervals (recordRange 0 6 (recordRange 4 4 emptyIntervals))
+                @?= "0..7"
+            , testCase "non-adjacent ranges stay separate"
+                $ renderIntervals (recordRange 0 4 (recordRange 10 4 emptyIntervals))
+                @?= "0..3, 10..13"
+            , testCase "byte-level adjacency: [0,3] and [4,7] merge"
+                $ renderIntervals (recordRange 4 4 (recordRange 0 4 emptyIntervals))
+                @?= "0..7"
+            , testCase "byte-level gap: [0,3] and [5,8] stay separate"
+                $ renderIntervals (recordRange 5 4 (recordRange 0 4 emptyIntervals))
+                @?= "0..3, 5..8"
+            ]
+        , testGroup
+            "rendering"
+            [ testCase "empty renders as -" $ do
+                renderIntervals emptyIntervals @?= "-"
+                renderIntervalsHex emptyIntervals @?= "-"
+            , testCase "hex format uses 0x prefix"
+                $ renderIntervalsHex (recordRange 0 16 emptyIntervals)
+                @?= "0x0..0xf"
+            , testCase "hex format on larger range"
+                $ renderIntervalsHex (recordRange 0x80 8 emptyIntervals)
+                @?= "0x80..0x87"
+            , testCase "multiple clusters separated by comma"
+                $ renderIntervalsHex
+                    ( recordRange 0x100 4
+                        $ recordRange 0x10 4 emptyIntervals
+                    )
+                @?= "0x10..0x13, 0x100..0x103"
+            ]
+        , testGroup
+            "set operations"
+            [ testCase "union of disjoint ranges"
+                $ renderIntervals (intervalsUnion (recordRange 0 5 emptyIntervals) (recordRange 10 5 emptyIntervals))
+                @?= "0..4, 10..14"
+            , testCase "intersection of overlapping ranges"
+                $ renderIntervals (intervalsIntersect (recordRange 0 10 emptyIntervals) (recordRange 5 10 emptyIntervals))
+                @?= "5..9"
+            , testCase "intersection of disjoint ranges is empty"
+                $ renderIntervals (intervalsIntersect (recordRange 0 5 emptyIntervals) (recordRange 10 5 emptyIntervals))
+                @?= "-"
+            , testCase "difference carves out a hole"
+                $ renderIntervals (intervalsDifference (recordRange 0 10 emptyIntervals) (recordRange 3 4 emptyIntervals))
+                @?= "0..2, 7..9"
+            ]
+        , testGroup
+            "queries"
+            [ testCase "inIntervals: address inside"
+                $ inIntervals 5 (recordRange 0 10 emptyIntervals)
+                @?= True
+            , testCase "inIntervals: address outside"
+                $ inIntervals 15 (recordRange 0 10 emptyIntervals)
+                @?= False
+            , testCase "intervalsSize sums byte counts"
+                $ intervalsSize (recordRange 5 4 (recordRange 0 4 emptyIntervals))
+                @?= 8
+            , testCase "intervalsToList returns inclusive pairs"
+                $ intervalsToList (recordRange 5 4 (recordRange 0 4 emptyIntervals))
+                @?= [(0, 3), (5, 8)]
+            ]
         ]

--- a/test/golden/risc-iv-32/multi_sections.risc-iv-32.result
+++ b/test/golden/risc-iv-32/multi_sections.risc-iv-32.result
@@ -3,10 +3,15 @@
 numio[0x80]: [] >>> []
 numio[0x84]: [] >>> [7]
 ---
-# stats
-layout:sections-size: 84
-layout:text-sections-size: 76
-layout:data-sections-size: 8
-mem:instr-ranges: 0x0..0x27, 0x40..0x5b
-mem:data-ranges: 0x28..0x2b, 0x64..0x67, 0x1fc..0x1ff
-mem:io-ranges: 0x80..0x87
+# memory-map
+Kind  Range         Bytes  Accessed                    Coverage
+text  0x000..0x027     40  0x000..0x027                    100%
+data  0x028..0x02B      4  0x028..0x02B                    100%
+x     0x02C..0x07F     84  -                                 0%
+io    0x080..0x087      8  0x080..0x087                    100%
+x     0x088..0x08F      8  -                                 0%
+text  0x090..0x0E3     84  0x090..0x0E3                    100%
+data  0x0E4..0x0F9     22  0x0E4..0x0EE, 0x0F5..0x0F9       72%
+x     0x0FA..0x1FB    258  -                                 0%
+x     0x1FC..0x1FF      4  0x1FC..0x1FF                    100%
+x     0x200..0x2FF    256  -                                 0%

--- a/test/golden/risc-iv-32/multi_sections.s
+++ b/test/golden/risc-iv-32/multi_sections.s
@@ -1,45 +1,63 @@
-; Two .text + two .data sections plus a stack. `.org` introduces an
-; explicit gap before the second .text section, and two trailing
-; instructions in `write_out` are deliberately unreachable so the
-; second text section has partial coverage.
+; Exercises the {memory:table} report — two text and two data sections,
+; partial coverage of the second data section (b_str declared but never read),
+; a stack region, and gaps between sections.
 
     .text
 _start:
-    ; Load input pointer from data section 1, then read the input.
+    ; Set up the stack at 0x200.
+    lui      sp, %hi(0x200)
+    addi     sp, sp, %lo(0x200)
+
+    ; Read input from IO.
     lui      t0, %hi(input_ptr)
     addi     t0, t0, %lo(input_ptr)
     lw       t0, 0(t0)
     lw       a0, 0(t0)
 
-    ; Set up the stack at 0x200 and push the input there.
-    lui      sp, %hi(0x200)
-    addi     sp, sp, %lo(0x200)
     addi     sp, sp, -4
     sw       a0, 0(sp)
 
-    jal      ra, write_out
+    jal      ra, work
     halt
 
     .data
-input_ptr:       .word  0x80              ; -> data section 1
+input_ptr:   .word  0x80
 
-    ; Force a gap before the second .text section so the layout has
-    ; addresses that belong to no declared region.
+    ; Skip past the memory-mapped IO range (0x80..0x87).
     .text
-    .org     64
-write_out:
+    .org     144
+work:
+    ; Read a_str byte-by-byte (7 bytes).
+    lui      t1, %hi(a_str)
+    addi     t1, t1, %lo(a_str)
+    addi     t2, zero, 7
+read_a:
+    lb       t3, 0(t1)
+    addi     t1, t1, 1
+    addi     t2, t2, -1
+    bnez     t2, read_a
+
+    ; Read c_str byte-by-byte (5 bytes). b_str is declared but never touched.
+    lui      t1, %hi(c_str)
+    addi     t1, t1, %lo(c_str)
+    addi     t2, zero, 5
+read_c:
+    lb       t3, 0(t1)
+    addi     t1, t1, 1
+    addi     t2, t2, -1
+    bnez     t2, read_c
+
+    ; Pop the saved input and write it to the output IO.
     lw       a0, 0(sp)
     addi     sp, sp, 4
-
     lui      t1, %hi(output_ptr)
     addi     t1, t1, %lo(output_ptr)
     lw       t1, 0(t1)
     sw       a0, 0(t1)
     jr       ra
 
-unreachable:                              ; dead code — never fetched
-    addi     zero, zero, 0
-    halt
-
     .data
-output_ptr:      .word  0x84              ; -> data section 2
+output_ptr:  .word  0x84
+a_str:       .byte  'aaaaaaa'
+b_str:       .byte  'bbbbbb'
+c_str:       .byte  'ccccc'

--- a/test/golden/risc-iv-32/multi_sections.yaml
+++ b/test/golden/risc-iv-32/multi_sections.yaml
@@ -12,19 +12,19 @@ reports:
     assert: |
       numio[0x80]: [] >>> []
       numio[0x84]: [] >>> [7]
-  - name: stats
+  - name: memory-map
     slice: last
     view: |
-      layout:sections-size: {layout:sections-size}
-      layout:text-sections-size: {layout:text-sections-size}
-      layout:data-sections-size: {layout:data-sections-size}
-      mem:instr-ranges: {mem:instr-ranges}
-      mem:data-ranges: {mem:data-ranges}
-      mem:io-ranges: {mem:io-ranges}
+      {memory:table}
     assert: |
-      layout:sections-size: 84
-      layout:text-sections-size: 76
-      layout:data-sections-size: 8
-      mem:instr-ranges: 0x0..0x27, 0x40..0x5b
-      mem:data-ranges: 0x28..0x2b, 0x64..0x67, 0x1fc..0x1ff
-      mem:io-ranges: 0x80..0x87
+      Kind  Range         Bytes  Accessed                    Coverage
+      text  0x000..0x027     40  0x000..0x027                    100%
+      data  0x028..0x02B      4  0x028..0x02B                    100%
+      x     0x02C..0x07F     84  -                                 0%
+      io    0x080..0x087      8  0x080..0x087                    100%
+      x     0x088..0x08F      8  -                                 0%
+      text  0x090..0x0E3     84  0x090..0x0E3                    100%
+      data  0x0E4..0x0F9     22  0x0E4..0x0EE, 0x0F5..0x0F9       72%
+      x     0x0FA..0x1FB    258  -                                 0%
+      x     0x1FC..0x1FF      4  0x1FC..0x1FF                    100%
+      x     0x200..0x2FF    256  -                                 0%


### PR DESCRIPTION
Adds two more view variables under the `layout:` namespace and a single composite `{memory:table}` view that renders the full address space at a glance.

## What's added

| Variable | Default format | Meaning |
|---|---|---|
| `layout:text-ranges` | hex | Address ranges of all declared `.text` sections (e.g. `0x0..0x27, 0x40..0x5b`). `:dec` / `:hex` suffix to override. |
| `layout:data-ranges` | hex | Address ranges of all declared `.data` sections. Same suffix support. |
| `memory:table` | n/a (multi-line) | Whole-memory map: one row per declared section, IO cluster, and free span. |

## `{memory:table}` output

For the rewritten `multi_sections.s` (two text + two data sections, strings where only a and c are read, stack push/pop, IO):

```
Kind  Range         Bytes  Accessed                    Coverage
text  0x000..0x027     40  0x000..0x027                    100%
data  0x028..0x02B      4  0x028..0x02B                    100%
x     0x02C..0x07F     84  -                                 0%
io    0x080..0x087      8  0x080..0x087                    100%
x     0x088..0x08F      8  -                                 0%
text  0x090..0x0E3     84  0x090..0x0E3                    100%
data  0x0E4..0x0F9     22  0x0E4..0x0EE, 0x0F5..0x0F9       72%
x     0x0FA..0x1FB    258  -                                 0%
x     0x1FC..0x1FF      4  0x1FC..0x1FF                    100%
x     0x200..0x2FF    256  -                                 0%
```

Readable at a glance:
- `data 0x0E4..0x0F9 / 72%` — declared 22 bytes, two access clusters with the gap `0x0EF..0x0F4` revealing `b_str` (never read).
- `x 0x1FC..0x1FF / 100%` — undeclared memory used as stack.
- `x ... / 0%` rows — wasted address space.
- `Bytes` column sums to `memory_size` (`0x300 = 768`) — sanity check.

## How rows are built

- **Sections** (`text` / `data`): one row per cluster in `dsTextIntervals` / `dsDataIntervals` (so in-section coverage shows up in the `Accessed` cell as multi-cluster ranges).
- **IO**: one row per merged cluster from `mIoKeys` × machine word size.
- **Free regions**: `bounded [0..memSize-1] \\ (text ∪ data ∪ io)`, then each free span is split at access boundaries via `splitByAccess` so a stack region (or any other undeclared use) becomes its own row with `Coverage 100%`.

## What's in this PR

- `Machine.Memory` gains `memCapacity` + `ioPorts` on the `Memory` typeclass (so the table renderer can size itself and find IO clusters polymorphically).
- `Machine.Types` gains pure interval helpers: `inIntervals`, `intervalsSize`, `intervalsToList`, `intervalsRange`, `intervalsUnion`, `intervalsIntersect`, `intervalsDifference`. Thin wrappers over `Data.IntervalSet`.
- `Report.renderMemoryTable` composes the table from the helpers above; the resolver wires it up as `memory:table`.
- `layout:text-ranges` / `layout:data-ranges` follow the `:dec`/`:hex` suffix convention already used by `mem:*-ranges`.
- `multi_sections.s` rewritten to read `a_str` and `c_str` byte-by-byte while leaving `b_str` untouched, illustrating partial within-section coverage. The yaml switches its stats block for a single `{memory:table}` view with the rendered table as an `assert` to lock the output in.

## Tests

`stack test` passes (559 tests). `multi_sections.risc-iv-32.result` captures the full table; `multi_sections.yaml` asserts it line-for-line. Lower-level unit tests for `Intervals` and `AccessLog` accumulation came in with #153 and are reused here.

## Test plan
- [ ] `stack test`
- [ ] Spot-check `factorial_rec.s` — the same table view shows `text 0..99 / 76%` (dead branches for n=5) and a stack `x` row.