### PR TITLE
Track f32a data/return stack high-water marks

### DIFF
--- a/docs/f32a.md
+++ b/docs/f32a.md
@@ -31,6 +31,33 @@ Inspired by [F18a](https://www.greenarraychips.com/home/documents/greg/DB001-221
 - `EAM` -- Extended Arithmetic Mode (1 if enabled, 0 if disabled).
 - `C` -- Carry Flag (1 if set, 0 if cleared).
 
+### Stack utilization
+
+The simulator tracks the high-water mark (deepest level reached) of each stack over the whole run and exposes it through two summary view variables. They are run-totals, so use them with `slice: last`.
+
+- `f32a:data-stack-max` -- maximum data stack depth reached during execution.
+- `f32a:return-stack-max` -- maximum return stack depth reached during execution.
+
+Example -- print a stack-depth summary at the end of the simulation:
+
+```yaml
+reports:
+    - name: stacks
+      slice: last
+      view: |
+        f32a:data-stack-max:   {f32a:data-stack-max}
+        f32a:return-stack-max: {f32a:return-stack-max}
+```
+
+For `factorial.s` computing `4!` the summary reads:
+
+```text
+f32a:data-stack-max:   5
+f32a:return-stack-max: 3
+```
+
+The return-stack depth reflects how deeply the recursive/nested calls nested; the data-stack depth bounds how many operands were live at once -- useful for sizing the stack region and spotting runaway recursion.
+
 ## Instructions
 
 Instruction size: 1 byte for opcode, 4 bytes for each argument.

--- a/src/wrench/Wrench/Isa/F32a.hs
+++ b/src/wrench/Wrench/Isa/F32a.hs
@@ -235,6 +235,10 @@ data MachineState mem w = State
     , ram :: mem
     , dataStack :: [w]
     , returnStack :: [w]
+    , dataStackMax :: !Int
+    -- ^ High-water mark of the data stack depth over the run (for f32a:data-stack-max).
+    , returnStackMax :: !Int
+    -- ^ High-water mark of the return stack depth over the run (for f32a:return-stack-max).
     , stopped :: Bool
     , extendedArithmeticMode :: Bool
     , carryFlag :: Bool
@@ -250,6 +254,8 @@ instance (MachineWord w) => InitState (IoMem (Isa w w) w) (MachineState (IoMem (
             , b = def
             , dataStack = []
             , returnStack = []
+            , dataStackMax = 0
+            , returnStackMax = 0
             , ram = dump
             , stopped = False
             , extendedArithmeticMode = False
@@ -290,8 +296,9 @@ setWord addr w = do
 
 dataPush w = do
     setCarryFlag False
-    st@State{dataStack} <- get
-    put st{dataStack = w : dataStack}
+    st@State{dataStack, dataStackMax} <- get
+    let dataStack' = w : dataStack
+    put st{dataStack = dataStack', dataStackMax = max dataStackMax (length dataStack')}
 
 dataPop :: (MachineWord w) => State (MachineState (IoMem (Isa w w) w) w) w
 dataPop = do
@@ -305,8 +312,9 @@ dataPop = do
             return x
 
 returnPush w = do
-    st@State{returnStack} <- get
-    put st{returnStack = w : returnStack}
+    st@State{returnStack, returnStackMax} <- get
+    let returnStack' = w : returnStack
+    put st{returnStack = returnStack', returnStackMax = max returnStackMax (length returnStack')}
 
 returnPop :: (MachineWord w) => State (MachineState (IoMem (Isa w w) w) w) w
 returnPop = do
@@ -364,6 +372,11 @@ instance (MachineWord w) => StateInterspector (MachineState (IoMem (Isa w w) w) 
             stack "dec" dt = toText $ intercalate ":" $ map show dt
             stack "hex" dt = T.intercalate ":" $ map (toText . word32ToHex) dt
             stack f _ = unknownFormat f
+
+    summaryView _labels State{dataStackMax, returnStackMax} v = case T.splitOn ":" v of
+        ["f32a", "data-stack-max"] -> Just $ show dataStackMax
+        ["f32a", "return-stack-max"] -> Just $ show returnStackMax
+        _ -> Nothing
 
 instance (MachineWord w) => Machine (MachineState (IoMem (Isa w w) w) w) (Isa w w) w where
     instructionFetch = do

--- a/test/golden/f32a/factorial.f32a.result
+++ b/test/golden/f32a/factorial.f32a.result
@@ -1442,3 +1442,7 @@ T A S 0x00000000 0x00000084 0x00000000 R 0
 # Result
 numio[0x80]: [] >>> []
 numio[0x84]: [] >>> [24]
+---
+# Stack utilization
+f32a:data-stack-max: 5
+f32a:return-stack-max: 3

--- a/test/golden/f32a/factorial.yaml
+++ b/test/golden/f32a/factorial.yaml
@@ -18,3 +18,11 @@ reports:
     assert: |
       numio[0x80]: [] >>> []
       numio[0x84]: [] >>> [24]
+  - name: Stack utilization
+    slice: last
+    view: |
+      f32a:data-stack-max: {f32a:data-stack-max}
+      f32a:return-stack-max: {f32a:return-stack-max}
+    assert: |
+      f32a:data-stack-max: 5
+      f32a:return-stack-max: 3


### PR DESCRIPTION
Adds two per-run summary view variables for the **f32a** ISA, reporting the deepest level each stack reached during execution — the stack analogue of the `vliw:*` load stats from #155.

## Variables

| Variable | Meaning |
|---|---|
| `f32a:data-stack-max` | maximum data stack depth reached over the run |
| `f32a:return-stack-max` | maximum return stack depth reached over the run |

Both are run-totals, so use them with `slice: last`. The return-stack depth shows how deeply nested/recursive calls went; the data-stack depth bounds how many operands were live at once — useful for sizing the stack region and spotting runaway recursion.

## How it works

- `MachineState` gains `dataStackMax` / `returnStackMax :: !Int` (init `0`).
- Updated in `dataPush` / `returnPush` as `max current (length stack')` — the high-water mark is captured exactly where the stacks grow.
- Exposed via a new `StateInterspector.summaryView`. `Report.hs` reads `summaryView` from the **final** machine state, so the reported value is the true run-wide peak (not off-by-one from the pre-step trace records). This mirrors how `vliw:*` is resolved.

The existing `reprState` views (`stack`, `rstack`, `T`/`S`/`R`, …) are unchanged.

## Docs

`docs/f32a.md` gains a "Stack utilization" subsection documenting both variables with a worked `factorial.s` example.

## Tests

`test/golden/f32a/factorial.yaml` gains a `Stack utilization` report asserting `f32a:data-stack-max: 5` / `f32a:return-stack-max: 3` for `4!`; the golden `.result` is regenerated. The existing F32a unit tests are unaffected (they construct state via `initState`).

## Test plan
- [x] `stack test` — passes (no `--accept`); the new assertion holds.
- [x] fourmolu clean.
- [ ] Spot-check on another f32a program (e.g. `div.s`) that the depths match the call/operand nesting.