### PR TITLE
Show execution stats on wrench-serv report page

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -301,6 +301,7 @@ Execution and memory statistics. These are typically used with `slice: last` to 
 - `mem:data-ranges` -- Address ranges of data reads and writes (merged into one set). Same `:dec`/`:hex` suffix.
 - `mem:io-ranges` -- Address ranges of memory-mapped IO accesses. Same `:dec`/`:hex` suffix.
 - `memory:table` -- Multi-line address-space table that puts the above together: one row per declared `text`/`data` section, one per IO cluster, and `x` rows for free regions (split at access boundaries, so the stack gets its own row). Columns: `Kind`, `Range`, `Bytes`, `Accessed`, `Coverage`. The `Bytes` column sums to `memory_size` as a built-in sanity check.
+- `isa-specific` -- ISA-specific summary block. Each architecture fills it with its own stat lines (e.g. `vliw:load-percent` + `vliw:bundles-by-load` on vliw-iv; `f32a:data-stack-max` + `f32a:return-stack-max` on f32a); architectures without any render an empty block. Lets one report template stay uniform across ISAs without emitting `[unknown-view]` for the variables that don't apply.
 
 Example -- print a stats summary after the simulation finishes:
 

--- a/docs/f32a.md
+++ b/docs/f32a.md
@@ -58,6 +58,8 @@ f32a:return-stack-max: 3
 
 The return-stack depth reflects how deeply the recursive/nested calls nested; the data-stack depth bounds how many operands were live at once -- useful for sizing the stack region and spotting runaway recursion.
 
+Both lines are also emitted together by the generic `{isa-specific}` summary block, which lets a single report template stay uniform across ISAs.
+
 ## Instructions
 
 Instruction size: 1 byte for opcode, 4 bytes for each argument.

