### PR TITLE
Bump CI actions to Node 24 majors; fix HLint suggestion

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -141,7 +141,7 @@ jobs:
           tar -czvf wrench-${{ runner.os }}-${{ runner.arch }}.tar.gz -C ./dist .
 
       - name: Upload Binary as Artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: wrench-${{ runner.os }}-${{ runner.arch }}
           path: wrench-${{ runner.os }}-${{ runner.arch }}.tar.gz
@@ -156,7 +156,7 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/')
     steps:
       - uses: actions/checkout@v6
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           path: release
           merge-multiple: true
@@ -200,19 +200,19 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Log in to Docker Hub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v7
         with:
           context: .
           push: true

--- a/src/wrench/Wrench/Report.hs
+++ b/src/wrench/Wrench/Report.hs
@@ -164,7 +164,7 @@ renderMemoryTable dumpStats mem =
         wordSize = byteSizeT @w
         AccessLog{alInstr, alData, alIo} = accessLog mem
         DumpStats{dsTextIntervals, dsDataIntervals} = dumpStats
-        ioIntervals = foldr (\k acc -> recordRange k wordSize acc) emptyIntervals ports
+        ioIntervals = foldr (`recordRange` wordSize) emptyIntervals ports
         accessedAll = alInstr `intervalsUnion` alData `intervalsUnion` alIo
 
         -- Declared section rows: one per text/data/io cluster (in-section


### PR DESCRIPTION
Clears all annotations from the latest `master` CI run (run [26915556911](https://github.com/ryukzak/wrench/actions/runs/26915556911)).

## Node.js 20 deprecation
GitHub forces Node 24 on 2026-06-16 and removes Node 20 on 2026-09-16. Bumped each flagged action to its latest Node-24 major (verified each target declares `using: node24`):

| Action | Before | After |
|---|---|---|
| `actions/upload-artifact` | v4 | v7 |
| `actions/download-artifact` | v4 | v8 |
| `docker/login-action` | v2 | v4 |
| `docker/build-push-action` | v4 | v7 |
| `docker/setup-qemu-action` | v3 | v4 |
| `docker/setup-buildx-action` | v3 | v4 |

`download-artifact` wasn't flagged yet but is bumped to keep the upload/download pair matched and off Node 20.

## HLint
`src/wrench/Wrench/Report.hs:167` — replaced `\k acc -> recordRange k wordSize acc` with the `` (`recordRange` wordSize) `` section. `stack build` re-verified.

## Not addressed
The `windows-latest -> windows-2025-vs2026` NOTICE is informational; the rolling label redirect is the intended behavior, so no change.

Note: the `build-push-action`/artifact bumps cross multiple majors but only the inputs already in use are touched, all still supported. These steps run only on `master`/tags, so they won't be exercised by this PR's checks — worth watching the first edge-image and release run after merge.