### PR TITLE
feat(vliw-iv): add vliw:avg-load simulation stat

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -301,7 +301,7 @@ Execution and memory statistics. These are typically used with `slice: last` to 
 - `mem:data-ranges` -- Address ranges of data reads and writes (merged into one set). Same `:dec`/`:hex` suffix.
 - `mem:io-ranges` -- Address ranges of memory-mapped IO accesses. Same `:dec`/`:hex` suffix.
 - `memory:table` -- Multi-line address-space table that puts the above together: one row per declared `text`/`data` section, one per IO cluster, and `x` rows for free regions (split at access boundaries, so the stack gets its own row). Columns: `Kind`, `Range`, `Bytes`, `Accessed`, `Coverage`. The `Bytes` column sums to `memory_size` as a built-in sanity check.
-- `isa-specific` -- ISA-specific summary block. Each architecture fills it with its own stat lines (e.g. `vliw:load-percent` + `vliw:bundles-by-load` on vliw-iv; `f32a:data-stack-max` + `f32a:return-stack-max` on f32a); architectures without any render an empty block. Lets one report template stay uniform across ISAs without emitting `[unknown-view]` for the variables that don't apply.
+- `isa-specific` -- ISA-specific summary block. Each architecture fills it with its own stat lines (e.g. `vliw:load-percent` + `vliw:avg-load` + `vliw:bundles-by-load` on vliw-iv; `f32a:data-stack-max` + `f32a:return-stack-max` on f32a); architectures without any render an empty block. Lets one report template stay uniform across ISAs without emitting `[unknown-view]` for the variables that don't apply.
 
 Example -- print a stats summary after the simulation finishes:
 

--- a/docs/vliw-iv.md
+++ b/docs/vliw-iv.md
@@ -251,9 +251,10 @@ Available registers: `Zero`, `Ra`, `Sp`, `Gp`, `Tp`, `T0`, `T1`, `T2`, `S0Fp`, `
 
 ### Slot utilization (parallelism)
 
-Each VLIW bundle has four execution slots (memory, ALU1, ALU2, control). A slot containing the corresponding `nop` is idle; everything else counts as active. The simulator tallies how many slots each executed bundle used and exposes two summary view variables. They're typically used with `slice: last` because the values are run-totals.
+Each VLIW bundle has four execution slots (memory, ALU1, ALU2, control). A slot containing the corresponding `nop` is idle; everything else counts as active. The simulator tallies how many slots each executed bundle used and exposes three summary view variables. They're typically used with `slice: last` because the values are run-totals.
 
 - `vliw:load-percent` -- average slot utilization across the run, as an integer percent. `(active_slots * 100) / (bundles * 4)`. `25%` means each bundle used one slot on average; `100%` means every slot of every bundle was active.
+- `vliw:avg-load` -- average number of active processing units (slots) per executed bundle, rendered with two decimals. `active_slots / bundles`, a value in `0.00`–`4.00`. This is the same measure as `vliw:load-percent` expressed as units-per-bundle instead of a percent of the four-wide width.
 - `vliw:bundles-by-load` -- histogram rendered as comma-separated `K:N (P%)` entries, one per non-empty bucket. `K` is the active-slot count, `N` is the number of bundles in that bucket, `P` is its percent share of all executed bundles. Empty buckets are skipped. A peak at 1 means a serial program; a peak at 3-4 means the compiler / programmer is exploiting the pipeline.
 
 Example -- print a load summary at the end of the simulation:
@@ -264,6 +265,7 @@ reports:
       slice: last
       view: |
         vliw:load-percent:    {vliw:load-percent}
+        vliw:avg-load:        {vliw:avg-load}
         vliw:bundles-by-load: {vliw:bundles-by-load}
 ```
 
@@ -271,9 +273,10 @@ For `hello.s` running on this ISA the summary reads:
 
 ```text
 vliw:load-percent:    81%
+vliw:avg-load:        3.24
 vliw:bundles-by-load: 1:3 (9%), 3:16 (48%), 4:14 (42%)
 ```
 