--- a/docs/vliw-iv.md
+++ b/docs/vliw-iv.md
@@ -275,3 +275,5 @@ vliw:bundles-by-load: 1:3 (9%), 3:16 (48%), 4:14 (42%)
 ```
 
 — 14 fully-packed bundles (`4:14 (42%)`), 16 three-wide (`3:16 (48%)`), 3 with a single active slot (`1:3 (9%)`), no idle or two-slot bundles.
+
+Both lines are also emitted together by the generic `{isa-specific}` summary block, which lets a single report template stay uniform across ISAs.

--- a/script/variants.py
+++ b/script/variants.py
@@ -135,8 +135,24 @@ def run_python_test_cases(verbose):
             case.check_assert(variant.reference)
 
 
-def generate_wrench_test_cases(conf_name, case):
+EXECUTION_STATS_REPORT = """  - name: Execution statistics
+    slice: last
+    view: |
+      sim:instruction-count: {sim:instruction-count}
+      layout:sections-size:  {layout:sections-size} (text {layout:text-sections-size} / data {layout:data-sections-size})
+      mem:instr-ranges:      {mem:instr-ranges}
+      mem:data-ranges:       {mem:data-ranges}
+      mem:io-ranges:         {mem:io-ranges}
+
+      {isa-specific}
+
+      {memory:table}
+"""
+
+
+def generate_wrench_test_cases(conf_name, case, with_stats=False):
     conf_name = case.assert_string(conf_name)
+    stats_report = EXECUTION_STATS_REPORT if with_stats else ""
     return f"""name: "{conf_name}"
 limit: {case.limit}
 memory_size: 0x1000
@@ -151,7 +167,7 @@ reports:
 {case.yaml_view()}
     assert: |
 {case.yaml_assert()}
-"""
+{stats_report}"""
 
 
 ###########################################################
@@ -182,7 +198,7 @@ def generate_wrench_variant_test_cases(path):
             fn = f"{path}/{name}/{idx}.yaml"
             with open(fn, "w") as f:
                 print(fn)
-                f.write(generate_wrench_test_cases(name, case))
+                f.write(generate_wrench_test_cases(name, case, with_stats=True))
 
 
 def inf_shuffle(xs):

--- a/src/wrench-serv/Main.hs
+++ b/src/wrench-serv/Main.hs
@@ -142,6 +142,18 @@ submitForm conf@Config{cStoragePath, cVariantsPath} cookie task@SimulationReques
         let testCaseLogFn = dir <> "/test_cases_result.log"
         liftIO $ writeFileText testCaseLogFn srTestCase
 
+    -- Execution stats for every variant case (the `Execution statistics`
+    -- report block injected into each generated variant config). Headed by
+    -- the case's status line so the report page can show stats per case.
+    let statsLog =
+            T.intercalate "\n\n---\n\n"
+                $ map
+                    ( \(SimulationResult{srTestCaseStatus, srStats}) ->
+                        "# " <> T.takeWhile (/= '\n') srTestCaseStatus <> "\n" <> srStats
+                    )
+                    varChecks
+    liftIO $ writeFileText (dir <> "/stats.log") statsLog
+
     endAt <- liftIO now
     track <- liftIO $ getTrack cookie
     posthogId <- liftIO $ getPosthogIdFromCookie cookie (track <> "_mp")
@@ -195,6 +207,7 @@ getReport conf@Config{cStoragePath} cookie guid = do
             then decodeUtf8 <$> readFileBS (dir <> "/wrench-version.txt")
             else return "< 0.2.11"
     dump <- liftIO (fromMaybe "DUMP NOT AVAILABLE" <$> maybeReadFile (dumpFn cStoragePath guid))
+    stats <- liftIO (fromMaybe "" <$> maybeReadFile (dir <> "/stats.log"))
 
     template <- liftIO (decodeUtf8 <$> readFileBS "static/result.html")
 
@@ -219,6 +232,7 @@ getReport conf@Config{cStoragePath} cookie guid = do
                 , ("{{yaml_content}}", formatCodeWithLineNumbers configContent)
                 , ("{{result}}", formatCodeWithLineNumbers logContent)
                 , ("{{test_cases_result}}", formatCodeWithLineNumbers testCaseResult)
+                , ("{{execution_stats}}", formatCodeWithLineNumbers stats)
                 , ("{{dump}}", formatCodeWithLineNumbers dump)
                 ]
 

--- a/src/wrench-serv/WrenchServ/Simulation.hs
+++ b/src/wrench-serv/WrenchServ/Simulation.hs
@@ -70,6 +70,7 @@ data SimulationResult = SimulationResult
     , srStatusLog :: Text
     , srTestCaseStatus :: Text
     , srTestCase :: Text
+    , srStats :: Text
     , srSuccess :: Bool
     }
     deriving (Generic, Show)
@@ -92,6 +93,7 @@ doSimulation Config{cWrenchPath, cWrenchArgs, cLogLimit} SimulationTask{stIsa, s
                 "\n"
                 ["$ date", show currentTime, "$ wrench --version", wrenchVersion, srCmd, show srExitCode, toText srError]
         stdoutText = toText out
+        srStats = extractStats stdoutText
         srOutput =
             if T.length stdoutText > cLogLimit
                 then "LOG TOO LONG, CROPPED\n\n" <> T.drop (T.length stdoutText - cLogLimit) stdoutText
@@ -117,4 +119,15 @@ doSimulation Config{cWrenchPath, cWrenchArgs, cLogLimit} SimulationTask{stIsa, s
             , srStatusLog
             , srTestCase
             , srTestCaseStatus
+            , srStats
             }
+
+-- | Pull the @Execution statistics@ report block out of wrench's stdout.
+-- Report blocks are @---@-separated and prefixed with @# <name>@ (see
+-- 'Wrench.Wrench.wrench'); we return the body of that block with the
+-- header line dropped, or @""@ if the config produced no stats report.
+extractStats :: Text -> Text
+extractStats out =
+    let header = "# Execution statistics"
+        section = find (T.isPrefixOf header . T.strip) $ map T.strip $ T.splitOn "---" out
+     in maybe "" (T.strip . T.drop (T.length header) . T.strip) section

--- a/src/wrench/Wrench/Isa/F32a.hs
+++ b/src/wrench/Wrench/Isa/F32a.hs
@@ -376,6 +376,13 @@ instance (MachineWord w) => StateInterspector (MachineState (IoMem (Isa w w) w) 
     summaryView _labels State{dataStackMax, returnStackMax} v = case T.splitOn ":" v of
         ["f32a", "data-stack-max"] -> Just $ show dataStackMax
         ["f32a", "return-stack-max"] -> Just $ show returnStackMax
+        ["isa-specific"] ->
+            Just
+                $ "f32a:data-stack-max:   "
+                <> show dataStackMax
+                <> "\n"
+                <> "f32a:return-stack-max: "
+                <> show returnStackMax
         _ -> Nothing
 
 instance (MachineWord w) => Machine (MachineState (IoMem (Isa w w) w) w) (Isa w w) w where

--- a/src/wrench/Wrench/Isa/VliwIv.hs
+++ b/src/wrench/Wrench/Isa/VliwIv.hs
@@ -524,6 +524,13 @@ instance (MachineWord w) => StateInterspector (MachineState (IoMem (Isa w w) w) 
     summaryView _labels State{vliwLoad} v = case T.splitOn ":" v of
         ["vliw", "load-percent"] -> Just (show (vliwLoadPercent vliwLoad) <> "%")
         ["vliw", "bundles-by-load"] -> Just (renderBundlesByLoad vliwLoad)
+        ["isa-specific"] ->
+            Just
+                $ "vliw:load-percent:     "
+                <> show (vliwLoadPercent vliwLoad)
+                <> "%\n"
+                <> "vliw:bundles-by-load: "
+                <> renderBundlesByLoad vliwLoad
         _ -> Nothing
 
 instance (MachineWord w) => Machine (MachineState (IoMem (Isa w w) w) w) (Isa w w) w where

--- a/src/wrench/Wrench/Machine/Memory.hs
+++ b/src/wrench/Wrench/Machine/Memory.hs
@@ -38,7 +38,7 @@ data DumpStats = DumpStats
     }
     deriving (Eq, Show)
 
-prepareDump :: (ByteSize isa, MachineWord w) => Int -> [Section isa w w] -> Mem isa w
+prepareDump :: (ByteSize isa, MachineWord w) => Int -> [Section isa w w] -> Either Text (Mem isa w)
 prepareDump memorySize sections =
     let addSection cells offset dump =
             let dump' = zip [offset ..] cells
@@ -75,12 +75,18 @@ prepareDump memorySize sections =
         placeholder = map (,Value 0) [0 .. memorySize - 1]
      in if dumpSize > memorySize
             then
-                error $ "error: can not fit translation results in memory, need: " <> show dumpSize <> " available: " <> show memorySize
+                Left
+                    $ "program does not fit in memory: it needs "
+                    <> show dumpSize
+                    <> " bytes, but memory_size is "
+                    <> show memorySize
+                    <> " bytes. Increase memory_size in the configuration."
             else
-                Mem
-                    { memorySize
-                    , memoryData = fromList (placeholder <> fromSections)
-                    }
+                Right
+                    Mem
+                        { memorySize
+                        , memoryData = fromList (placeholder <> fromSections)
+                        }
 
 -- | Translation-time layout summary derived from the section list.
 computeDumpStats :: (ByteSize isa, ByteSizeT w) => [Section isa w l] -> DumpStats

--- a/src/wrench/Wrench/Report.hs
+++ b/src/wrench/Wrench/Report.hs
@@ -143,6 +143,10 @@ prepareStateView line TranslatorResult{labels, dumpStats} finalState instrCount 
             ["mem", "io-ranges"] -> renderIntervalsHex alIo
             ["mem", "io-ranges", fmt] -> rangesFmt fmt alIo
             ["memory", "table"] -> renderMemoryTable dumpStats (memoryDump finalState)
+            -- ISA-specific summary block: each architecture fills it with its
+            -- own stats (vliw:*, f32a:*, ...); ISAs without any render "".
+            -- Lets a single report template stay uniform across ISAs.
+            ["isa-specific"] -> fromMaybe "" (summaryView labels finalState "isa-specific")
             _ -> case summaryView labels finalState v of
                 Just txt -> txt
                 Nothing -> reprState labels st v

--- a/src/wrench/Wrench/Translator.hs
+++ b/src/wrench/Wrench/Translator.hs
@@ -84,7 +84,8 @@ translate memorySize fn src =
                 (Right labels) ->
                     let resolveLabel l = (labels !? l)
                         code = map (uncurry (derefSection resolveLabel)) (markupSectionOffsets 0 sections)
-                        dump = prepareDump memorySize code
                         stats = computeDumpStats code
-                     in Right $ TranslatorResult dump labels stats
+                     in do
+                            dump <- prepareDump memorySize code
+                            Right $ TranslatorResult dump labels stats
         Left err -> Left $ toText $ errorBundlePretty err

--- a/static/result.html
+++ b/static/result.html
@@ -65,6 +65,11 @@
           'test-cases-result-empty-tag',
         )
         handleEmptyContent(
+          'execution-stats-text-element',
+          'accordion-collapse-execution-stats',
+          'execution-stats-empty-tag',
+        )
+        handleEmptyContent(
           'simulation-log-text-element',
           'accordion-collapse-simulation-log',
           'simulation-log-empty-tag',
@@ -349,6 +354,42 @@
           class="hidden bg-[var(--c-dark-grey)] mb-4 p-4 rounded-lg"
         >
           failed_test_case = ""
+          <span class="text-[var(--c-grey)]"> /* nothing returned */</span>
+        </div>
+        <div
+          id="accordion-collapse-execution-stats"
+          data-accordion="collapse"
+          class="bg-[var(--c-dark-grey)] mb-4 p-4 rounded-lg"
+          data-inactive-classes="vim-folded text-[var(--c-orange-low-saturation)]"
+          data-active-classes="text-[var(--c-orange-low-saturation)] bg-transparent"
+        >
+          <h2
+            id="accordion-collapse-heading-execution-stats"
+            class="flex justify-between items-center hover:bg-[var(--c-white)] hover:opacity-80 w-full text-[var(--c-orange-low-saturation)] hover:text-[var(--c-black)] text-left hover:cursor-pointer vim-folded"
+            data-accordion-target="#accordion-collapse-body-execution-stats"
+            aria-expanded="false"
+            aria-controls="accordion-collapse-body-execution-stats"
+          >
+            <span class="flex-1 select-none">execution_stats =</span>
+          </h2>
+          <div
+            id="accordion-collapse-body-execution-stats"
+            class="hidden"
+            aria-labelledby="accordion-collapse-heading-execution-stats"
+          >
+            <div
+              id="execution-stats-text-element"
+              class="pb-4 rounded-lg overflow-x-auto"
+            >
+              {{execution_stats}}
+            </div>
+          </div>
+        </div>
+        <div
+          id="execution-stats-empty-tag"
+          class="hidden bg-[var(--c-dark-grey)] mb-4 p-4 rounded-lg"
+        >
+          execution_stats = ""
           <span class="text-[var(--c-grey)]"> /* nothing returned */</span>
         </div>
         <div

--- a/test/golden/f32a/factorial.f32a.result
+++ b/test/golden/f32a/factorial.f32a.result
@@ -1446,3 +1446,7 @@ numio[0x84]: [] >>> [24]
 # Stack utilization
 f32a:data-stack-max: 5
 f32a:return-stack-max: 3
+---
+# isa-specific
+f32a:data-stack-max:   5
+f32a:return-stack-max: 3

--- a/test/golden/f32a/factorial.yaml
+++ b/test/golden/f32a/factorial.yaml
@@ -26,3 +26,10 @@ reports:
     assert: |
       f32a:data-stack-max: 5
       f32a:return-stack-max: 3
+  - name: isa-specific
+    slice: last
+    view: |
+      {isa-specific}
+    assert: |
+      f32a:data-stack-max:   5
+      f32a:return-stack-max: 3

--- a/test/golden/vliw-iv/hello.vliw-iv.result
+++ b/test/golden/vliw-iv/hello.vliw-iv.result
@@ -8,3 +8,7 @@ symio[0x84]: "" >>> "?Hello\n\0World!"
 # vliw-load
 vliw:load-percent:    81%
 vliw:bundles-by-load: 1:3 (9%), 3:16 (48%), 4:14 (42%)
+---
+# isa-specific
+vliw:load-percent:     81%
+vliw:bundles-by-load: 1:3 (9%), 3:16 (48%), 4:14 (42%)

--- a/test/golden/vliw-iv/hello.yaml
+++ b/test/golden/vliw-iv/hello.yaml
@@ -20,3 +20,10 @@ reports:
     assert: |
       vliw:load-percent:    81%
       vliw:bundles-by-load: 1:3 (9%), 3:16 (48%), 4:14 (42%)
+  - name: isa-specific
+    slice: last
+    view: |
+      {isa-specific}
+    assert: |
+      vliw:load-percent:     81%
+      vliw:bundles-by-load: 1:3 (9%), 3:16 (48%), 4:14 (42%)


### PR DESCRIPTION
Surfaces the execution & memory stats (#153–#155) plus the per-ISA summary stats (`vliw:*` from #155, `f32a:*` from #158) on the **wrench-serv report page**, sourced from the variant check runs. Rebased on master (includes #158).

## New `{isa-specific}` report variable

A single report variable that each architecture fills with its own summary block:

- **vliw-iv** → `vliw:load-percent` + `vliw:bundles-by-load`
- **f32a** → `f32a:data-stack-max` + `f32a:return-stack-max`
- **risc-iv-32 / m68k / acc32** → empty block

Resolved via `StateInterspector.summaryView "isa-specific"` (default `Nothing` → `""`) in `Report.hs`. This lets one report template stay uniform across all ISAs **without** referencing ISA-specific variables directly — so there's no `[unknown-view]` garbage and no `errorView` crash on the ISAs that lack a given variable. All five ISAs run cleanly (exit 0).

## What you see

A collapsed **`execution_stats =`** accordion in the report's right column, between `failed_test_case` and `dump`. Per variant test case, headed by its status line:

```
# variants/factorial/1.yaml: ExitSuccess
sim:instruction-count: 23
layout:sections-size: 348 (text 204 / data 144)
mem:instr-ranges: 0x90..0xa2, 0xa8..0xb4, 0xec..0xfc, 0x15a..0x15b
mem:data-ranges: 0x0..0x7
mem:io-ranges: 0x80..0x87
f32a:data-stack-max: 3
f32a:return-stack-max: 3
Kind  Range         Bytes  Accessed                          Coverage
...
```

(The `f32a:*` lines come from `{isa-specific}`; on a risc-iv-32 submission those lines are simply absent.) Stats are produced for **all** variant cases. With no variant selected the panel shows `execution_stats = "" /* nothing returned */`.

## How it works

- **`script/variants.py`** — `generate_wrench_test_cases` gains a `with_stats` flag appending an `Execution statistics` report block (`sim:`, `layout:`, `mem:*-ranges`, `memory:table`, and a single `{isa-specific}` line). Only the **deployed** variant generator passes `with_stats=True`.
- **`Wrench.Report`** — resolver maps `{isa-specific}` to `summaryView … "isa-specific"`, defaulting to `""`.
- **`Wrench.Isa.VliwIv` / `Wrench.Isa.F32a`** — `summaryView` handles `"isa-specific"`, returning the ISA's composite block.
- **`WrenchServ.Simulation`** — `SimulationResult` gains `srStats`, extracted from the `# Execution statistics` block of wrench stdout.
- **`WrenchServ` `Main`** — writes `stats.log` (one block per variant case) and substitutes `{{execution_stats}}`.
- **`static/result.html`** — collapsed accordion mirroring the `dump` panel.

## Why not the golden fixtures

The stats block is kept out of `test/golden/generated/*`: there `factorial.s` and `factorial_rec.s` run against the **same** generated config and share one golden `.result` file; their stats legitimately differ and would collide. Coverage instead lives in dedicated goldens — `vliw-iv/hello.yaml` and `f32a/factorial.yaml` now also assert the `{isa-specific}` block.

## Test plan

- [x] `stack test` — all pass.
- [x] Ran `wrench-serv` locally; submitted variant runs on **all five ISAs** — each renders its own `{isa-specific}` block (or empty), no crashes, no `[unknown-view]`.