### PR TITLE
Track VLIW load level (slot utilization)

### DIFF
--- a/docs/vliw-iv.md
+++ b/docs/vliw-iv.md
@@ -248,3 +248,30 @@ add rd, rs1, rs2 / addi rd, rs1, k / lw rd, offset(rs1) / beq rs1, rs2, k
 - `<reg>:dec`, `<reg>:hex` -- View the value of a specific register in decimal or hexadecimal format.
 
 Available registers: `Zero`, `Ra`, `Sp`, `Gp`, `Tp`, `T0`, `T1`, `T2`, `S0Fp`, `S1`, `A0`, `A1`, `A2`, `A3`, `A4`, `A5`, `A6`, `A7`, `S2`, `S3`, `S4`, `S5`, `S6`, `S7`, `S8`, `S9`, `S10`, `S11`, `T3`, `T4`, `T5`, `T6`.
+
+### Slot utilization (parallelism)
+
+Each VLIW bundle has four execution slots (memory, ALU1, ALU2, control). A slot containing the corresponding `nop` is idle; everything else counts as active. The simulator tallies how many slots each executed bundle used and exposes two summary view variables. They're typically used with `slice: last` because the values are run-totals.
+
+- `vliw:load-percent` -- average slot utilization across the run, as an integer percent. `(active_slots * 100) / (bundles * 4)`. `25%` means each bundle used one slot on average; `100%` means every slot of every bundle was active.
+- `vliw:bundles-by-load` -- histogram rendered as comma-separated `K:N (P%)` entries, one per non-empty bucket. `K` is the active-slot count, `N` is the number of bundles in that bucket, `P` is its percent share of all executed bundles. Empty buckets are skipped. A peak at 1 means a serial program; a peak at 3-4 means the compiler / programmer is exploiting the pipeline.
+
+Example -- print a load summary at the end of the simulation:
+
+```yaml
+reports:
+    - name: vliw-load
+      slice: last
+      view: |
+        vliw:load-percent:    {vliw:load-percent}
+        vliw:bundles-by-load: {vliw:bundles-by-load}
+```
+
+For `hello.s` running on this ISA the summary reads:
+
+```text
+vliw:load-percent:    81%
+vliw:bundles-by-load: 1:3 (9%), 3:16 (48%), 4:14 (42%)
+```
+
+— 14 fully-packed bundles (`4:14 (42%)`), 16 three-wide (`3:16 (48%)`), 3 with a single active slot (`1:3 (9%)`), no idle or two-slot bundles.

--- a/src/wrench/Wrench/Isa/VliwIv.hs
+++ b/src/wrench/Wrench/Isa/VliwIv.hs
@@ -9,6 +9,8 @@ module Wrench.Isa.VliwIv (
     MachineState (..),
     VliwIvState,
     Register (..),
+    VliwLoadAcc,
+    emptyVliwLoad,
 ) where
 
 import Data.Bits (shiftL, shiftR, (.&.), (.|.))
@@ -169,6 +171,60 @@ data Isa w l = Isa
     , ctrlOp :: ControlOp w l
     }
     deriving (Show)
+
+-- * Load-level accumulator
+
+-- | Per-run histogram of how many slots were active in each executed bundle.
+--   @vlByLoad@ maps active-slot count (0..4) to the number of bundles with
+--   that load. Used by the @vliw:*@ report variables to summarise how well
+--   the program exploits the four-wide pipeline.
+newtype VliwLoadAcc = VliwLoadAcc {vlByLoad :: IntMap Int}
+    deriving (Eq, Show)
+
+emptyVliwLoad :: VliwLoadAcc
+emptyVliwLoad = VliwLoadAcc mempty
+
+isMemActive :: MemoryOp w l -> Bool
+isMemActive NopM = False
+isMemActive _ = True
+
+isAluActive :: AluOp w l -> Bool
+isAluActive NopA = False
+isAluActive _ = True
+
+isCtrlActive :: ControlOp w l -> Bool
+isCtrlActive NopC = False
+isCtrlActive _ = True
+
+bundleActiveCount :: Isa w l -> Int
+bundleActiveCount Isa{memOp, alu1Op, alu2Op, ctrlOp} =
+    bool 0 1 (isMemActive memOp)
+        + bool 0 1 (isAluActive alu1Op)
+        + bool 0 1 (isAluActive alu2Op)
+        + bool 0 1 (isCtrlActive ctrlOp)
+
+recordBundle :: Isa w l -> VliwLoadAcc -> VliwLoadAcc
+recordBundle isa (VliwLoadAcc m) =
+    VliwLoadAcc $ alter (Just . maybe 1 (+ 1)) (bundleActiveCount isa) m
+
+vliwLoadPercent :: VliwLoadAcc -> Int
+vliwLoadPercent (VliwLoadAcc m) =
+    let total = sum m
+        active = sum [k * n | (k, n) <- toPairs m]
+     in if total == 0 then 0 else (active * 100) `div` (total * 4)
+
+-- | Render the per-load histogram as @"K:N (P%)"@ pairs separated by commas,
+--   one per non-empty bucket. @K@ is the active-slot count, @N@ is the
+--   number of bundles in that bucket, @P@ is its percent share of executed
+--   bundles. Empty buckets are omitted; an empty histogram renders as @"-"@.
+renderBundlesByLoad :: VliwLoadAcc -> Text
+renderBundlesByLoad (VliwLoadAcc m) =
+    let nonZero = [(k, n) | k <- [0 .. 4 :: Int], let n = lookupDefault 0 k m, n > 0]
+        total = sum (map snd nonZero)
+        pct n = if total == 0 then 0 else (n * 100) `div` total
+        fmt (k, n) =
+            (show k :: Text) <> ":" <> show n <> " (" <> show (pct n) <> "%)"
+     in if null nonZero then "-" else T.intercalate ", " (map fmt nonZero)
 
 -- * Parser Helpers
 