-— 14 fully-packed bundles (`4:14 (42%)`), 16 three-wide (`3:16 (48%)`), 3 with a single active slot (`1:3 (9%)`), no idle or two-slot bundles.
+— 14 fully-packed bundles (`4:14 (42%)`), 16 three-wide (`3:16 (48%)`), 3 with a single active slot (`1:3 (9%)`), no idle or two-slot bundles, for an average of `3.24` active units per bundle.
 
-Both lines are also emitted together by the generic `{isa-specific}` summary block, which lets a single report template stay uniform across ISAs.
+All three lines are also emitted together by the generic `{isa-specific}` summary block, which lets a single report template stay uniform across ISAs.

--- a/src/wrench/Wrench/Isa/VliwIv.hs
+++ b/src/wrench/Wrench/Isa/VliwIv.hs
@@ -213,6 +213,21 @@ vliwLoadPercent (VliwLoadAcc m) =
         active = sum [k * n | (k, n) <- toPairs m]
      in if total == 0 then 0 else (active * 100) `div` (total * 4)
 
+-- | Average number of active slots (processing units) used per executed
+--   bundle, rendered with two decimal places. An empty histogram renders as
+--   @"0.00"@.
+vliwAvgLoad :: VliwLoadAcc -> Text
+vliwAvgLoad (VliwLoadAcc m) =
+    let total = sum m
+        active = sum [k * n | (k, n) <- toPairs m]
+     in if total == 0
+            then "0.00"
+            else
+                let scaled = (active * 100) `div` total
+                    whole = scaled `div` 100
+                    frac = scaled `mod` 100
+                 in show whole <> "." <> (if frac < 10 then "0" else "") <> show frac
+
 -- | Render the per-load histogram as @"K:N (P%)"@ pairs separated by commas,
 --   one per non-empty bucket. @K@ is the active-slot count, @N@ is the
 --   number of bundles in that bucket, @P@ is its percent share of executed
