### PR TITLE
fix(m68k): An as source no longer silently parses as a label (#143)

### DIFF
--- a/docs/m68k.md
+++ b/docs/m68k.md
@@ -59,8 +59,8 @@ Example: `add.b D0, D1` operates on the least significant byte of D0 and D1.
 The M68k ISA supports the following addressing modes:
 
 1. **Register Direct**
-   - **Data Register Direct**: `D0` through `D7`
-   - **Address Register Direct**: `A0` through `A7`
+   - **Data Register Direct**: `D0` through `D7` -- usable as source or destination for every instruction that takes an operand.
+   - **Address Register Direct**: `A0` through `A7` -- usable only as `movea`'s source/destination and as the address-register operand of `link`/`unlk`. Other instructions reject `An` in the operand slot with a parser error; reach an address register's value via `movea` first, or use one of the indirect modes below.
 
 2. **Immediate**: `value`
    - Example: `move.l 42, D0`
@@ -110,13 +110,14 @@ The M68k ISA supports the following addressing modes:
 
 - **Move to Address Register**
     - **Syntax:** `movea.l <source>, <destination>`
-    - **Description:** Move data from the source to the destination address register.
+    - **Description:** Move data from the source to the destination address register. `movea` is the only instruction that accepts `An` as a direct source operand -- other instructions reject `An` at parse time. `movea` is long-only (no `.b` form). Does not affect flags.
     - **Operation:** `<destination> <- <source>`
     - **Examples:**
 
       ```assembly
       movea.l 1000, A0    ; Load immediate value 1000 into A0
       movea.l D0, A1      ; Copy D0 to A1
+      movea.l A2, A0      ; Copy A2 to A0 (only place An is accepted as source)
       ```
 
 ### Logical Instructions

--- a/src/wrench/Wrench/Isa/M68k.hs
+++ b/src/wrench/Wrench/Isa/M68k.hs
@@ -22,8 +22,8 @@ import Data.Text qualified as T
 import Relude
 import Relude.Extra
 import Relude.Unsafe qualified as Unsafe
-import Text.Megaparsec (choice, oneOf, try)
-import Text.Megaparsec.Char (hspace, hspace1, string)
+import Text.Megaparsec (choice, notFollowedBy, oneOf, try)
+import Text.Megaparsec.Char (alphaNumChar, char, hspace, hspace1, string)
 import Wrench.Machine.Memory
 import Wrench.Machine.Types
 import Wrench.Report
@@ -119,7 +119,7 @@ instance (MachineWord w) => MnemonicParser (Isa w (Ref w)) where
     mnemonic =
         choice
             [ cmd2args "move" Move (longMode <|> byteMode) src dst
-            , cmd2args "movea" MoveA longMode src addrRegister
+            , cmd2args "movea" MoveA longMode srcMovea addrRegister
             , cmd1args "not" Not (longMode <|> byteMode) dst
             , cmd1args "neg" Neg (longMode <|> byteMode) dst
             , cmd1args "clr" Clr (longMode <|> byteMode) dst
@@ -167,7 +167,15 @@ instance (MachineWord w) => MnemonicParser (Isa w (Ref w)) where
             , cmd0args "halt" Halt
             ]
         where
+            -- Generic source for instructions where Address Register Direct
+            -- is *not* a valid mode (move, add, sub, cmp, mul, div, logical
+            -- ops, shifts). @immidiate@ refuses register-shaped tokens, so
+            -- @move.l A2, D0@ produces a clean parse error instead of
+            -- silently consuming @A2@ as a label (issue #143).
             src = dataRegister <|> allIndirectAddr <|> immidiate
+            -- @movea@ is the one instruction that legitimately takes An as
+            -- source (e.g. @movea.l A2, A0@), so it gets a wider source.
+            srcMovea = dataRegister <|> addrRegister <|> allIndirectAddr <|> immidiate
             dst = dataRegister <|> allIndirectAddr
 
 cmd0args :: String -> Isa w (Ref w) -> Parser (Isa w (Ref w))
@@ -270,8 +278,19 @@ indirectAddrRegPostIncrement = try $ do
 
 allIndirectAddr = indirectAddrRegPreDecrement <|> indirectAddrRegPostIncrement <|> indirectAddrRegister
 
+-- | A bare register name (e.g. @A2@, @D3@) at the start of the input.
+--   Used as a negative guard so @immidiate@ refuses to consume register
+--   names as labels.
+registerLikeName :: Parser ()
+registerLikeName = try $ do
+    void (oneOf ['A', 'D'])
+    void (oneOf ['0' .. '7'])
+    notFollowedBy (alphaNumChar <|> char '_')
+
 immidiate :: (MachineWord w) => Parser (Argument w (Ref w))
-immidiate = Immediate <$> reference
+immidiate = do
+    notFollowedBy registerLikeName
+    Immediate <$> reference
 
 instance DerefMnemonic (Isa w) w where
     derefMnemonic f _offset i =

--- a/src/wrench/Wrench/Translator.hs
+++ b/src/wrench/Wrench/Translator.hs
@@ -71,6 +71,7 @@ translate ::
     , DerefMnemonic (isa_ w) w
     , MachineWord w
     , MnemonicParser (isa_ w (Ref w))
+    , Show (isa_ w w)
     ) =>
     Int
     -> FilePath

--- a/src/wrench/Wrench/Translator/Types.hs
+++ b/src/wrench/Wrench/Translator/Types.hs
@@ -42,7 +42,7 @@ instance (ByteSize isa, ByteSizeT w) => ByteSize (Section isa w l) where
 
 derefSection ::
     forall isa w.
-    (ByteSize (isa (Ref w)), DerefMnemonic isa w, MachineWord w) =>
+    (ByteSize (isa (Ref w)), DerefMnemonic isa w, MachineWord w, Show (isa w)) =>
     (String -> Maybe w)
     -> w
     -> Section (isa (Ref w)) w String
@@ -56,6 +56,14 @@ derefSection f offset code@Code{codeTokens} =
                 map
                     ( \(offset', m) ->
                         let m' = derefMnemonic f offset' m
+                            -- Force every Ref-derived field of m' to WHNF so that
+                            -- an unresolved label aborts translation here, not
+                            -- lazily at execution when something happens to read
+                            -- the value (see issue #143). Walking @show@ visits
+                            -- every constructor field, which is enough since
+                            -- @w@ is a machine word and forcing it to WHNF is
+                            -- already full evaluation.
+                            !_ = length (show m' :: String)
                          in Mnemonic m'
                     )
                     marked
@@ -105,9 +113,15 @@ instance (Show w) => Show (Ref w) where
     show (Ref _ l) = l
     show (ValueR f x) = show $ f x
 
+-- | Resolve a 'Ref' against a label table. Strict: forces the lookup and the
+--   resulting value to WHNF before returning. Call sites should use @$!@ so
+--   that an unresolved label aborts translation rather than producing a thunk
+--   that only blows up later if something happens to read it.
 deref' :: (String -> Maybe w) -> Ref w -> w
-deref' f (Ref prepare l) = prepare <$> fromMaybe (error ("Can't resolve label: " <> show l)) $ f l
-deref' _f (ValueR prepare x) = prepare x
+deref' f (Ref prepare l) = case f l of
+    Just w -> let !v = prepare w in v
+    Nothing -> error ("Can't resolve label: " <> show l)
+deref' _f (ValueR prepare x) = let !v = prepare x in v
 
 data DataToken w l = DataToken
     { dtLabel :: !l

--- a/src/wrench/Wrench/Wrench.hs
+++ b/src/wrench/Wrench/Wrench.hs
@@ -148,6 +148,7 @@ wrench ::
     , Machine st isa2 w
     , MachineWord w
     , MnemonicParser isa1
+    , Show (isa_ w w)
     , StateInterspector st (IoMem isa2 w) isa2 w
     , isa1 ~ isa_ w (Ref w)
     , isa2 ~ isa_ w w

--- a/test/Wrench/Isa/M68k/Test.hs
+++ b/test/Wrench/Isa/M68k/Test.hs
@@ -111,8 +111,23 @@ tests =
             translate "cmp.l D1, D0" @?= Right (Cmp Long (DirectDataReg D1) (DirectDataReg D0))
             translate "cmp.b 10, D0" @?= Right (Cmp Byte (Immediate $ ValueR id 10) (DirectDataReg D0))
             translate "cmp.l (A1), D0" @?= Right (Cmp Long (IndirectAddrReg 0 A1 Nothing) (DirectDataReg D0))
+            -- movea is the one instruction that legitimately accepts An as source.
+            translate "movea.l A2, A0" @?= Right (MoveA Long (DirectAddrReg A2) (DirectAddrReg A0))
             translate "jsr 0x20" @?= Right (Jsr (ValueR id 0x20))
             translate "rts" @?= Right Rts
+        , testCase "An as source rejected outside movea (issue #143)" $ do
+            -- Address Register Direct is not a valid source mode for these
+            -- instructions; the parser must fail rather than silently
+            -- consuming @A2@ as a label.
+            let parsesM68k :: String -> Either String (Isa Int32 (Ref Int32))
+                parsesM68k = translate
+            isLeft (parsesM68k "move.l A2, D0") @?= True
+            isLeft (parsesM68k "add.l A0, D1") @?= True
+            isLeft (parsesM68k "sub.l A0, D1") @?= True
+            isLeft (parsesM68k "cmp.l A0, D0") @?= True
+            isLeft (parsesM68k "and.l A0, D1") @?= True
+            -- @movea@ still accepts An as source.
+            isRight (parsesM68k "movea.l A2, A0") @?= True
         , testCase "Read byte from memory by address register" $ do
             let State{dataRegs, addrRegs} = simulate "move.b (A2), D0" st0{addrRegs = insert A2 6 addrRegs0}
              in do


### PR DESCRIPTION
#143.

## Summary

Two coordinated fixes for the silent-success class of bug in #143:

- **`fix(translator)`** — `deref'` was lazy: an unresolved label became a thunk inside an Argument field and only blew up if execution happened to force it (e.g. a view reading the corrupted register). Programs whose broken instruction wrote to an unread register exited 0 with the assertion passing on the previous, untouched value. `deref'` is now an explicit case and `derefSection` walks every Ref-substituted instruction (`length (show m' :: String)`), so an unresolved label aborts translation deterministically. Constraint `Show (isa w)` propagated through `translate`/`wrench` — every ISA already derives it.
- **`fix(m68k)`** — `A0..A7` in source position used to slip through to `immidiate` → `reference` → `labelRef`, so `move.l A2, D0` was silently consumed as a label `A2`. `immidiate` now refuses register-shaped tokens via `notFollowedBy registerLikeName`, and the generic `src` alternation no longer accepts `addrRegister`. The one instruction that legitimately takes An as source — `movea` — gets its own wider `srcMovea`. The user now gets `unexpected "A2", expecting ...` at the operand instead of `Can't resolve label: "A2"` later.

Real M68000 lets An act as source for more instructions, but wrench does not model the quirks (ADDA/SUBA flag suppression, no `.b` form, ...) — surfacing a translation error is simpler and clearer than silently accepting arguably-wrong forms.

## Test plan

- [x] `stack test` — 560 tests pass (existing 559 + new "An as source rejected outside movea" case asserting parse failure for `move`/`add`/`sub`/`cmp`/`and` and parse success for `movea.l A2, A0`).
- [x] Manual: the issue's reproducer (`movea.l 42, A2 ; move.l A2, D0`) now fails at parse with `unexpected "A2", expecting "-(", "0x", '(', '-', 'D', '_', digit, or white space`, regardless of what the report `view:` contains.
- [x] `movea.l A2, A0` continues to translate and execute correctly.

## Not in scope (separate work)

- `docs/m68k.md` Addressing Modes section still lists Address Register Direct as a general mode. Worth a follow-up doc tweak clarifying that it's only valid as `movea`'s operand or inside indirect modes.