@@ -371,6 +427,7 @@ data MachineState mem w = State
     , stopped :: Bool
     , internalError :: Maybe Text
     , randoms :: [Int]
+    , vliwLoad :: !VliwLoadAcc
     }
     deriving (Show)
 
@@ -446,6 +503,7 @@ instance (MachineWord w) => InitState (IoMem (Isa w w) w) (MachineState (IoMem (
             , stopped = False
             , internalError = Nothing
             , randoms = randomStream
+            , vliwLoad = emptyVliwLoad
             }
 
 instance (MachineWord w) => StateInterspector (MachineState (IoMem (Isa w w) w) w) (IoMem (Isa w w) w) (Isa w w) w where
@@ -463,6 +521,11 @@ instance (MachineWord w) => StateInterspector (MachineState (IoMem (Isa w w) w) 
                     viewRegister f r''
             _ -> errorView v
 
+    summaryView _labels State{vliwLoad} v = case T.splitOn ":" v of
+        ["vliw", "load-percent"] -> Just (show (vliwLoadPercent vliwLoad) <> "%")
+        ["vliw", "bundles-by-load"] -> Just (renderBundlesByLoad vliwLoad)
+        _ -> Nothing
+
 instance (MachineWord w) => Machine (MachineState (IoMem (Isa w w) w) w) (Isa w w) w where
     instructionFetch = do
         st <- get
@@ -476,7 +539,9 @@ instance (MachineWord w) => Machine (MachineState (IoMem (Isa w w) w) w) (Isa w 
                         put st{mem = mem'}
                         return $ Right (pc, instruction)
 
-    instructionExecute _pc Isa{memOp, alu1Op, alu2Op, ctrlOp} = do
+    instructionExecute _pc bundle@Isa{memOp, alu1Op, alu2Op, ctrlOp} = do
+        -- Tally per-bundle slot usage for the vliw:* report variables.
+        modify $ \st -> st{vliwLoad = recordBundle bundle (vliwLoad st)}
         -- Phase 1: Read all source operands and compute results (without modifying state)
         memResult <- computeMem memOp
         alu1OpResult <- computeAlu alu1Op

--- a/src/wrench/Wrench/Machine/Types.hs
+++ b/src/wrench/Wrench/Machine/Types.hs
@@ -179,6 +179,15 @@ class StateInterspector st m isa w | st -> m isa w where
     reprState :: HashMap String w -> st -> Text -> Text
     reprState _labels _st var = "unknown variable: " <> var
 
+    -- | Per-run summary views, resolved from the simulator's *final* state
+    --   (not the per-state record in the trace log). Use this for stats that
+    --   only make sense at end-of-run -- e.g. accumulators that grow each
+    --   step, where the per-state value would be off by one. Returns
+    --   'Nothing' when the variable isn't a summary view, in which case the
+    --   resolver falls through to the per-state 'reprState'.
+    summaryView :: HashMap String w -> st -> Text -> Maybe Text
+    summaryView _labels _st _var = Nothing
+
 class Machine st isa w | st -> isa w where
     instructionFetch :: State st (Either Text (Int, isa))
     instructionStep :: State st ()

--- a/src/wrench/Wrench/Report.hs
+++ b/src/wrench/Wrench/Report.hs
@@ -143,7 +143,9 @@ prepareStateView line TranslatorResult{labels, dumpStats} finalState instrCount 
             ["mem", "io-ranges"] -> renderIntervalsHex alIo
             ["mem", "io-ranges", fmt] -> rangesFmt fmt alIo
             ["memory", "table"] -> renderMemoryTable dumpStats (memoryDump finalState)
-            _ -> reprState labels st v
+            _ -> case summaryView labels finalState v of
+                Just txt -> txt
+                Nothing -> reprState labels st v
         rangesFmt "dec" = renderIntervals
         rangesFmt "hex" = renderIntervalsHex
         rangesFmt fmt = const (unknownFormat fmt)

--- a/test/Wrench/Isa/VliwIv/Test.hs
+++ b/test/Wrench/Isa/VliwIv/Test.hs
@@ -224,6 +224,7 @@ st0 =
         , stopped = False
         , internalError = Nothing
         , randoms = []
+        , vliwLoad = emptyVliwLoad
         }
 
 withRegs :: [(Register, Int32)] -> VliwIvState Int32

--- a/test/golden/vliw-iv/hello.vliw-iv.result
+++ b/test/golden/vliw-iv/hello.vliw-iv.result
@@ -4,3 +4,7 @@ numio[0x80]: [] >>> []
 numio[0x84]: [] >>> [31,72,101,108,108,111,10,0,87,111,114,108,100,33]
 symio[0x80]: "" >>> ""
 symio[0x84]: "" >>> "?Hello\n\0World!"
+---
+# vliw-load
+vliw:load-percent:    81%
+vliw:bundles-by-load: 1:3 (9%), 3:16 (48%), 4:14 (42%)

--- a/test/golden/vliw-iv/hello.yaml
+++ b/test/golden/vliw-iv/hello.yaml
@@ -12,3 +12,11 @@ reports:
       numio[0x84]: {io:0x84:dec}
       symio[0x80]: {io:0x80:sym}
       symio[0x84]: {io:0x84:sym}
+  - name: vliw-load
+    slice: last
+    view: |
+      vliw:load-percent:    {vliw:load-percent}
+      vliw:bundles-by-load: {vliw:bundles-by-load}
+    assert: |
+      vliw:load-percent:    81%
+      vliw:bundles-by-load: 1:3 (9%), 3:16 (48%), 4:14 (42%)


### PR DESCRIPTION
Adds two report view variables for the VLIW-IV ISA that show how well a program exploits the four-wide pipeline.

## What's new

| Variable | Meaning |
|---|---|
| `vliw:load-percent` | Aggregate slot utilization, rendered as `NN%`. `25%` means 1 slot per bundle on average; `100%` means every bundle was fully packed. |
| `vliw:bundles-by-load` | Histogram `0:N, 1:N, 2:N, 3:N, 4:N` of bundles grouped by active-slot count. |

A bundle slot is "active" if it isn't the corresponding `nop` (`NopM`, `NopA`, `NopC`). The simulator tallies one entry per executed bundle.

## Sample readings

Running across the existing vliw-iv goldens (and the new assertion on `hello.s`):

| Program | load | histogram |
|---|---|---|
| `hello.s` | **81%** | `0:0, 1:3, 2:0, 3:16, 4:14` |
| `count.s` | 37% | `0:0, 1:23, 2:22, 3:0, 4:0` |
| `factorial.s` | 25% | `0:0, 1:42, 2:0, 3:0, 4:0` |
| `ble_bleu.s` | 25% | `0:0, 1:9, 2:0, 3:0, 4:0` |
| `lui_addi.s` | 25% | `0:0, 1:5, 2:0, 3:0, 4:0` |

`hello.s` is the headline -- 30 of 33 bundles use 3 or 4 slots. `factorial.s` and friends are serial: every bundle uses exactly one slot.

## How it works

- `Wrench.Isa.VliwIv.MachineState` gains `vliwLoad :: !VliwLoadAcc`, an `IntMap` keyed by active-slot count (0..4) mapping to bundle counts.
- `instructionExecute` updates it once per bundle via `recordBundle bundle`.
- `Wrench.Machine.Types.StateInterspector` gains a new `summaryView` method (default `Nothing`) for per-run summary stats. `prepareStateView` consults `summaryView finalState` before falling through to `reprState st`. This mirrors how `mem:*` is read from the simulator's final state -- without it the histogram would be off-by-one because `tellState` records the pre-step state, so the last recorded `TState` wouldn't include the last bundle's increment.
- `VliwIv.summaryView` implements `vliw:load-percent` and `vliw:bundles-by-load`. The per-state `reprState` is unchanged (regs and flags continue to reflect per-step values for `slice: all` views).

## Test coverage

- `test/golden/vliw-iv/hello.yaml` extended with a `vliw-load` report asserting the values above. 524 tests pass (one new assertion).
- `test/Wrench/Isa/VliwIv/Test.hs`'s test fixture updated for the new `vliwLoad` field.

## Documentation

`docs/vliw-iv.md` gains a "Slot utilization (parallelism)" subsection describing the two variables with a worked example showing the `hello.s` reading.

## Test plan
- [ ] `stack test`
- [ ] Spot-check on `hello.s` -- the asserted histogram (`0:0, 1:3, 2:0, 3:16, 4:14`) matches the parallelism the compiler/programmer expressed.
- [ ] Spot-check on `factorial.s` -- expected `25%` / mostly 1-active because the iterative factorial doesn't expose parallelism.