@@ -523,13 +538,17 @@ instance (MachineWord w) => StateInterspector (MachineState (IoMem (Isa w w) w) 
 
     summaryView _labels State{vliwLoad} v = case T.splitOn ":" v of
         ["vliw", "load-percent"] -> Just (show (vliwLoadPercent vliwLoad) <> "%")
+        ["vliw", "avg-load"] -> Just (vliwAvgLoad vliwLoad)
         ["vliw", "bundles-by-load"] -> Just (renderBundlesByLoad vliwLoad)
         ["isa-specific"] ->
             Just
-                $ "vliw:load-percent:     "
+                $ "vliw:load-percent:      "
                 <> show (vliwLoadPercent vliwLoad)
                 <> "%\n"
-                <> "vliw:bundles-by-load: "
+                <> "vliw:avg-load:         "
+                <> vliwAvgLoad vliwLoad
+                <> "\n"
+                <> "vliw:bundles-by-load:  "
                 <> renderBundlesByLoad vliwLoad
         _ -> Nothing
 

--- a/src/wrench/Wrench/Isa/VliwIv.hs
+++ b/src/wrench/Wrench/Isa/VliwIv.hs
@@ -542,13 +542,13 @@ instance (MachineWord w) => StateInterspector (MachineState (IoMem (Isa w w) w) 
         ["vliw", "bundles-by-load"] -> Just (renderBundlesByLoad vliwLoad)
         ["isa-specific"] ->
             Just
-                $ "vliw:load-percent:      "
+                $ "vliw:load-percent:    "
                 <> show (vliwLoadPercent vliwLoad)
                 <> "%\n"
-                <> "vliw:avg-load:         "
+                <> "vliw:avg-load:        "
                 <> vliwAvgLoad vliwLoad
                 <> "\n"
-                <> "vliw:bundles-by-load:  "
+                <> "vliw:bundles-by-load: "
                 <> renderBundlesByLoad vliwLoad
         _ -> Nothing
 

--- a/test/golden/vliw-iv/hello.vliw-iv.result
+++ b/test/golden/vliw-iv/hello.vliw-iv.result
@@ -7,8 +7,10 @@ symio[0x84]: "" >>> "?Hello\n\0World!"
 ---
 # vliw-load
 vliw:load-percent:    81%
+vliw:avg-load:        3.24
 vliw:bundles-by-load: 1:3 (9%), 3:16 (48%), 4:14 (42%)
 ---
 # isa-specific
 vliw:load-percent:     81%
+vliw:avg-load:         3.24
 vliw:bundles-by-load: 1:3 (9%), 3:16 (48%), 4:14 (42%)

--- a/test/golden/vliw-iv/hello.vliw-iv.result
+++ b/test/golden/vliw-iv/hello.vliw-iv.result
@@ -11,6 +11,6 @@ vliw:avg-load:        3.24
 vliw:bundles-by-load: 1:3 (9%), 3:16 (48%), 4:14 (42%)
 ---
 # isa-specific
-vliw:load-percent:     81%
-vliw:avg-load:         3.24
+vliw:load-percent:    81%
+vliw:avg-load:        3.24
 vliw:bundles-by-load: 1:3 (9%), 3:16 (48%), 4:14 (42%)

--- a/test/golden/vliw-iv/hello.yaml
+++ b/test/golden/vliw-iv/hello.yaml
@@ -27,6 +27,6 @@ reports:
     view: |
       {isa-specific}
     assert: |
-      vliw:load-percent:     81%
-      vliw:avg-load:         3.24
+      vliw:load-percent:    81%
+      vliw:avg-load:        3.24
       vliw:bundles-by-load: 1:3 (9%), 3:16 (48%), 4:14 (42%)

--- a/test/golden/vliw-iv/hello.yaml
+++ b/test/golden/vliw-iv/hello.yaml
@@ -16,9 +16,11 @@ reports:
     slice: last
     view: |
       vliw:load-percent:    {vliw:load-percent}
+      vliw:avg-load:        {vliw:avg-load}
       vliw:bundles-by-load: {vliw:bundles-by-load}
     assert: |
       vliw:load-percent:    81%
+      vliw:avg-load:        3.24
       vliw:bundles-by-load: 1:3 (9%), 3:16 (48%), 4:14 (42%)
   - name: isa-specific
     slice: last
@@ -26,4 +28,5 @@ reports:
       {isa-specific}
     assert: |
       vliw:load-percent:     81%
+      vliw:avg-load:         3.24
       vliw:bundles-by-load: 1:3 (9%), 3:16 (48%), 4:14 (42%)


### PR DESCRIPTION
## Summary

Adds a new VLIW simulation statistic — **`vliw:avg-load`**: the average number of processing units (slots) used per executed bundle.

The simulator already tracked `vliw:load-percent` (utilization as a percent of the 4-wide width) and `vliw:bundles-by-load` (per-load histogram). This adds the same measure expressed as units-per-instruction (`active_slots / bundles`, range `0.00`–`4.00`), which is a more direct "how many PUs per instruction on average" readout.

## Changes

- `src/wrench/Wrench/Isa/VliwIv.hs` — new `vliwAvgLoad` helper (two-decimal formatting via integer math, reuses the existing histogram accumulator — no new state), wired into `summaryView` as `vliw:avg-load` and into the combined `{isa-specific}` block.
- `docs/vliw-iv.md`, `docs/README.md` — document the new variable.
- `test/golden/vliw-iv/hello.{yaml,vliw-iv.result}` — exercise the new line (`hello.s` → `3.24` = 107 active slots / 33 bundles).

## Notes

"Per instruction" here means per VLIW bundle, consistent with how `sim:instruction-count` counts bundles in this ISA.

## Test plan

- [x] `stack build`
- [x] `stack test` — all 559 tests pass