### PR TITLE
Render memory:table addresses in lowercase hex

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -326,13 +326,13 @@ For the same picture in one shot, use `{memory:table}` -- it walks the whole add
 ```text
 Kind  Range         Bytes  Accessed                    Coverage
 text  0x000..0x027     40  0x000..0x027                    100%
-data  0x028..0x02B      4  0x028..0x02B                    100%
-x     0x02C..0x07F     84  -                                 0%
+data  0x028..0x02b      4  0x028..0x02b                    100%
+x     0x02c..0x07f     84  -                                 0%
 io    0x080..0x087      8  0x080..0x087                    100%
-text  0x090..0x0E3     84  0x090..0x0E3                    100%
-data  0x0E4..0x0F9     22  0x0E4..0x0EE, 0x0F5..0x0F9       72%   <- partial: middle bytes untouched
-x     0x1FC..0x1FF      4  0x1FC..0x1FF                    100%  <- undeclared use (stack)
-x     0x200..0x2FF    256  -                                 0%
+text  0x090..0x0e3     84  0x090..0x0e3                    100%
+data  0x0e4..0x0f9     22  0x0e4..0x0ee, 0x0f5..0x0f9       72%   <- partial: middle bytes untouched
+x     0x1fc..0x1ff      4  0x1fc..0x1ff                    100%  <- undeclared use (stack)
+x     0x200..0x2ff    256  -                                 0%
 ```
 
 For ISA-specific state views, see the respective architecture documentation.

--- a/src/wrench/Wrench/Report.hs
+++ b/src/wrench/Wrench/Report.hs
@@ -191,10 +191,7 @@ renderMemoryTable dumpStats mem =
         hexW = max 3 (length (showHex (max 0 (memSize - 1)) ""))
         addrStr a =
             let h = showHex a ""
-             in "0x" <> T.pack (replicate (hexW - length h) '0') <> T.pack (map toUpperHex h)
-        toUpperHex c
-            | c >= 'a' && c <= 'f' = toEnum (fromEnum c - 32)
-            | otherwise = c
+             in "0x" <> T.pack (replicate (hexW - length h) '0') <> T.pack h
 
         formatRange lo hi = addrStr lo <> ".." <> addrStr hi
 

--- a/test/golden/risc-iv-32/multi_sections.risc-iv-32.result
+++ b/test/golden/risc-iv-32/multi_sections.risc-iv-32.result
@@ -6,12 +6,12 @@ numio[0x84]: [] >>> [7]
 # memory-map
 Kind  Range         Bytes  Accessed                    Coverage
 text  0x000..0x027     40  0x000..0x027                    100%
-data  0x028..0x02B      4  0x028..0x02B                    100%
-x     0x02C..0x07F     84  -                                 0%
+data  0x028..0x02b      4  0x028..0x02b                    100%
+x     0x02c..0x07f     84  -                                 0%
 io    0x080..0x087      8  0x080..0x087                    100%
-x     0x088..0x08F      8  -                                 0%
-text  0x090..0x0E3     84  0x090..0x0E3                    100%
-data  0x0E4..0x0F9     22  0x0E4..0x0EE, 0x0F5..0x0F9       72%
-x     0x0FA..0x1FB    258  -                                 0%
-x     0x1FC..0x1FF      4  0x1FC..0x1FF                    100%
-x     0x200..0x2FF    256  -                                 0%
+x     0x088..0x08f      8  -                                 0%
+text  0x090..0x0e3     84  0x090..0x0e3                    100%
+data  0x0e4..0x0f9     22  0x0e4..0x0ee, 0x0f5..0x0f9       72%
+x     0x0fa..0x1fb    258  -                                 0%
+x     0x1fc..0x1ff      4  0x1fc..0x1ff                    100%
+x     0x200..0x2ff    256  -                                 0%

--- a/test/golden/risc-iv-32/multi_sections.yaml
+++ b/test/golden/risc-iv-32/multi_sections.yaml
@@ -19,12 +19,12 @@ reports:
     assert: |
       Kind  Range         Bytes  Accessed                    Coverage
       text  0x000..0x027     40  0x000..0x027                    100%
-      data  0x028..0x02B      4  0x028..0x02B                    100%
-      x     0x02C..0x07F     84  -                                 0%
+      data  0x028..0x02b      4  0x028..0x02b                    100%
+      x     0x02c..0x07f     84  -                                 0%
       io    0x080..0x087      8  0x080..0x087                    100%
-      x     0x088..0x08F      8  -                                 0%
-      text  0x090..0x0E3     84  0x090..0x0E3                    100%
-      data  0x0E4..0x0F9     22  0x0E4..0x0EE, 0x0F5..0x0F9       72%
-      x     0x0FA..0x1FB    258  -                                 0%
-      x     0x1FC..0x1FF      4  0x1FC..0x1FF                    100%
-      x     0x200..0x2FF    256  -                                 0%
+      x     0x088..0x08f      8  -                                 0%
+      text  0x090..0x0e3     84  0x090..0x0e3                    100%
+      data  0x0e4..0x0f9     22  0x0e4..0x0ee, 0x0f5..0x0f9       72%
+      x     0x0fa..0x1fb    258  -                                 0%
+      x     0x1fc..0x1ff      4  0x1fc..0x1ff                    100%
+      x     0x200..0x2ff    256  -                                 0%


### PR DESCRIPTION
Uniforms the case of **generated** hex output. Everything wrench emits is already lowercase — `word32ToHex`, `word8ToHex`, and `renderIntervalsHex` (backing `mem:*-ranges` / `layout:*-ranges`) use `showHex`. The one outlier was `renderMemoryTable`, which uppercased addresses via a local `toUpperHex`.

Same address rendered two ways before this change:
- `mem:instr-ranges` → `0x90..0xa2` (lower)
- `memory:table` → `0x090..0x0A2` (upper)

## Change
Drop `toUpperHex` so the table uses `showHex`'s lowercase output, matching the rest of the codebase.
- `test/golden/risc-iv-32/multi_sections.{yaml,risc-iv-32.result}` — table + assert relowercased.
- `docs/README.md` — `memory:table` example relowercased.

Input hex literals in docs/asm (`0xFF`, `0xCC`) are untouched — this only affects generated output.

## Test plan
- [x] `stack test` — all 559 pass.
- [x] fourmolu clean.