### PR TITLE
Redesign VLIW-IV bundle as 112-bit/14-byte format with field truncation

### DIFF
--- a/docs/vliw-iv.md
+++ b/docs/vliw-iv.md
@@ -7,7 +7,7 @@ The VLIW ISA is a simple register-based instruction set inspired by VLIW (Very L
 The VLIW architecture is a 32-bit VLIW (Very Long Instruction Word) architecture inspired by RISC-V and classic VLIW designs. It features:
 
 - 32 general-purpose registers (including one hardwired zero register — writes to `Zero` are silently ignored)
-- Fixed-length 11-byte (90-bit) instruction bundles, divided into 4 slots for parallel execution
+- Fixed-length 14-byte (112-bit) instruction bundles, divided into 4 slots for parallel execution
 - Load-store architecture (memory access only through specific instructions in dedicated slots)
 - Simple addressing modes
 - Memory-mapped I/O
@@ -44,14 +44,42 @@ addi a0, a0, %lo(address) / nop / nop / nop ; Add lower 12 bits to a0
 
 ## Instructions
 
-Instruction size: 11 bytes (90-bit bundle).
+Instruction size: 14 bytes (112-bit bundle).
 
 ```text
-[SLOT 0]   alu 1: 20 bits     <opcode:5><r1:5><r2:5><r3:5>
-[SLOT 1]   alu 2: 20 bits     <opcode:5><r1:5><r2:5><r3:5>
-[SLOT 2]   memory: 36 bits    <opcode:4><addr:32>
-[SLOT 3]   control: 14 bits   <opcode:4><offset or offset+register:10>
+Bundle: [ALU1:32] [ALU2:32] [MEM:24] [CTRL:24]
+
+[ALU1/ALU2]:
+  [opcode:5] [rd:5] [rs1:5] [rs2:5] [reserved:12]   ; add sub mul mulh div rem sll srl sra and or xor
+  [opcode:5] [rd:5] [rs1:5] [imm_sign:17]           ; addi slti
+  [opcode:5] [rd:5] [imm_unsign:22]                 ; lui
+  [opcode:5] [rd:5] [rs1:5] [reserved:17]           ; mv
+  [opcode:5] [reserved:27]                          ; nop
+[MEM] (24 bits):
+  [opcode:3] [rd:5]  [base:5] [offset_sign:11]      ; lw lb        (reg = rd)
+  [opcode:3] [rs2:5] [base:5] [offset_sign:11]      ; sw sb        (reg = rs2)
+  [opcode:3] [reserved:21]                          ; nop
+[CTRL] (24 bits):
+  [opcode:4] [rs1:5] [rs2:5] [offset_sign:10]       ; beq bne blt bgt ble bgtu bleu
+  [opcode:4] [rs1:5] [offset_sign:15]               ; beqz bnez
+  [opcode:4] [rd:5]  [offset_sign:15]               ; jal
+  [opcode:4] [rs:5]  [reserved:15]                  ; jr
+  [opcode:4] [offset_sign:20]                       ; j
+  [opcode:4] [reserved:20]                          ; nop halt
 ```
+
+The two ALU slots are 32 bits each; MEM and CTRL are 24 bits each, for a 112-bit (14-byte)
+bundle. The opcode occupies the high bits of its slot, sized to the number of operations the slot
+defines: 5 bits for ALU (17 ops), 4 for CTRL (14 ops), 3 for MEM (5 ops). Register fields
+follow the opcode; the remaining low bits hold the immediate/offset.
+
+Every immediate and offset is **silently truncated** to its field width: the value is reduced
+to the low bits of the field and sign-extended (`lui`'s `imm_unsign` is zero-extended), with no
+error if it does not fit. So `addi`/`slti` see a 17-bit signed immediate, branches a 10-bit
+signed offset, `beqz`/`bnez`/`jal` a 15-bit one, `j` a 20-bit one, and memory ops an 11-bit
+one. `lui` keeps only the low 20 bits (after the `<< 12` shift the upper bits of the 22-bit
+field cannot be represented in a 32-bit word). The `%lo` (12-bit) and `%hi` (20-bit) relocation
+values fit within these fields unchanged.
 
 Each instruction is a bundle with 4 slots: Slot 0 (ALU1), Slot 1 (ALU2), Slot 2 (Memory), Slot 3 (Control). Operations in slots execute in parallel. Unused slots are NOP (no operation). Assembly syntax uses `/` to separate slots.
 
@@ -75,8 +103,8 @@ add rd, rs1, rs2 / addi rd, rs1, k / lw rd, offset(rs1) / beq rs1, rs2, k
 
 - **Add Immediate**
     - **Syntax:** `addi <rd>, <rs1>, <k>`
-    - **Description:** Add a 12-bit sign-extended immediate value to the source register and store the result in the destination register. The immediate `k` is truncated to 12 bits and sign-extended to 32 bits before the addition.
-    - **Operation:** `rd <- rs1 + signext(k[11:0])`
+    - **Description:** Add a 17-bit sign-extended immediate value to the source register and store the result in the destination register. The immediate `k` is truncated to the 17-bit `imm_sign` field and sign-extended to 32 bits before the addition.
+    - **Operation:** `rd <- rs1 + signext(k[16:0])`
 
 - **Add**
     - **Syntax:** `add <rd>, <rs1>, <rs2>`
@@ -183,7 +211,7 @@ add rd, rs1, rs2 / addi rd, rs1, k / lw rd, offset(rs1) / beq rs1, rs2, k
 - **Jump and Link**
     - **Syntax:** `jal <rd>, <k>`
     - **Description:** Store the address of the next instruction in the destination register and jump to the address computed by adding the immediate value to the current program counter.
-    - **Operation:** `rd <- pc + 11, pc <- pc + k`  // Adjusted for bundle size
+    - **Operation:** `rd <- pc + 14, pc <- pc + k`  // Adjusted for bundle size
 
 - **Jump Register**
     - **Syntax:** `jr <rs>`

--- a/src/wrench/Wrench/Isa/Acc32.hs
+++ b/src/wrench/Wrench/Isa/Acc32.hs
@@ -15,6 +15,7 @@ import Text.Megaparsec (choice, try)
 import Text.Megaparsec.Char (hspace, hspace1, string)
 import Wrench.Machine.Memory
 import Wrench.Machine.Types
+import Wrench.Machine.Word
 import Wrench.Report
 import Wrench.Translator.Parser.Misc
 import Wrench.Translator.Parser.Types

--- a/src/wrench/Wrench/Isa/F32a.hs
+++ b/src/wrench/Wrench/Isa/F32a.hs
@@ -18,6 +18,7 @@ import Text.Megaparsec (anySingleBut, choice, try)
 import Text.Megaparsec.Char (char, hspace, hspace1, string)
 import Wrench.Machine.Memory
 import Wrench.Machine.Types
+import Wrench.Machine.Word
 import Wrench.Report
 import Wrench.Translator.Parser.Misc
 import Wrench.Translator.Parser.Types

--- a/src/wrench/Wrench/Isa/M68k.hs
+++ b/src/wrench/Wrench/Isa/M68k.hs
@@ -26,6 +26,7 @@ import Text.Megaparsec (choice, oneOf, try)
 import Text.Megaparsec.Char (hspace, hspace1, string)
 import Wrench.Machine.Memory
 import Wrench.Machine.Types
+import Wrench.Machine.Word
 import Wrench.Report
 import Wrench.Translator.Parser.Misc
 import Wrench.Translator.Parser.Types

--- a/src/wrench/Wrench/Isa/RiscIv.hs
+++ b/src/wrench/Wrench/Isa/RiscIv.hs
@@ -29,9 +29,8 @@ import Wrench.Machine.Types (
     StateInterspector (..),
     fromSign,
     halted,
-    lShiftR,
-    signBitAnd,
  )
+import Wrench.Machine.Word (lShiftR, signBitAnd)
 import Wrench.Report
 import Wrench.Translator.Parser.Misc (eol', hexNum, num, reference, referenceWithDirective)
 import Wrench.Translator.Parser.Types

--- a/src/wrench/Wrench/Isa/VliwIv.hs
+++ b/src/wrench/Wrench/Isa/VliwIv.hs
@@ -13,7 +13,7 @@ module Wrench.Isa.VliwIv (
     emptyVliwLoad,
 ) where
 
-import Data.Bits (shiftL, shiftR, (.&.), (.|.))
+import Data.Bits (bit, complement, shiftL, shiftR, testBit, (.&.), (.|.))
 import Data.Default
 import Data.Text qualified as T
 import Relude
@@ -31,7 +31,6 @@ import Wrench.Machine.Types (
     fromSign,
     halted,
     lShiftR,
-    signBitAnd,
  )
 import Wrench.Report
 import Wrench.Translator.Parser.Misc (eol', hexNum, num, reference, referenceWithDirective)
@@ -411,7 +410,17 @@ instance (MachineWord w) => DerefMnemonic (Isa w) w where
             }
 
 instance ByteSize (Isa w l) where
-    byteSize _ = 11
+    byteSize _ = 14
+
+-- | Sign-extend the low @n@ bits of a value to the full machine word, modelling
+-- a fixed-width signed instruction field. Bits at or above bit @n@ are silently
+-- discarded (truncation), matching the documented per-slot field widths: any
+-- constant that does not fit its field is reduced to its low @n@ bits.
+fitSigned :: (MachineWord w) => Int -> w -> w
+fitSigned n x =
+    let mask = bit n - 1
+        low = x .&. mask
+     in if testBit low (n - 1) then low .|. complement mask else low
 
 comma = hspace >> string "," >> hspace
 
@@ -459,7 +468,7 @@ setPc addr = modify $ \st -> st{pc = addr}
 nextPc :: forall w. State (MachineState (IoMem (Isa w w) w) w) ()
 nextPc = do
     State{pc} <- get
-    setPc (pc + 11) -- Bundle size 11 bytes
+    setPc (pc + 14) -- Bundle size 14 bytes
 
 raiseInternalError :: Text -> State (MachineState (IoMem (Isa w w) w) w) ()
 raiseInternalError msg = modify $ \st -> st{internalError = Just msg}
@@ -605,21 +614,21 @@ instance (MachineWord w) => Machine (MachineState (IoMem (Isa w w) w) w) (Isa w 
             computeMem NopM = return Nothing
             computeMem (Lw lwRd (MemRef mrOffset mrReg)) = do
                 rs1' <- getReg mrReg
-                w <- getWord $ fromEnum (mrOffset + rs1')
+                w <- getWord $ fromEnum (fitSigned 11 mrOffset + rs1')
                 return $ Just (lwRd, w)
             computeMem (Lb lbRd (MemRef mrOffset mrReg)) = do
                 rs1' <- getReg mrReg
-                b <- getByte $ fromEnum (mrOffset + rs1')
+                b <- getByte $ fromEnum (fitSigned 11 mrOffset + rs1')
                 return $ Just (lbRd, fromIntegral (fromIntegral b :: Int8))
             computeMem (Sw swRs2 (MemRef mrOffset mrReg)) = do
                 rs2' <- getReg swRs2
                 mrReg' <- getReg mrReg
-                setWord (fromEnum (mrReg' + mrOffset)) rs2'
+                setWord (fromEnum (mrReg' + fitSigned 11 mrOffset)) rs2'
                 return Nothing
             computeMem (Sb sbRs2 (MemRef mrOffset mrReg)) = do
                 rs2' <- getReg sbRs2
                 mrReg' <- getReg mrReg
-                setByte (fromEnum (mrReg' + mrOffset)) $ fromIntegral rs2'
+                setByte (fromEnum (mrReg' + fitSigned 11 mrOffset)) $ fromIntegral rs2'
                 return Nothing
 
             -- Apply memory operation result
@@ -632,7 +641,7 @@ instance (MachineWord w) => Machine (MachineState (IoMem (Isa w w) w) w) (Isa w 
             computeAlu NopA = return Nothing
             computeAlu (Addi addiRd addiRs1 addiK) = do
                 rs1' <- getReg addiRs1
-                return $ Just (addiRd, rs1' + (addiK `signBitAnd` 0x00000FFF))
+                return $ Just (addiRd, rs1' + fitSigned 17 addiK)
             computeAlu (Add addRd addRs1 addRs2) = aluOpCompute addRd addRs1 addRs2 id id (+)
             computeAlu (Sub subRd subRs1 subRs2) = aluOpCompute subRd subRs1 subRs2 id id (-)
             computeAlu (Mul mulRd mulRs1 mulRs2) = aluOpCompute mulRd mulRs1 mulRs2 id id (*)
@@ -658,7 +667,7 @@ instance (MachineWord w) => Machine (MachineState (IoMem (Isa w w) w) w) (Isa w 
             computeAlu (Xor xorRd xorRs1 xorRs2) = aluOpCompute xorRd xorRs1 xorRs2 id id xor
             computeAlu (Slti sltiRd sltiRs1 sltiK) = do
                 rs1' <- getReg sltiRs1
-                return $ Just (sltiRd, if rs1' < sltiK then 1 else 0)
+                return $ Just (sltiRd, if rs1' < fitSigned 17 sltiK then 1 else 0)
             computeAlu (Lui luiRd luiK) = return $ Just (luiRd, (luiK .&. 0x000FFFFF) `shiftL` 12)
             computeAlu (Mv mvRd mvRs) = do
                 val <- getReg mvRs
@@ -678,26 +687,26 @@ instance (MachineWord w) => Machine (MachineState (IoMem (Isa w w) w) w) (Isa w 
             execCtrl NopC = return False
             execCtrl (J jK) = do
                 State{pc} <- get
-                setPc (pc + fromEnum jK)
+                setPc (pc + fromEnum (fitSigned 20 jK))
                 return True
             execCtrl (Jal jalRd jalK) = do
                 State{pc} <- get
-                setReg jalRd (toEnum pc + 11)
-                setPc (pc + fromEnum jalK)
+                setReg jalRd (toEnum pc + 14)
+                setPc (pc + fromEnum (fitSigned 15 jalK))
                 return True
             execCtrl (Jr jrRs) = do
                 rs' <- getReg jrRs
                 setPc (fromEnum rs')
                 return True
-            execCtrl (Beqz beqzRs1 beqzK) = branchIf beqzRs1 beqzK (== 0)
-            execCtrl (Bnez bnezRs1 bnezK) = branchIf bnezRs1 bnezK (/= 0)
-            execCtrl (Bgt bgtRs1 bgtRs2 bgtK) = branchIf2 bgtRs1 bgtRs2 bgtK (>)
-            execCtrl (Ble bleRs1 bleRs2 bleK) = branchIf2 bleRs1 bleRs2 bleK (<=)
-            execCtrl (Bgtu bgtuRs1 bgtuRs2 bgtuK) = branchIf2u bgtuRs1 bgtuRs2 bgtuK (>)
-            execCtrl (Bleu bleuRs1 bleuRs2 bleuK) = branchIf2u bleuRs1 bleuRs2 bleuK (<=)
-            execCtrl (Beq beqRs1 beqRs2 beqK) = branchIf2 beqRs1 beqRs2 beqK (==)
-            execCtrl (Bne bneRs1 bneRs2 bneK) = branchIf2 bneRs1 bneRs2 bneK (/=)
-            execCtrl (Blt bltRs1 bltRs2 bltK) = branchIf2 bltRs1 bltRs2 bltK (<)
+            execCtrl (Beqz beqzRs1 beqzK) = branchIf beqzRs1 (fitSigned 15 beqzK) (== 0)
+            execCtrl (Bnez bnezRs1 bnezK) = branchIf bnezRs1 (fitSigned 15 bnezK) (/= 0)
+            execCtrl (Bgt bgtRs1 bgtRs2 bgtK) = branchIf2 bgtRs1 bgtRs2 (fitSigned 10 bgtK) (>)
+            execCtrl (Ble bleRs1 bleRs2 bleK) = branchIf2 bleRs1 bleRs2 (fitSigned 10 bleK) (<=)
+            execCtrl (Bgtu bgtuRs1 bgtuRs2 bgtuK) = branchIf2u bgtuRs1 bgtuRs2 (fitSigned 10 bgtuK) (>)
+            execCtrl (Bleu bleuRs1 bleuRs2 bleuK) = branchIf2u bleuRs1 bleuRs2 (fitSigned 10 bleuK) (<=)
+            execCtrl (Beq beqRs1 beqRs2 beqK) = branchIf2 beqRs1 beqRs2 (fitSigned 10 beqK) (==)
+            execCtrl (Bne bneRs1 bneRs2 bneK) = branchIf2 bneRs1 bneRs2 (fitSigned 10 bneK) (/=)
+            execCtrl (Blt bltRs1 bltRs2 bltK) = branchIf2 bltRs1 bltRs2 (fitSigned 10 bltK) (<)
             execCtrl Halt = do
                 modify $ \st -> st{stopped = True}
                 return True

--- a/src/wrench/Wrench/Isa/VliwIv.hs
+++ b/src/wrench/Wrench/Isa/VliwIv.hs
@@ -13,7 +13,7 @@ module Wrench.Isa.VliwIv (
     emptyVliwLoad,
 ) where
 
-import Data.Bits (bit, complement, shiftL, shiftR, testBit, (.&.), (.|.))
+import Data.Bits (shiftL, shiftR, (.&.), (.|.))
 import Data.Default
 import Data.Text qualified as T
 import Relude
@@ -30,8 +30,8 @@ import Wrench.Machine.Types (
     StateInterspector (..),
     fromSign,
     halted,
-    lShiftR,
  )
+import Wrench.Machine.Word (fitSigned, lShiftR)
 import Wrench.Report
 import Wrench.Translator.Parser.Misc (eol', hexNum, num, reference, referenceWithDirective)
 import Wrench.Translator.Parser.Types
@@ -411,16 +411,6 @@ instance (MachineWord w) => DerefMnemonic (Isa w) w where
 
 instance ByteSize (Isa w l) where
     byteSize _ = 14
-
--- | Sign-extend the low @n@ bits of a value to the full machine word, modelling
--- a fixed-width signed instruction field. Bits at or above bit @n@ are silently
--- discarded (truncation), matching the documented per-slot field widths: any
--- constant that does not fit its field is reduced to its low @n@ bits.
-fitSigned :: (MachineWord w) => Int -> w -> w
-fitSigned n x =
-    let mask = bit n - 1
-        low = x .&. mask
-     in if testBit low (n - 1) then low .|. complement mask else low
 
 comma = hspace >> string "," >> hspace
 

--- a/src/wrench/Wrench/Machine/Types.hs
+++ b/src/wrench/Wrench/Machine/Types.hs
@@ -27,14 +27,7 @@ module Wrench.Machine.Types (
     ByteSize (..),
     ByteSizeT (..),
     WordParts (..),
-    signBitAnd,
-    Ext (..),
-    addExt,
-    subExt,
-    mulExt,
     halted,
-    lShiftL,
-    lShiftR,
 ) where
 
 import Data.Bits
@@ -115,41 +108,6 @@ instance WordParts Int8 where
     wordCombine [b] = fromInteger $ toInteger b
     wordCombine _ = error "not applicable"
     byteToWord = fromIntegral
-
-signBitAnd :: (MachineWord w) => w -> w -> w
-signBitAnd x mask
-    | x < 0 = x .|. complement mask
-    | otherwise = x .&. mask
-
-lShiftR :: (MachineWord w) => w -> w -> w
-lShiftR x n = toSign (fromSign x `shiftR` fromEnum n)
-
-lShiftL :: (MachineWord w) => w -> w -> w
-lShiftL x n = toSign (fromSign x `shiftL` fromEnum n)
-
-data Ext a = Ext {value :: a, overflow :: Bool, carry :: Bool}
-    deriving (Eq, Show)
-
-addExt :: (MachineWord w) => w -> w -> Ext w
-addExt x y =
-    let result = x + y
-        overflow = ((x > 0 && y > 0 && result < 0) || (x < 0 && y < 0 && result > 0))
-        carry = testBit (toInteger (fromSign x) + toInteger (fromSign y)) (finiteBitSize x)
-     in Ext{value = result, overflow, carry}
-
-subExt :: (MachineWord w) => w -> w -> Ext w
-subExt x y =
-    let result = x - y
-        overflow = ((x > 0 && y < 0 && result < 0) || (x < 0 && y > 0 && result > 0))
-        carry = fromSign x < fromSign y
-     in Ext{value = result, overflow, carry}
-
-mulExt :: (MachineWord w) => w -> w -> Ext w
-mulExt x y =
-    let result = x * y
-        overflow = (x /= 0 && y /= 0 && result `div` x /= y)
-        carry = (fromIntegral x * fromIntegral y) > (maxBound :: Word)
-     in Ext{value = result, overflow, carry}
 
 class ByteSize t where
     byteSize :: t -> Int

--- a/src/wrench/Wrench/Machine/Word.hs
+++ b/src/wrench/Wrench/Machine/Word.hs
@@ -1,0 +1,68 @@
+{- | Pure machine-word helpers: fixed-width truncation/sign handling and
+arithmetic that also reports overflow and carry. These operate on any
+'MachineWord' and are shared across the ISA implementations.
+-}
+module Wrench.Machine.Word (
+    signBitAnd,
+    fitSigned,
+    lShiftR,
+    lShiftL,
+    Ext (..),
+    addExt,
+    subExt,
+    mulExt,
+) where
+
+import Data.Bits
+import Relude
+import Wrench.Machine.Types (FromSign (..), MachineWord)
+
+-- | Truncate @x@ to the low bits of @mask@ while preserving its original sign:
+-- a negative value keeps its high bits set, a non-negative one is masked. This
+-- is /not/ a signed-field truncation (see 'fitSigned') — it is the semantics the
+-- accumulator and RISC-V ISAs rely on for unsigned low-bit immediates such as
+-- @%lo@.
+signBitAnd :: (MachineWord w) => w -> w -> w
+signBitAnd x mask
+    | x < 0 = x .|. complement mask
+    | otherwise = x .&. mask
+
+-- | Reduce a value to a fixed-width signed instruction field: keep the low @n@
+-- bits and sign-extend from bit @n-1@ to the full machine word. Bits at or above
+-- bit @n@ are silently discarded, modelling an immediate/offset that does not
+-- fit its encoding field.
+fitSigned :: (MachineWord w) => Int -> w -> w
+fitSigned n x =
+    let mask = bit n - 1
+        low = x .&. mask
+     in if testBit low (n - 1) then low .|. complement mask else low
+
+lShiftR :: (MachineWord w) => w -> w -> w
+lShiftR x n = toSign (fromSign x `shiftR` fromEnum n)
+
+lShiftL :: (MachineWord w) => w -> w -> w
+lShiftL x n = toSign (fromSign x `shiftL` fromEnum n)
+
+data Ext a = Ext {value :: a, overflow :: Bool, carry :: Bool}
+    deriving (Eq, Show)
+
+addExt :: (MachineWord w) => w -> w -> Ext w
+addExt x y =
+    let result = x + y
+        overflow = ((x > 0 && y > 0 && result < 0) || (x < 0 && y < 0 && result > 0))
+        carry = testBit (toInteger (fromSign x) + toInteger (fromSign y)) (finiteBitSize x)
+     in Ext{value = result, overflow, carry}
+
+subExt :: (MachineWord w) => w -> w -> Ext w
+subExt x y =
+    let result = x - y
+        overflow = ((x > 0 && y < 0 && result < 0) || (x < 0 && y > 0 && result > 0))
+        carry = fromSign x < fromSign y
+     in Ext{value = result, overflow, carry}
+
+mulExt :: (MachineWord w) => w -> w -> Ext w
+mulExt x y =
+    let result = x * y
+        overflow = (x /= 0 && y /= 0 && result `div` x /= y)
+        carry = (fromIntegral x * fromIntegral y) > (maxBound :: Word)
+     in Ext{value = result, overflow, carry}

--- a/test/Wrench/Isa/VliwIv/Test.hs
+++ b/test/Wrench/Isa/VliwIv/Test.hs
@@ -105,7 +105,7 @@ tests =
                         st0{pc = 50}
              in do
                     pc @?= 150
-                    (regs !? Ra) @?= Just 61 -- 50 + 11 (bundle size)
+                    (regs !? Ra) @?= Just 64 -- 50 + 14 (bundle size)
         , testCase "Control flow: Jr (jump register)" $ do
             let State{pc} =
                     simulate
@@ -123,7 +123,7 @@ tests =
                     simulate
                         "nop / nop / nop / beqz a0, 50"
                         (withRegs [(A0, 5)])
-             in pc @?= 11 -- Advanced by bundle size
+             in pc @?= 14 -- Advanced by bundle size
         , testCase "Control flow: Bnez (branch if not equal to zero) - taken" $ do
             let State{pc} =
                     simulate
@@ -141,7 +141,7 @@ tests =
                     simulate
                         "nop / nop / nop / bgt a0, a1, 50"
                         (withRegs [(A0, 5), (A1, 10)])
-             in pc @?= 11
+             in pc @?= 14
         , testCase "Control flow: Ble (branch if less than or equal) - taken" $ do
             let State{pc} =
                     simulate
@@ -212,6 +212,32 @@ tests =
             translate "addi a1, a0, 3 / nop / nop / nop" @?= True
             translate "nop / nop / lw a1, 20(a0) / j 100" @?= True
             translate "add a2, a0, a1 / sub a3, a0, a1 / sw a1, 0(a0) / halt" @?= True
+        , testGroup
+            "Constant field truncation (silent)"
+            -- A constant that does not fit its documented slot field is reduced to
+            -- the low bits of that field and sign-extended; nothing errors.
+            [ testCase "addi: 17-bit signed immediate field" $ do
+                let State{regs} =
+                        simulate
+                            "addi a0, zero, 0x1FFFF / nop / nop / nop"
+                            st0
+                 in (regs !? A0) @?= Just (-1) -- all 17 bits set -> -1
+            , testCase "beq: 10-bit signed offset field" $ do
+                let State{pc} =
+                        simulate
+                            "nop / nop / nop / beq a0, a1, 0x401"
+                            (withRegs [(A0, 0), (A1, 0)])
+                 in pc @?= 1 -- 0x401 truncated to low 10 bits = 1
+            , testCase "lw: 11-bit signed offset field" $ do
+                let st1 = withRegs [(A0, 20)]
+                    mem1 = either error id $ do
+                        m1 <- writeByte (mem st1) 20 0x11
+                        m2 <- writeByte m1 21 0x22
+                        m3 <- writeByte m2 22 0x33
+                        writeByte m3 23 0x44
+                    State{regs} = simulate "nop / nop / lw a1, 0x800(a0) / nop" st1{mem = mem1}
+                 in (regs !? A1) @?= Just 0x44332211 -- offset 0x800 truncates to 0 -> reads [a0]
+            ]
         ]
 
 -- Test helper: Initial state for most tests

--- a/test/Wrench/Machine/Types/Test.hs
+++ b/test/Wrench/Machine/Types/Test.hs
@@ -6,6 +6,7 @@ import Relude
 import Test.Tasty (TestTree, testGroup)
 import Test.Tasty.HUnit (testCase, (@?=))
 import Wrench.Machine.Types
+import Wrench.Machine.Word
 
 tests :: TestTree
 tests =

--- a/test/golden/vliw-iv/all.s.vliw-iv.result
+++ b/test/golden/vliw-iv/all.s.vliw-iv.result
@@ -1,54 +1,54 @@
 0:	input_addr
 4:	output_addr
 256:	_start
-553:	jump_label
-564:	beqz_label
-575:	bnez_label
-586:	bgt_label
-597:	ble_label
-608:	bgtu_label
-619:	bleu_label
-630:	beq_label
-641:	bne_label
+634:	jump_label
+648:	beqz_label
+662:	bnez_label
+676:	bgt_label
+690:	ble_label
+704:	bgtu_label
+718:	bleu_label
+732:	beq_label
+746:	bne_label
 ---
 mem[0..3]: 	80 00 00 00	@"input_addr"
 mem[4..255]: 	84 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00	@"output_addr"
-mem[256..266]: 	Isa {memOp = NopM, alu1Op = Addi {addiRd = T0, addiRs1 = T0, addiK = 0}, alu2Op = NopA, ctrlOp = NopC} 	@_start
-mem[267..277]: 	Isa {memOp = NopM, alu1Op = Add {addRd = T2, addRs1 = T1, addRs2 = T0}, alu2Op = NopA, ctrlOp = NopC}
-mem[278..288]: 	Isa {memOp = NopM, alu1Op = Sub {subRd = T3, subRs1 = T1, subRs2 = T0}, alu2Op = NopA, ctrlOp = NopC}
-mem[289..299]: 	Isa {memOp = NopM, alu1Op = Mul {mulRd = T4, mulRs1 = T1, mulRs2 = T0}, alu2Op = NopA, ctrlOp = NopC}
-mem[300..310]: 	Isa {memOp = NopM, alu1Op = Mulh {mulhRd = T5, mulhRs1 = T1, mulhRs2 = T0}, alu2Op = NopA, ctrlOp = NopC}
-mem[311..321]: 	Isa {memOp = NopM, alu1Op = Div {divRd = T6, divRs1 = T1, divRs2 = T0}, alu2Op = NopA, ctrlOp = NopC}
-mem[322..332]: 	Isa {memOp = NopM, alu1Op = Rem {remRd = T2, remRs1 = T1, remRs2 = T0}, alu2Op = NopA, ctrlOp = NopC}
-mem[333..343]: 	Isa {memOp = NopM, alu1Op = Sll {sllRd = T2, sllRs1 = T1, sllRs2 = T0}, alu2Op = NopA, ctrlOp = NopC}
-mem[344..354]: 	Isa {memOp = NopM, alu1Op = Srl {srlRd = T2, srlRs1 = T1, srlRs2 = T0}, alu2Op = NopA, ctrlOp = NopC}
-mem[355..365]: 	Isa {memOp = NopM, alu1Op = Sra {sraRd = T2, sraRs1 = T1, sraRs2 = T0}, alu2Op = NopA, ctrlOp = NopC}
-mem[366..376]: 	Isa {memOp = NopM, alu1Op = And {andRd = T2, andRs1 = T1, andRs2 = T0}, alu2Op = NopA, ctrlOp = NopC}
-mem[377..387]: 	Isa {memOp = NopM, alu1Op = Or {orRd = T2, orRs1 = T1, orRs2 = T0}, alu2Op = NopA, ctrlOp = NopC}
-mem[388..398]: 	Isa {memOp = NopM, alu1Op = Xor {xorRd = T2, xorRs1 = T1, xorRs2 = T0}, alu2Op = NopA, ctrlOp = NopC}
-mem[399..409]: 	Isa {memOp = NopM, alu1Op = Mv {mvRd = T2, mvRs = T1}, alu2Op = NopA, ctrlOp = NopC}
-mem[410..420]: 	Isa {memOp = Sw {swRs2 = T2, swOffsetRs1 = MemRef {mrOffset = 0, mrReg = T0}}, alu1Op = NopA, alu2Op = NopA, ctrlOp = NopC}
-mem[421..431]: 	Isa {memOp = Sb {sbRs2 = T2, sbOffsetRs1 = MemRef {mrOffset = 0, mrReg = T0}}, alu1Op = NopA, alu2Op = NopA, ctrlOp = NopC}
-mem[432..442]: 	Isa {memOp = NopM, alu1Op = Lui {luiRd = T2, luiK = 4660}, alu2Op = NopA, ctrlOp = NopC}
-mem[443..453]: 	Isa {memOp = Lw {lwRd = T2, lwOffsetRs1 = MemRef {mrOffset = 0, mrReg = T0}}, alu1Op = NopA, alu2Op = NopA, ctrlOp = NopC}
-mem[454..464]: 	Isa {memOp = NopM, alu1Op = NopA, alu2Op = NopA, ctrlOp = J {jK = 99}}
-mem[465..475]: 	Isa {memOp = NopM, alu1Op = NopA, alu2Op = NopA, ctrlOp = Beqz {beqzRs1 = T1, beqzK = 99}}
-mem[476..486]: 	Isa {memOp = NopM, alu1Op = NopA, alu2Op = NopA, ctrlOp = Bnez {bnezRs1 = T1, bnezK = 99}}
-mem[487..497]: 	Isa {memOp = NopM, alu1Op = NopA, alu2Op = NopA, ctrlOp = Bgt {bgtRs1 = T1, bgtRs2 = T0, bgtK = 99}}
-mem[498..508]: 	Isa {memOp = NopM, alu1Op = NopA, alu2Op = NopA, ctrlOp = Ble {bleRs1 = T1, bleRs2 = T0, bleK = 99}}
-mem[509..519]: 	Isa {memOp = NopM, alu1Op = NopA, alu2Op = NopA, ctrlOp = Bgtu {bgtuRs1 = T1, bgtuRs2 = T0, bgtuK = 99}}
-mem[520..530]: 	Isa {memOp = NopM, alu1Op = NopA, alu2Op = NopA, ctrlOp = Bleu {bleuRs1 = T1, bleuRs2 = T0, bleuK = 99}}
-mem[531..541]: 	Isa {memOp = NopM, alu1Op = NopA, alu2Op = NopA, ctrlOp = Beq {beqRs1 = T1, beqRs2 = T0, beqK = 99}}
-mem[542..552]: 	Isa {memOp = NopM, alu1Op = NopA, alu2Op = NopA, ctrlOp = Bne {bneRs1 = T1, bneRs2 = T0, bneK = 99}}
-mem[553..563]: 	Isa {memOp = NopM, alu1Op = Addi {addiRd = T0, addiRs1 = T0, addiK = 4}, alu2Op = NopA, ctrlOp = NopC} 	@jump_label
-mem[564..574]: 	Isa {memOp = NopM, alu1Op = Addi {addiRd = T0, addiRs1 = T0, addiK = 4}, alu2Op = NopA, ctrlOp = NopC} 	@beqz_label
-mem[575..585]: 	Isa {memOp = NopM, alu1Op = Addi {addiRd = T0, addiRs1 = T0, addiK = 4}, alu2Op = NopA, ctrlOp = NopC} 	@bnez_label
-mem[586..596]: 	Isa {memOp = NopM, alu1Op = Addi {addiRd = T0, addiRs1 = T0, addiK = 4}, alu2Op = NopA, ctrlOp = NopC} 	@bgt_label
-mem[597..607]: 	Isa {memOp = NopM, alu1Op = Addi {addiRd = T0, addiRs1 = T0, addiK = 4}, alu2Op = NopA, ctrlOp = NopC} 	@ble_label
-mem[608..618]: 	Isa {memOp = NopM, alu1Op = Addi {addiRd = T0, addiRs1 = T0, addiK = 4}, alu2Op = NopA, ctrlOp = NopC} 	@bgtu_label
-mem[619..629]: 	Isa {memOp = NopM, alu1Op = Addi {addiRd = T0, addiRs1 = T0, addiK = 4}, alu2Op = NopA, ctrlOp = NopC} 	@bleu_label
-mem[630..640]: 	Isa {memOp = NopM, alu1Op = Addi {addiRd = T0, addiRs1 = T0, addiK = 4}, alu2Op = NopA, ctrlOp = NopC} 	@beq_label
-mem[641..651]: 	Isa {memOp = NopM, alu1Op = Addi {addiRd = T0, addiRs1 = T0, addiK = 4}, alu2Op = NopA, ctrlOp = NopC} 	@bne_label
-mem[652..662]: 	Isa {memOp = NopM, alu1Op = NopA, alu2Op = NopA, ctrlOp = Halt}
-mem[663..999]: 	( 00 )
+mem[256..269]: 	Isa {memOp = NopM, alu1Op = Addi {addiRd = T0, addiRs1 = T0, addiK = 0}, alu2Op = NopA, ctrlOp = NopC} 	@_start
+mem[270..283]: 	Isa {memOp = NopM, alu1Op = Add {addRd = T2, addRs1 = T1, addRs2 = T0}, alu2Op = NopA, ctrlOp = NopC}
+mem[284..297]: 	Isa {memOp = NopM, alu1Op = Sub {subRd = T3, subRs1 = T1, subRs2 = T0}, alu2Op = NopA, ctrlOp = NopC}
+mem[298..311]: 	Isa {memOp = NopM, alu1Op = Mul {mulRd = T4, mulRs1 = T1, mulRs2 = T0}, alu2Op = NopA, ctrlOp = NopC}
+mem[312..325]: 	Isa {memOp = NopM, alu1Op = Mulh {mulhRd = T5, mulhRs1 = T1, mulhRs2 = T0}, alu2Op = NopA, ctrlOp = NopC}
+mem[326..339]: 	Isa {memOp = NopM, alu1Op = Div {divRd = T6, divRs1 = T1, divRs2 = T0}, alu2Op = NopA, ctrlOp = NopC}
+mem[340..353]: 	Isa {memOp = NopM, alu1Op = Rem {remRd = T2, remRs1 = T1, remRs2 = T0}, alu2Op = NopA, ctrlOp = NopC}
+mem[354..367]: 	Isa {memOp = NopM, alu1Op = Sll {sllRd = T2, sllRs1 = T1, sllRs2 = T0}, alu2Op = NopA, ctrlOp = NopC}
+mem[368..381]: 	Isa {memOp = NopM, alu1Op = Srl {srlRd = T2, srlRs1 = T1, srlRs2 = T0}, alu2Op = NopA, ctrlOp = NopC}
+mem[382..395]: 	Isa {memOp = NopM, alu1Op = Sra {sraRd = T2, sraRs1 = T1, sraRs2 = T0}, alu2Op = NopA, ctrlOp = NopC}
+mem[396..409]: 	Isa {memOp = NopM, alu1Op = And {andRd = T2, andRs1 = T1, andRs2 = T0}, alu2Op = NopA, ctrlOp = NopC}
+mem[410..423]: 	Isa {memOp = NopM, alu1Op = Or {orRd = T2, orRs1 = T1, orRs2 = T0}, alu2Op = NopA, ctrlOp = NopC}
+mem[424..437]: 	Isa {memOp = NopM, alu1Op = Xor {xorRd = T2, xorRs1 = T1, xorRs2 = T0}, alu2Op = NopA, ctrlOp = NopC}
+mem[438..451]: 	Isa {memOp = NopM, alu1Op = Mv {mvRd = T2, mvRs = T1}, alu2Op = NopA, ctrlOp = NopC}
+mem[452..465]: 	Isa {memOp = Sw {swRs2 = T2, swOffsetRs1 = MemRef {mrOffset = 0, mrReg = T0}}, alu1Op = NopA, alu2Op = NopA, ctrlOp = NopC}
+mem[466..479]: 	Isa {memOp = Sb {sbRs2 = T2, sbOffsetRs1 = MemRef {mrOffset = 0, mrReg = T0}}, alu1Op = NopA, alu2Op = NopA, ctrlOp = NopC}
+mem[480..493]: 	Isa {memOp = NopM, alu1Op = Lui {luiRd = T2, luiK = 4660}, alu2Op = NopA, ctrlOp = NopC}
+mem[494..507]: 	Isa {memOp = Lw {lwRd = T2, lwOffsetRs1 = MemRef {mrOffset = 0, mrReg = T0}}, alu1Op = NopA, alu2Op = NopA, ctrlOp = NopC}
+mem[508..521]: 	Isa {memOp = NopM, alu1Op = NopA, alu2Op = NopA, ctrlOp = J {jK = 126}}
+mem[522..535]: 	Isa {memOp = NopM, alu1Op = NopA, alu2Op = NopA, ctrlOp = Beqz {beqzRs1 = T1, beqzK = 126}}
+mem[536..549]: 	Isa {memOp = NopM, alu1Op = NopA, alu2Op = NopA, ctrlOp = Bnez {bnezRs1 = T1, bnezK = 126}}
+mem[550..563]: 	Isa {memOp = NopM, alu1Op = NopA, alu2Op = NopA, ctrlOp = Bgt {bgtRs1 = T1, bgtRs2 = T0, bgtK = 126}}
+mem[564..577]: 	Isa {memOp = NopM, alu1Op = NopA, alu2Op = NopA, ctrlOp = Ble {bleRs1 = T1, bleRs2 = T0, bleK = 126}}
+mem[578..591]: 	Isa {memOp = NopM, alu1Op = NopA, alu2Op = NopA, ctrlOp = Bgtu {bgtuRs1 = T1, bgtuRs2 = T0, bgtuK = 126}}
+mem[592..605]: 	Isa {memOp = NopM, alu1Op = NopA, alu2Op = NopA, ctrlOp = Bleu {bleuRs1 = T1, bleuRs2 = T0, bleuK = 126}}
+mem[606..619]: 	Isa {memOp = NopM, alu1Op = NopA, alu2Op = NopA, ctrlOp = Beq {beqRs1 = T1, beqRs2 = T0, beqK = 126}}
+mem[620..633]: 	Isa {memOp = NopM, alu1Op = NopA, alu2Op = NopA, ctrlOp = Bne {bneRs1 = T1, bneRs2 = T0, bneK = 126}}
+mem[634..647]: 	Isa {memOp = NopM, alu1Op = Addi {addiRd = T0, addiRs1 = T0, addiK = 4}, alu2Op = NopA, ctrlOp = NopC} 	@jump_label
+mem[648..661]: 	Isa {memOp = NopM, alu1Op = Addi {addiRd = T0, addiRs1 = T0, addiK = 4}, alu2Op = NopA, ctrlOp = NopC} 	@beqz_label
+mem[662..675]: 	Isa {memOp = NopM, alu1Op = Addi {addiRd = T0, addiRs1 = T0, addiK = 4}, alu2Op = NopA, ctrlOp = NopC} 	@bnez_label
+mem[676..689]: 	Isa {memOp = NopM, alu1Op = Addi {addiRd = T0, addiRs1 = T0, addiK = 4}, alu2Op = NopA, ctrlOp = NopC} 	@bgt_label
+mem[690..703]: 	Isa {memOp = NopM, alu1Op = Addi {addiRd = T0, addiRs1 = T0, addiK = 4}, alu2Op = NopA, ctrlOp = NopC} 	@ble_label
+mem[704..717]: 	Isa {memOp = NopM, alu1Op = Addi {addiRd = T0, addiRs1 = T0, addiK = 4}, alu2Op = NopA, ctrlOp = NopC} 	@bgtu_label
+mem[718..731]: 	Isa {memOp = NopM, alu1Op = Addi {addiRd = T0, addiRs1 = T0, addiK = 4}, alu2Op = NopA, ctrlOp = NopC} 	@bleu_label
+mem[732..745]: 	Isa {memOp = NopM, alu1Op = Addi {addiRd = T0, addiRs1 = T0, addiK = 4}, alu2Op = NopA, ctrlOp = NopC} 	@beq_label
+mem[746..759]: 	Isa {memOp = NopM, alu1Op = Addi {addiRd = T0, addiRs1 = T0, addiK = 4}, alu2Op = NopA, ctrlOp = NopC} 	@bne_label
+mem[760..773]: 	Isa {memOp = NopM, alu1Op = NopA, alu2Op = NopA, ctrlOp = Halt}
+mem[774..999]: 	( 00 )
 ---

--- a/test/golden/vliw-iv/ble_bleu.vliw-iv.result
+++ b/test/golden/vliw-iv/ble_bleu.vliw-iv.result
@@ -3,18 +3,18 @@
 A0 0 A1 0
 0:	Isa {memOp = NopM, alu1Op = Addi {addiRd = A0, addiRs1 = Zero, addiK = -1}, alu2Op = NopA, ctrlOp = NopC}	@_start
 A0 -1 A1 0
-11:	Isa {memOp = NopM, alu1Op = Addi {addiRd = A1, addiRs1 = Zero, addiK = -1}, alu2Op = NopA, ctrlOp = NopC}	
+14:	Isa {memOp = NopM, alu1Op = Addi {addiRd = A1, addiRs1 = Zero, addiK = -1}, alu2Op = NopA, ctrlOp = NopC}	
 A0 -1 A1 -1
-22:	Isa {memOp = NopM, alu1Op = NopA, alu2Op = NopA, ctrlOp = J {jK = 55}}	
+28:	Isa {memOp = NopM, alu1Op = NopA, alu2Op = NopA, ctrlOp = J {jK = 70}}	
 A0 -1 A1 -1
-77:	Isa {memOp = NopM, alu1Op = NopA, alu2Op = NopA, ctrlOp = Ble {bleRs1 = A0, bleRs2 = Zero, bleK = -44}}	@continue
+98:	Isa {memOp = NopM, alu1Op = NopA, alu2Op = NopA, ctrlOp = Ble {bleRs1 = A0, bleRs2 = Zero, bleK = -56}}	@continue
 A0 -1 A1 -1
-33:	Isa {memOp = NopM, alu1Op = Sub {subRd = A0, subRs1 = Zero, subRs2 = A0}, alu2Op = NopA, ctrlOp = NopC}	@make_pos_a0
+42:	Isa {memOp = NopM, alu1Op = Sub {subRd = A0, subRs1 = Zero, subRs2 = A0}, alu2Op = NopA, ctrlOp = NopC}	@make_pos_a0
 A0 1 A1 -1
-44:	Isa {memOp = NopM, alu1Op = NopA, alu2Op = NopA, ctrlOp = J {jK = 33}}	
+56:	Isa {memOp = NopM, alu1Op = NopA, alu2Op = NopA, ctrlOp = J {jK = 42}}	
 A0 1 A1 -1
-77:	Isa {memOp = NopM, alu1Op = NopA, alu2Op = NopA, ctrlOp = Ble {bleRs1 = A0, bleRs2 = Zero, bleK = -44}}	@continue
+98:	Isa {memOp = NopM, alu1Op = NopA, alu2Op = NopA, ctrlOp = Ble {bleRs1 = A0, bleRs2 = Zero, bleK = -56}}	@continue
 A0 1 A1 -1
-88:	Isa {memOp = NopM, alu1Op = NopA, alu2Op = NopA, ctrlOp = Bleu {bleuRs1 = A1, bleuRs2 = Zero, bleuK = -33}}	
+112:	Isa {memOp = NopM, alu1Op = NopA, alu2Op = NopA, ctrlOp = Bleu {bleuRs1 = A1, bleuRs2 = Zero, bleuK = -42}}	
 A0 1 A1 -1
-99:	Isa {memOp = NopM, alu1Op = NopA, alu2Op = NopA, ctrlOp = Halt}
+126:	Isa {memOp = NopM, alu1Op = NopA, alu2Op = NopA, ctrlOp = Halt}

--- a/test/golden/vliw-iv/count.s.vliw-iv.result
+++ b/test/golden/vliw-iv/count.s.vliw-iv.result
@@ -3,28 +3,28 @@
 8:	out_port
 12:	limit
 256:	_start
-388:	count
-421:	end
+424:	count
+466:	end
 ---
 mem[0..3]: 	00 00 00 00	@"acc"
 mem[4..7]: 	02 00 00 00	@"step"
 mem[8..11]: 	58 00 00 00	@"out_port"
 mem[12..255]: 	15 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00	@"limit"
-mem[256..266]: 	Isa {memOp = NopM, alu1Op = Lui {luiRd = T0, luiK = 0}, alu2Op = NopA, ctrlOp = NopC} 	@_start
-mem[267..277]: 	Isa {memOp = NopM, alu1Op = Addi {addiRd = T0, addiRs1 = T0, addiK = 4}, alu2Op = NopA, ctrlOp = NopC}
-mem[278..288]: 	Isa {memOp = Lw {lwRd = T1, lwOffsetRs1 = MemRef {mrOffset = 0, mrReg = T0}}, alu1Op = NopA, alu2Op = NopA, ctrlOp = NopC}
-mem[289..299]: 	Isa {memOp = NopM, alu1Op = Lui {luiRd = T0, luiK = 0}, alu2Op = NopA, ctrlOp = NopC}
-mem[300..310]: 	Isa {memOp = NopM, alu1Op = Addi {addiRd = T0, addiRs1 = T0, addiK = 0}, alu2Op = NopA, ctrlOp = NopC}
-mem[311..321]: 	Isa {memOp = Lw {lwRd = T2, lwOffsetRs1 = MemRef {mrOffset = 0, mrReg = T0}}, alu1Op = NopA, alu2Op = NopA, ctrlOp = NopC}
-mem[322..332]: 	Isa {memOp = NopM, alu1Op = Lui {luiRd = T3, luiK = 0}, alu2Op = NopA, ctrlOp = NopC}
-mem[333..343]: 	Isa {memOp = NopM, alu1Op = Addi {addiRd = T3, addiRs1 = T3, addiK = 8}, alu2Op = NopA, ctrlOp = NopC}
-mem[344..354]: 	Isa {memOp = Lw {lwRd = T4, lwOffsetRs1 = MemRef {mrOffset = 0, mrReg = T3}}, alu1Op = NopA, alu2Op = NopA, ctrlOp = NopC}
-mem[355..365]: 	Isa {memOp = NopM, alu1Op = Lui {luiRd = T6, luiK = 0}, alu2Op = NopA, ctrlOp = NopC}
-mem[366..376]: 	Isa {memOp = NopM, alu1Op = Addi {addiRd = T6, addiRs1 = T6, addiK = 12}, alu2Op = NopA, ctrlOp = NopC}
-mem[377..387]: 	Isa {memOp = Lw {lwRd = T5, lwOffsetRs1 = MemRef {mrOffset = 0, mrReg = T6}}, alu1Op = NopA, alu2Op = NopA, ctrlOp = NopC}
-mem[388..398]: 	Isa {memOp = Sw {swRs2 = T2, swOffsetRs1 = MemRef {mrOffset = 0, mrReg = T0}}, alu1Op = Add {addRd = T2, addRs1 = T2, addRs2 = T1}, alu2Op = NopA, ctrlOp = NopC} 	@count
-mem[399..409]: 	Isa {memOp = Sw {swRs2 = T2, swOffsetRs1 = MemRef {mrOffset = 0, mrReg = T4}}, alu1Op = NopA, alu2Op = NopA, ctrlOp = Bgt {bgtRs1 = T2, bgtRs2 = T5, bgtK = 22}}
-mem[410..420]: 	Isa {memOp = NopM, alu1Op = NopA, alu2Op = NopA, ctrlOp = J {jK = -22}}
-mem[421..431]: 	Isa {memOp = NopM, alu1Op = NopA, alu2Op = NopA, ctrlOp = Halt} 	@end
-mem[432..999]: 	( 00 )
+mem[256..269]: 	Isa {memOp = NopM, alu1Op = Lui {luiRd = T0, luiK = 0}, alu2Op = NopA, ctrlOp = NopC} 	@_start
+mem[270..283]: 	Isa {memOp = NopM, alu1Op = Addi {addiRd = T0, addiRs1 = T0, addiK = 4}, alu2Op = NopA, ctrlOp = NopC}
+mem[284..297]: 	Isa {memOp = Lw {lwRd = T1, lwOffsetRs1 = MemRef {mrOffset = 0, mrReg = T0}}, alu1Op = NopA, alu2Op = NopA, ctrlOp = NopC}
+mem[298..311]: 	Isa {memOp = NopM, alu1Op = Lui {luiRd = T0, luiK = 0}, alu2Op = NopA, ctrlOp = NopC}
+mem[312..325]: 	Isa {memOp = NopM, alu1Op = Addi {addiRd = T0, addiRs1 = T0, addiK = 0}, alu2Op = NopA, ctrlOp = NopC}
+mem[326..339]: 	Isa {memOp = Lw {lwRd = T2, lwOffsetRs1 = MemRef {mrOffset = 0, mrReg = T0}}, alu1Op = NopA, alu2Op = NopA, ctrlOp = NopC}
+mem[340..353]: 	Isa {memOp = NopM, alu1Op = Lui {luiRd = T3, luiK = 0}, alu2Op = NopA, ctrlOp = NopC}
+mem[354..367]: 	Isa {memOp = NopM, alu1Op = Addi {addiRd = T3, addiRs1 = T3, addiK = 8}, alu2Op = NopA, ctrlOp = NopC}
+mem[368..381]: 	Isa {memOp = Lw {lwRd = T4, lwOffsetRs1 = MemRef {mrOffset = 0, mrReg = T3}}, alu1Op = NopA, alu2Op = NopA, ctrlOp = NopC}
+mem[382..395]: 	Isa {memOp = NopM, alu1Op = Lui {luiRd = T6, luiK = 0}, alu2Op = NopA, ctrlOp = NopC}
+mem[396..409]: 	Isa {memOp = NopM, alu1Op = Addi {addiRd = T6, addiRs1 = T6, addiK = 12}, alu2Op = NopA, ctrlOp = NopC}
+mem[410..423]: 	Isa {memOp = Lw {lwRd = T5, lwOffsetRs1 = MemRef {mrOffset = 0, mrReg = T6}}, alu1Op = NopA, alu2Op = NopA, ctrlOp = NopC}
+mem[424..437]: 	Isa {memOp = Sw {swRs2 = T2, swOffsetRs1 = MemRef {mrOffset = 0, mrReg = T0}}, alu1Op = Add {addRd = T2, addRs1 = T2, addRs2 = T1}, alu2Op = NopA, ctrlOp = NopC} 	@count
+mem[438..451]: 	Isa {memOp = Sw {swRs2 = T2, swOffsetRs1 = MemRef {mrOffset = 0, mrReg = T4}}, alu1Op = NopA, alu2Op = NopA, ctrlOp = Bgt {bgtRs1 = T2, bgtRs2 = T5, bgtK = 28}}
+mem[452..465]: 	Isa {memOp = NopM, alu1Op = NopA, alu2Op = NopA, ctrlOp = J {jK = -28}}
+mem[466..479]: 	Isa {memOp = NopM, alu1Op = NopA, alu2Op = NopA, ctrlOp = Halt} 	@end
+mem[480..999]: 	( 00 )
 ---

--- a/test/golden/vliw-iv/count.vliw-iv.result
+++ b/test/golden/vliw-iv/count.vliw-iv.result
@@ -1,50 +1,50 @@
 ---
 # Step-by-step
 256:	Isa {memOp = NopM, alu1Op = Lui {luiRd = T0, luiK = 0}, alu2Op = NopA, ctrlOp = NopC}	0x00000000 0x00000000 0x00000000 0x00000000 @_start
-267:	Isa {memOp = NopM, alu1Op = Addi {addiRd = T0, addiRs1 = T0, addiK = 4}, alu2Op = NopA, ctrlOp = NopC}	0x00000000 0x00000000 0x00000000 0x00000000 
-278:	Isa {memOp = Lw {lwRd = T1, lwOffsetRs1 = MemRef {mrOffset = 0, mrReg = T0}}, alu1Op = NopA, alu2Op = NopA, ctrlOp = NopC}	0x00000004 0x00000000 0x00000000 0x00000000 
-289:	Isa {memOp = NopM, alu1Op = Lui {luiRd = T0, luiK = 0}, alu2Op = NopA, ctrlOp = NopC}	0x00000004 0x00000002 0x00000000 0x00000000 
-300:	Isa {memOp = NopM, alu1Op = Addi {addiRd = T0, addiRs1 = T0, addiK = 0}, alu2Op = NopA, ctrlOp = NopC}	0x00000000 0x00000002 0x00000000 0x00000000 
-311:	Isa {memOp = Lw {lwRd = T2, lwOffsetRs1 = MemRef {mrOffset = 0, mrReg = T0}}, alu1Op = NopA, alu2Op = NopA, ctrlOp = NopC}	0x00000000 0x00000002 0x00000000 0x00000000 
-322:	Isa {memOp = NopM, alu1Op = Lui {luiRd = T3, luiK = 0}, alu2Op = NopA, ctrlOp = NopC}	0x00000000 0x00000002 0x00000000 0x00000000 
-333:	Isa {memOp = NopM, alu1Op = Addi {addiRd = T3, addiRs1 = T3, addiK = 8}, alu2Op = NopA, ctrlOp = NopC}	0x00000000 0x00000002 0x00000000 0x00000000 
-344:	Isa {memOp = Lw {lwRd = T4, lwOffsetRs1 = MemRef {mrOffset = 0, mrReg = T3}}, alu1Op = NopA, alu2Op = NopA, ctrlOp = NopC}	0x00000000 0x00000002 0x00000000 0x00000008 
-355:	Isa {memOp = NopM, alu1Op = Lui {luiRd = T6, luiK = 0}, alu2Op = NopA, ctrlOp = NopC}	0x00000000 0x00000002 0x00000000 0x00000008 
-366:	Isa {memOp = NopM, alu1Op = Addi {addiRd = T6, addiRs1 = T6, addiK = 12}, alu2Op = NopA, ctrlOp = NopC}	0x00000000 0x00000002 0x00000000 0x00000008 
-377:	Isa {memOp = Lw {lwRd = T5, lwOffsetRs1 = MemRef {mrOffset = 0, mrReg = T6}}, alu1Op = NopA, alu2Op = NopA, ctrlOp = NopC}	0x00000000 0x00000002 0x00000000 0x00000008 
-388:	Isa {memOp = Sw {swRs2 = T2, swOffsetRs1 = MemRef {mrOffset = 0, mrReg = T0}}, alu1Op = Add {addRd = T2, addRs1 = T2, addRs2 = T1}, alu2Op = NopA, ctrlOp = NopC}	0x00000000 0x00000002 0x00000000 0x00000008 @count
-399:	Isa {memOp = Sw {swRs2 = T2, swOffsetRs1 = MemRef {mrOffset = 0, mrReg = T4}}, alu1Op = NopA, alu2Op = NopA, ctrlOp = Bgt {bgtRs1 = T2, bgtRs2 = T5, bgtK = 22}}	0x00000000 0x00000002 0x00000002 0x00000008 
-410:	Isa {memOp = NopM, alu1Op = NopA, alu2Op = NopA, ctrlOp = J {jK = -22}}	0x00000000 0x00000002 0x00000002 0x00000008 
-388:	Isa {memOp = Sw {swRs2 = T2, swOffsetRs1 = MemRef {mrOffset = 0, mrReg = T0}}, alu1Op = Add {addRd = T2, addRs1 = T2, addRs2 = T1}, alu2Op = NopA, ctrlOp = NopC}	0x00000000 0x00000002 0x00000002 0x00000008 @count
-399:	Isa {memOp = Sw {swRs2 = T2, swOffsetRs1 = MemRef {mrOffset = 0, mrReg = T4}}, alu1Op = NopA, alu2Op = NopA, ctrlOp = Bgt {bgtRs1 = T2, bgtRs2 = T5, bgtK = 22}}	0x00000000 0x00000002 0x00000004 0x00000008 
-410:	Isa {memOp = NopM, alu1Op = NopA, alu2Op = NopA, ctrlOp = J {jK = -22}}	0x00000000 0x00000002 0x00000004 0x00000008 
-388:	Isa {memOp = Sw {swRs2 = T2, swOffsetRs1 = MemRef {mrOffset = 0, mrReg = T0}}, alu1Op = Add {addRd = T2, addRs1 = T2, addRs2 = T1}, alu2Op = NopA, ctrlOp = NopC}	0x00000000 0x00000002 0x00000004 0x00000008 @count
-399:	Isa {memOp = Sw {swRs2 = T2, swOffsetRs1 = MemRef {mrOffset = 0, mrReg = T4}}, alu1Op = NopA, alu2Op = NopA, ctrlOp = Bgt {bgtRs1 = T2, bgtRs2 = T5, bgtK = 22}}	0x00000000 0x00000002 0x00000006 0x00000008 
-410:	Isa {memOp = NopM, alu1Op = NopA, alu2Op = NopA, ctrlOp = J {jK = -22}}	0x00000000 0x00000002 0x00000006 0x00000008 
-388:	Isa {memOp = Sw {swRs2 = T2, swOffsetRs1 = MemRef {mrOffset = 0, mrReg = T0}}, alu1Op = Add {addRd = T2, addRs1 = T2, addRs2 = T1}, alu2Op = NopA, ctrlOp = NopC}	0x00000000 0x00000002 0x00000006 0x00000008 @count
-399:	Isa {memOp = Sw {swRs2 = T2, swOffsetRs1 = MemRef {mrOffset = 0, mrReg = T4}}, alu1Op = NopA, alu2Op = NopA, ctrlOp = Bgt {bgtRs1 = T2, bgtRs2 = T5, bgtK = 22}}	0x00000000 0x00000002 0x00000008 0x00000008 
-410:	Isa {memOp = NopM, alu1Op = NopA, alu2Op = NopA, ctrlOp = J {jK = -22}}	0x00000000 0x00000002 0x00000008 0x00000008 
-388:	Isa {memOp = Sw {swRs2 = T2, swOffsetRs1 = MemRef {mrOffset = 0, mrReg = T0}}, alu1Op = Add {addRd = T2, addRs1 = T2, addRs2 = T1}, alu2Op = NopA, ctrlOp = NopC}	0x00000000 0x00000002 0x00000008 0x00000008 @count
-399:	Isa {memOp = Sw {swRs2 = T2, swOffsetRs1 = MemRef {mrOffset = 0, mrReg = T4}}, alu1Op = NopA, alu2Op = NopA, ctrlOp = Bgt {bgtRs1 = T2, bgtRs2 = T5, bgtK = 22}}	0x00000000 0x00000002 0x0000000a 0x00000008 
-410:	Isa {memOp = NopM, alu1Op = NopA, alu2Op = NopA, ctrlOp = J {jK = -22}}	0x00000000 0x00000002 0x0000000a 0x00000008 
-388:	Isa {memOp = Sw {swRs2 = T2, swOffsetRs1 = MemRef {mrOffset = 0, mrReg = T0}}, alu1Op = Add {addRd = T2, addRs1 = T2, addRs2 = T1}, alu2Op = NopA, ctrlOp = NopC}	0x00000000 0x00000002 0x0000000a 0x00000008 @count
-399:	Isa {memOp = Sw {swRs2 = T2, swOffsetRs1 = MemRef {mrOffset = 0, mrReg = T4}}, alu1Op = NopA, alu2Op = NopA, ctrlOp = Bgt {bgtRs1 = T2, bgtRs2 = T5, bgtK = 22}}	0x00000000 0x00000002 0x0000000c 0x00000008 
-410:	Isa {memOp = NopM, alu1Op = NopA, alu2Op = NopA, ctrlOp = J {jK = -22}}	0x00000000 0x00000002 0x0000000c 0x00000008 
-388:	Isa {memOp = Sw {swRs2 = T2, swOffsetRs1 = MemRef {mrOffset = 0, mrReg = T0}}, alu1Op = Add {addRd = T2, addRs1 = T2, addRs2 = T1}, alu2Op = NopA, ctrlOp = NopC}	0x00000000 0x00000002 0x0000000c 0x00000008 @count
-399:	Isa {memOp = Sw {swRs2 = T2, swOffsetRs1 = MemRef {mrOffset = 0, mrReg = T4}}, alu1Op = NopA, alu2Op = NopA, ctrlOp = Bgt {bgtRs1 = T2, bgtRs2 = T5, bgtK = 22}}	0x00000000 0x00000002 0x0000000e 0x00000008 
-410:	Isa {memOp = NopM, alu1Op = NopA, alu2Op = NopA, ctrlOp = J {jK = -22}}	0x00000000 0x00000002 0x0000000e 0x00000008 
-388:	Isa {memOp = Sw {swRs2 = T2, swOffsetRs1 = MemRef {mrOffset = 0, mrReg = T0}}, alu1Op = Add {addRd = T2, addRs1 = T2, addRs2 = T1}, alu2Op = NopA, ctrlOp = NopC}	0x00000000 0x00000002 0x0000000e 0x00000008 @count
-399:	Isa {memOp = Sw {swRs2 = T2, swOffsetRs1 = MemRef {mrOffset = 0, mrReg = T4}}, alu1Op = NopA, alu2Op = NopA, ctrlOp = Bgt {bgtRs1 = T2, bgtRs2 = T5, bgtK = 22}}	0x00000000 0x00000002 0x00000010 0x00000008 
-410:	Isa {memOp = NopM, alu1Op = NopA, alu2Op = NopA, ctrlOp = J {jK = -22}}	0x00000000 0x00000002 0x00000010 0x00000008 
-388:	Isa {memOp = Sw {swRs2 = T2, swOffsetRs1 = MemRef {mrOffset = 0, mrReg = T0}}, alu1Op = Add {addRd = T2, addRs1 = T2, addRs2 = T1}, alu2Op = NopA, ctrlOp = NopC}	0x00000000 0x00000002 0x00000010 0x00000008 @count
-399:	Isa {memOp = Sw {swRs2 = T2, swOffsetRs1 = MemRef {mrOffset = 0, mrReg = T4}}, alu1Op = NopA, alu2Op = NopA, ctrlOp = Bgt {bgtRs1 = T2, bgtRs2 = T5, bgtK = 22}}	0x00000000 0x00000002 0x00000012 0x00000008 
-410:	Isa {memOp = NopM, alu1Op = NopA, alu2Op = NopA, ctrlOp = J {jK = -22}}	0x00000000 0x00000002 0x00000012 0x00000008 
-388:	Isa {memOp = Sw {swRs2 = T2, swOffsetRs1 = MemRef {mrOffset = 0, mrReg = T0}}, alu1Op = Add {addRd = T2, addRs1 = T2, addRs2 = T1}, alu2Op = NopA, ctrlOp = NopC}	0x00000000 0x00000002 0x00000012 0x00000008 @count
-399:	Isa {memOp = Sw {swRs2 = T2, swOffsetRs1 = MemRef {mrOffset = 0, mrReg = T4}}, alu1Op = NopA, alu2Op = NopA, ctrlOp = Bgt {bgtRs1 = T2, bgtRs2 = T5, bgtK = 22}}	0x00000000 0x00000002 0x00000014 0x00000008 
-410:	Isa {memOp = NopM, alu1Op = NopA, alu2Op = NopA, ctrlOp = J {jK = -22}}	0x00000000 0x00000002 0x00000014 0x00000008 
-388:	Isa {memOp = Sw {swRs2 = T2, swOffsetRs1 = MemRef {mrOffset = 0, mrReg = T0}}, alu1Op = Add {addRd = T2, addRs1 = T2, addRs2 = T1}, alu2Op = NopA, ctrlOp = NopC}	0x00000000 0x00000002 0x00000014 0x00000008 @count
-399:	Isa {memOp = Sw {swRs2 = T2, swOffsetRs1 = MemRef {mrOffset = 0, mrReg = T4}}, alu1Op = NopA, alu2Op = NopA, ctrlOp = Bgt {bgtRs1 = T2, bgtRs2 = T5, bgtK = 22}}	0x00000000 0x00000002 0x00000016 0x00000008 
-421:	Isa {memOp = NopM, alu1Op = NopA, alu2Op = NopA, ctrlOp = Halt}	0x00000000 0x00000002 0x00000016 0x00000008 @end
+270:	Isa {memOp = NopM, alu1Op = Addi {addiRd = T0, addiRs1 = T0, addiK = 4}, alu2Op = NopA, ctrlOp = NopC}	0x00000000 0x00000000 0x00000000 0x00000000 
+284:	Isa {memOp = Lw {lwRd = T1, lwOffsetRs1 = MemRef {mrOffset = 0, mrReg = T0}}, alu1Op = NopA, alu2Op = NopA, ctrlOp = NopC}	0x00000004 0x00000000 0x00000000 0x00000000 
+298:	Isa {memOp = NopM, alu1Op = Lui {luiRd = T0, luiK = 0}, alu2Op = NopA, ctrlOp = NopC}	0x00000004 0x00000002 0x00000000 0x00000000 
+312:	Isa {memOp = NopM, alu1Op = Addi {addiRd = T0, addiRs1 = T0, addiK = 0}, alu2Op = NopA, ctrlOp = NopC}	0x00000000 0x00000002 0x00000000 0x00000000 
+326:	Isa {memOp = Lw {lwRd = T2, lwOffsetRs1 = MemRef {mrOffset = 0, mrReg = T0}}, alu1Op = NopA, alu2Op = NopA, ctrlOp = NopC}	0x00000000 0x00000002 0x00000000 0x00000000 
+340:	Isa {memOp = NopM, alu1Op = Lui {luiRd = T3, luiK = 0}, alu2Op = NopA, ctrlOp = NopC}	0x00000000 0x00000002 0x00000000 0x00000000 
+354:	Isa {memOp = NopM, alu1Op = Addi {addiRd = T3, addiRs1 = T3, addiK = 8}, alu2Op = NopA, ctrlOp = NopC}	0x00000000 0x00000002 0x00000000 0x00000000 
+368:	Isa {memOp = Lw {lwRd = T4, lwOffsetRs1 = MemRef {mrOffset = 0, mrReg = T3}}, alu1Op = NopA, alu2Op = NopA, ctrlOp = NopC}	0x00000000 0x00000002 0x00000000 0x00000008 
+382:	Isa {memOp = NopM, alu1Op = Lui {luiRd = T6, luiK = 0}, alu2Op = NopA, ctrlOp = NopC}	0x00000000 0x00000002 0x00000000 0x00000008 
+396:	Isa {memOp = NopM, alu1Op = Addi {addiRd = T6, addiRs1 = T6, addiK = 12}, alu2Op = NopA, ctrlOp = NopC}	0x00000000 0x00000002 0x00000000 0x00000008 
+410:	Isa {memOp = Lw {lwRd = T5, lwOffsetRs1 = MemRef {mrOffset = 0, mrReg = T6}}, alu1Op = NopA, alu2Op = NopA, ctrlOp = NopC}	0x00000000 0x00000002 0x00000000 0x00000008 
+424:	Isa {memOp = Sw {swRs2 = T2, swOffsetRs1 = MemRef {mrOffset = 0, mrReg = T0}}, alu1Op = Add {addRd = T2, addRs1 = T2, addRs2 = T1}, alu2Op = NopA, ctrlOp = NopC}	0x00000000 0x00000002 0x00000000 0x00000008 @count
+438:	Isa {memOp = Sw {swRs2 = T2, swOffsetRs1 = MemRef {mrOffset = 0, mrReg = T4}}, alu1Op = NopA, alu2Op = NopA, ctrlOp = Bgt {bgtRs1 = T2, bgtRs2 = T5, bgtK = 28}}	0x00000000 0x00000002 0x00000002 0x00000008 
+452:	Isa {memOp = NopM, alu1Op = NopA, alu2Op = NopA, ctrlOp = J {jK = -28}}	0x00000000 0x00000002 0x00000002 0x00000008 
+424:	Isa {memOp = Sw {swRs2 = T2, swOffsetRs1 = MemRef {mrOffset = 0, mrReg = T0}}, alu1Op = Add {addRd = T2, addRs1 = T2, addRs2 = T1}, alu2Op = NopA, ctrlOp = NopC}	0x00000000 0x00000002 0x00000002 0x00000008 @count
+438:	Isa {memOp = Sw {swRs2 = T2, swOffsetRs1 = MemRef {mrOffset = 0, mrReg = T4}}, alu1Op = NopA, alu2Op = NopA, ctrlOp = Bgt {bgtRs1 = T2, bgtRs2 = T5, bgtK = 28}}	0x00000000 0x00000002 0x00000004 0x00000008 
+452:	Isa {memOp = NopM, alu1Op = NopA, alu2Op = NopA, ctrlOp = J {jK = -28}}	0x00000000 0x00000002 0x00000004 0x00000008 
+424:	Isa {memOp = Sw {swRs2 = T2, swOffsetRs1 = MemRef {mrOffset = 0, mrReg = T0}}, alu1Op = Add {addRd = T2, addRs1 = T2, addRs2 = T1}, alu2Op = NopA, ctrlOp = NopC}	0x00000000 0x00000002 0x00000004 0x00000008 @count
+438:	Isa {memOp = Sw {swRs2 = T2, swOffsetRs1 = MemRef {mrOffset = 0, mrReg = T4}}, alu1Op = NopA, alu2Op = NopA, ctrlOp = Bgt {bgtRs1 = T2, bgtRs2 = T5, bgtK = 28}}	0x00000000 0x00000002 0x00000006 0x00000008 
+452:	Isa {memOp = NopM, alu1Op = NopA, alu2Op = NopA, ctrlOp = J {jK = -28}}	0x00000000 0x00000002 0x00000006 0x00000008 
+424:	Isa {memOp = Sw {swRs2 = T2, swOffsetRs1 = MemRef {mrOffset = 0, mrReg = T0}}, alu1Op = Add {addRd = T2, addRs1 = T2, addRs2 = T1}, alu2Op = NopA, ctrlOp = NopC}	0x00000000 0x00000002 0x00000006 0x00000008 @count
+438:	Isa {memOp = Sw {swRs2 = T2, swOffsetRs1 = MemRef {mrOffset = 0, mrReg = T4}}, alu1Op = NopA, alu2Op = NopA, ctrlOp = Bgt {bgtRs1 = T2, bgtRs2 = T5, bgtK = 28}}	0x00000000 0x00000002 0x00000008 0x00000008 
+452:	Isa {memOp = NopM, alu1Op = NopA, alu2Op = NopA, ctrlOp = J {jK = -28}}	0x00000000 0x00000002 0x00000008 0x00000008 
+424:	Isa {memOp = Sw {swRs2 = T2, swOffsetRs1 = MemRef {mrOffset = 0, mrReg = T0}}, alu1Op = Add {addRd = T2, addRs1 = T2, addRs2 = T1}, alu2Op = NopA, ctrlOp = NopC}	0x00000000 0x00000002 0x00000008 0x00000008 @count
+438:	Isa {memOp = Sw {swRs2 = T2, swOffsetRs1 = MemRef {mrOffset = 0, mrReg = T4}}, alu1Op = NopA, alu2Op = NopA, ctrlOp = Bgt {bgtRs1 = T2, bgtRs2 = T5, bgtK = 28}}	0x00000000 0x00000002 0x0000000a 0x00000008 
+452:	Isa {memOp = NopM, alu1Op = NopA, alu2Op = NopA, ctrlOp = J {jK = -28}}	0x00000000 0x00000002 0x0000000a 0x00000008 
+424:	Isa {memOp = Sw {swRs2 = T2, swOffsetRs1 = MemRef {mrOffset = 0, mrReg = T0}}, alu1Op = Add {addRd = T2, addRs1 = T2, addRs2 = T1}, alu2Op = NopA, ctrlOp = NopC}	0x00000000 0x00000002 0x0000000a 0x00000008 @count
+438:	Isa {memOp = Sw {swRs2 = T2, swOffsetRs1 = MemRef {mrOffset = 0, mrReg = T4}}, alu1Op = NopA, alu2Op = NopA, ctrlOp = Bgt {bgtRs1 = T2, bgtRs2 = T5, bgtK = 28}}	0x00000000 0x00000002 0x0000000c 0x00000008 
+452:	Isa {memOp = NopM, alu1Op = NopA, alu2Op = NopA, ctrlOp = J {jK = -28}}	0x00000000 0x00000002 0x0000000c 0x00000008 
+424:	Isa {memOp = Sw {swRs2 = T2, swOffsetRs1 = MemRef {mrOffset = 0, mrReg = T0}}, alu1Op = Add {addRd = T2, addRs1 = T2, addRs2 = T1}, alu2Op = NopA, ctrlOp = NopC}	0x00000000 0x00000002 0x0000000c 0x00000008 @count
+438:	Isa {memOp = Sw {swRs2 = T2, swOffsetRs1 = MemRef {mrOffset = 0, mrReg = T4}}, alu1Op = NopA, alu2Op = NopA, ctrlOp = Bgt {bgtRs1 = T2, bgtRs2 = T5, bgtK = 28}}	0x00000000 0x00000002 0x0000000e 0x00000008 
+452:	Isa {memOp = NopM, alu1Op = NopA, alu2Op = NopA, ctrlOp = J {jK = -28}}	0x00000000 0x00000002 0x0000000e 0x00000008 
+424:	Isa {memOp = Sw {swRs2 = T2, swOffsetRs1 = MemRef {mrOffset = 0, mrReg = T0}}, alu1Op = Add {addRd = T2, addRs1 = T2, addRs2 = T1}, alu2Op = NopA, ctrlOp = NopC}	0x00000000 0x00000002 0x0000000e 0x00000008 @count
+438:	Isa {memOp = Sw {swRs2 = T2, swOffsetRs1 = MemRef {mrOffset = 0, mrReg = T4}}, alu1Op = NopA, alu2Op = NopA, ctrlOp = Bgt {bgtRs1 = T2, bgtRs2 = T5, bgtK = 28}}	0x00000000 0x00000002 0x00000010 0x00000008 
+452:	Isa {memOp = NopM, alu1Op = NopA, alu2Op = NopA, ctrlOp = J {jK = -28}}	0x00000000 0x00000002 0x00000010 0x00000008 
+424:	Isa {memOp = Sw {swRs2 = T2, swOffsetRs1 = MemRef {mrOffset = 0, mrReg = T0}}, alu1Op = Add {addRd = T2, addRs1 = T2, addRs2 = T1}, alu2Op = NopA, ctrlOp = NopC}	0x00000000 0x00000002 0x00000010 0x00000008 @count
+438:	Isa {memOp = Sw {swRs2 = T2, swOffsetRs1 = MemRef {mrOffset = 0, mrReg = T4}}, alu1Op = NopA, alu2Op = NopA, ctrlOp = Bgt {bgtRs1 = T2, bgtRs2 = T5, bgtK = 28}}	0x00000000 0x00000002 0x00000012 0x00000008 
+452:	Isa {memOp = NopM, alu1Op = NopA, alu2Op = NopA, ctrlOp = J {jK = -28}}	0x00000000 0x00000002 0x00000012 0x00000008 
+424:	Isa {memOp = Sw {swRs2 = T2, swOffsetRs1 = MemRef {mrOffset = 0, mrReg = T0}}, alu1Op = Add {addRd = T2, addRs1 = T2, addRs2 = T1}, alu2Op = NopA, ctrlOp = NopC}	0x00000000 0x00000002 0x00000012 0x00000008 @count
+438:	Isa {memOp = Sw {swRs2 = T2, swOffsetRs1 = MemRef {mrOffset = 0, mrReg = T4}}, alu1Op = NopA, alu2Op = NopA, ctrlOp = Bgt {bgtRs1 = T2, bgtRs2 = T5, bgtK = 28}}	0x00000000 0x00000002 0x00000014 0x00000008 
+452:	Isa {memOp = NopM, alu1Op = NopA, alu2Op = NopA, ctrlOp = J {jK = -28}}	0x00000000 0x00000002 0x00000014 0x00000008 
+424:	Isa {memOp = Sw {swRs2 = T2, swOffsetRs1 = MemRef {mrOffset = 0, mrReg = T0}}, alu1Op = Add {addRd = T2, addRs1 = T2, addRs2 = T1}, alu2Op = NopA, ctrlOp = NopC}	0x00000000 0x00000002 0x00000014 0x00000008 @count
+438:	Isa {memOp = Sw {swRs2 = T2, swOffsetRs1 = MemRef {mrOffset = 0, mrReg = T4}}, alu1Op = NopA, alu2Op = NopA, ctrlOp = Bgt {bgtRs1 = T2, bgtRs2 = T5, bgtK = 28}}	0x00000000 0x00000002 0x00000016 0x00000008 
+466:	Isa {memOp = NopM, alu1Op = NopA, alu2Op = NopA, ctrlOp = Halt}	0x00000000 0x00000002 0x00000016 0x00000008 @end
 ---
 # Result
 mem[4..7]: 	02 00 00 00

--- a/test/golden/vliw-iv/factorial.s.vliw-iv.result
+++ b/test/golden/vliw-iv/factorial.s.vliw-iv.result
@@ -1,44 +1,44 @@
 0:	input_addr
 4:	output_addr
 144:	_start
-199:	factorial_begin
-210:	factorial_while
-276:	check_overflow
-353:	negative_case
-419:	factorial_end
-463:	exit
+214:	factorial_begin
+228:	factorial_while
+312:	check_overflow
+410:	negative_case
+494:	factorial_end
+550:	exit
 ---
 mem[0..3]: 	80 00 00 00	@"input_addr"
 mem[4..143]: 	84 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00	@"output_addr"
-mem[144..154]: 	Isa {memOp = NopM, alu1Op = Lui {luiRd = T0, luiK = 0}, alu2Op = NopA, ctrlOp = NopC} 	@_start
-mem[155..165]: 	Isa {memOp = NopM, alu1Op = Addi {addiRd = T0, addiRs1 = T0, addiK = 0}, alu2Op = NopA, ctrlOp = NopC}
-mem[166..176]: 	Isa {memOp = Lw {lwRd = T0, lwOffsetRs1 = MemRef {mrOffset = 0, mrReg = T0}}, alu1Op = NopA, alu2Op = NopA, ctrlOp = NopC}
-mem[177..187]: 	Isa {memOp = Lw {lwRd = T1, lwOffsetRs1 = MemRef {mrOffset = 0, mrReg = T0}}, alu1Op = NopA, alu2Op = NopA, ctrlOp = NopC}
-mem[188..198]: 	Isa {memOp = NopM, alu1Op = NopA, alu2Op = NopA, ctrlOp = Bgt {bgtRs1 = Zero, bgtRs2 = T1, bgtK = 165}}
-mem[199..209]: 	Isa {memOp = NopM, alu1Op = Addi {addiRd = T2, addiRs1 = Zero, addiK = 1}, alu2Op = NopA, ctrlOp = NopC} 	@factorial_begin
-mem[210..220]: 	Isa {memOp = NopM, alu1Op = NopA, alu2Op = NopA, ctrlOp = Beqz {beqzRs1 = T1, beqzK = 209}} 	@factorial_while
-mem[221..231]: 	Isa {memOp = NopM, alu1Op = Mulh {mulhRd = T3, mulhRs1 = T2, mulhRs2 = T1}, alu2Op = NopA, ctrlOp = NopC}
-mem[232..242]: 	Isa {memOp = NopM, alu1Op = NopA, alu2Op = NopA, ctrlOp = Bnez {bnezRs1 = T3, bnezK = 44}}
-mem[243..253]: 	Isa {memOp = NopM, alu1Op = Mul {mulRd = T2, mulRs1 = T2, mulRs2 = T1}, alu2Op = NopA, ctrlOp = NopC}
-mem[254..264]: 	Isa {memOp = NopM, alu1Op = Addi {addiRd = T1, addiRs1 = T1, addiK = -1}, alu2Op = NopA, ctrlOp = NopC}
-mem[265..275]: 	Isa {memOp = NopM, alu1Op = NopA, alu2Op = NopA, ctrlOp = J {jK = -55}}
-mem[276..286]: 	Isa {memOp = NopM, alu1Op = Lui {luiRd = T0, luiK = 0}, alu2Op = NopA, ctrlOp = NopC} 	@check_overflow
-mem[287..297]: 	Isa {memOp = NopM, alu1Op = Addi {addiRd = T0, addiRs1 = T0, addiK = 4}, alu2Op = NopA, ctrlOp = NopC}
-mem[298..308]: 	Isa {memOp = Lw {lwRd = T0, lwOffsetRs1 = MemRef {mrOffset = 0, mrReg = T0}}, alu1Op = NopA, alu2Op = NopA, ctrlOp = NopC}
-mem[309..319]: 	Isa {memOp = NopM, alu1Op = Lui {luiRd = T4, luiK = 838860}, alu2Op = NopA, ctrlOp = NopC}
-mem[320..330]: 	Isa {memOp = NopM, alu1Op = Addi {addiRd = T4, addiRs1 = T4, addiK = 3276}, alu2Op = NopA, ctrlOp = NopC}
-mem[331..341]: 	Isa {memOp = Sw {swRs2 = T4, swOffsetRs1 = MemRef {mrOffset = 0, mrReg = T0}}, alu1Op = NopA, alu2Op = NopA, ctrlOp = NopC}
-mem[342..352]: 	Isa {memOp = NopM, alu1Op = NopA, alu2Op = NopA, ctrlOp = J {jK = 121}}
-mem[353..363]: 	Isa {memOp = NopM, alu1Op = Lui {luiRd = T0, luiK = 0}, alu2Op = NopA, ctrlOp = NopC} 	@negative_case
-mem[364..374]: 	Isa {memOp = NopM, alu1Op = Addi {addiRd = T0, addiRs1 = T0, addiK = 4}, alu2Op = NopA, ctrlOp = NopC}
-mem[375..385]: 	Isa {memOp = Lw {lwRd = T0, lwOffsetRs1 = MemRef {mrOffset = 0, mrReg = T0}}, alu1Op = NopA, alu2Op = NopA, ctrlOp = NopC}
-mem[386..396]: 	Isa {memOp = NopM, alu1Op = Addi {addiRd = T4, addiRs1 = Zero, addiK = -1}, alu2Op = NopA, ctrlOp = NopC}
-mem[397..407]: 	Isa {memOp = Sw {swRs2 = T4, swOffsetRs1 = MemRef {mrOffset = 0, mrReg = T0}}, alu1Op = NopA, alu2Op = NopA, ctrlOp = NopC}
-mem[408..418]: 	Isa {memOp = NopM, alu1Op = NopA, alu2Op = NopA, ctrlOp = J {jK = 55}}
-mem[419..429]: 	Isa {memOp = NopM, alu1Op = Lui {luiRd = T0, luiK = 0}, alu2Op = NopA, ctrlOp = NopC} 	@factorial_end
-mem[430..440]: 	Isa {memOp = NopM, alu1Op = Addi {addiRd = T0, addiRs1 = T0, addiK = 4}, alu2Op = NopA, ctrlOp = NopC}
-mem[441..451]: 	Isa {memOp = Lw {lwRd = T0, lwOffsetRs1 = MemRef {mrOffset = 0, mrReg = T0}}, alu1Op = NopA, alu2Op = NopA, ctrlOp = NopC}
-mem[452..462]: 	Isa {memOp = Sw {swRs2 = T2, swOffsetRs1 = MemRef {mrOffset = 0, mrReg = T0}}, alu1Op = NopA, alu2Op = NopA, ctrlOp = NopC}
-mem[463..473]: 	Isa {memOp = NopM, alu1Op = NopA, alu2Op = NopA, ctrlOp = Halt} 	@exit
-mem[474..999]: 	( 00 )
+mem[144..157]: 	Isa {memOp = NopM, alu1Op = Lui {luiRd = T0, luiK = 0}, alu2Op = NopA, ctrlOp = NopC} 	@_start
+mem[158..171]: 	Isa {memOp = NopM, alu1Op = Addi {addiRd = T0, addiRs1 = T0, addiK = 0}, alu2Op = NopA, ctrlOp = NopC}
+mem[172..185]: 	Isa {memOp = Lw {lwRd = T0, lwOffsetRs1 = MemRef {mrOffset = 0, mrReg = T0}}, alu1Op = NopA, alu2Op = NopA, ctrlOp = NopC}
+mem[186..199]: 	Isa {memOp = Lw {lwRd = T1, lwOffsetRs1 = MemRef {mrOffset = 0, mrReg = T0}}, alu1Op = NopA, alu2Op = NopA, ctrlOp = NopC}
+mem[200..213]: 	Isa {memOp = NopM, alu1Op = NopA, alu2Op = NopA, ctrlOp = Bgt {bgtRs1 = Zero, bgtRs2 = T1, bgtK = 210}}
+mem[214..227]: 	Isa {memOp = NopM, alu1Op = Addi {addiRd = T2, addiRs1 = Zero, addiK = 1}, alu2Op = NopA, ctrlOp = NopC} 	@factorial_begin
+mem[228..241]: 	Isa {memOp = NopM, alu1Op = NopA, alu2Op = NopA, ctrlOp = Beqz {beqzRs1 = T1, beqzK = 266}} 	@factorial_while
+mem[242..255]: 	Isa {memOp = NopM, alu1Op = Mulh {mulhRd = T3, mulhRs1 = T2, mulhRs2 = T1}, alu2Op = NopA, ctrlOp = NopC}
+mem[256..269]: 	Isa {memOp = NopM, alu1Op = NopA, alu2Op = NopA, ctrlOp = Bnez {bnezRs1 = T3, bnezK = 56}}
+mem[270..283]: 	Isa {memOp = NopM, alu1Op = Mul {mulRd = T2, mulRs1 = T2, mulRs2 = T1}, alu2Op = NopA, ctrlOp = NopC}
+mem[284..297]: 	Isa {memOp = NopM, alu1Op = Addi {addiRd = T1, addiRs1 = T1, addiK = -1}, alu2Op = NopA, ctrlOp = NopC}
+mem[298..311]: 	Isa {memOp = NopM, alu1Op = NopA, alu2Op = NopA, ctrlOp = J {jK = -70}}
+mem[312..325]: 	Isa {memOp = NopM, alu1Op = Lui {luiRd = T0, luiK = 0}, alu2Op = NopA, ctrlOp = NopC} 	@check_overflow
+mem[326..339]: 	Isa {memOp = NopM, alu1Op = Addi {addiRd = T0, addiRs1 = T0, addiK = 4}, alu2Op = NopA, ctrlOp = NopC}
+mem[340..353]: 	Isa {memOp = Lw {lwRd = T0, lwOffsetRs1 = MemRef {mrOffset = 0, mrReg = T0}}, alu1Op = NopA, alu2Op = NopA, ctrlOp = NopC}
+mem[354..367]: 	Isa {memOp = NopM, alu1Op = Lui {luiRd = T4, luiK = 838860}, alu2Op = NopA, ctrlOp = NopC}
+mem[368..381]: 	Isa {memOp = NopM, alu1Op = Addi {addiRd = T4, addiRs1 = T4, addiK = 3276}, alu2Op = NopA, ctrlOp = NopC}
+mem[382..395]: 	Isa {memOp = Sw {swRs2 = T4, swOffsetRs1 = MemRef {mrOffset = 0, mrReg = T0}}, alu1Op = NopA, alu2Op = NopA, ctrlOp = NopC}
+mem[396..409]: 	Isa {memOp = NopM, alu1Op = NopA, alu2Op = NopA, ctrlOp = J {jK = 154}}
+mem[410..423]: 	Isa {memOp = NopM, alu1Op = Lui {luiRd = T0, luiK = 0}, alu2Op = NopA, ctrlOp = NopC} 	@negative_case
+mem[424..437]: 	Isa {memOp = NopM, alu1Op = Addi {addiRd = T0, addiRs1 = T0, addiK = 4}, alu2Op = NopA, ctrlOp = NopC}
+mem[438..451]: 	Isa {memOp = Lw {lwRd = T0, lwOffsetRs1 = MemRef {mrOffset = 0, mrReg = T0}}, alu1Op = NopA, alu2Op = NopA, ctrlOp = NopC}
+mem[452..465]: 	Isa {memOp = NopM, alu1Op = Addi {addiRd = T4, addiRs1 = Zero, addiK = -1}, alu2Op = NopA, ctrlOp = NopC}
+mem[466..479]: 	Isa {memOp = Sw {swRs2 = T4, swOffsetRs1 = MemRef {mrOffset = 0, mrReg = T0}}, alu1Op = NopA, alu2Op = NopA, ctrlOp = NopC}
+mem[480..493]: 	Isa {memOp = NopM, alu1Op = NopA, alu2Op = NopA, ctrlOp = J {jK = 70}}
+mem[494..507]: 	Isa {memOp = NopM, alu1Op = Lui {luiRd = T0, luiK = 0}, alu2Op = NopA, ctrlOp = NopC} 	@factorial_end
+mem[508..521]: 	Isa {memOp = NopM, alu1Op = Addi {addiRd = T0, addiRs1 = T0, addiK = 4}, alu2Op = NopA, ctrlOp = NopC}
+mem[522..535]: 	Isa {memOp = Lw {lwRd = T0, lwOffsetRs1 = MemRef {mrOffset = 0, mrReg = T0}}, alu1Op = NopA, alu2Op = NopA, ctrlOp = NopC}
+mem[536..549]: 	Isa {memOp = Sw {swRs2 = T2, swOffsetRs1 = MemRef {mrOffset = 0, mrReg = T0}}, alu1Op = NopA, alu2Op = NopA, ctrlOp = NopC}
+mem[550..563]: 	Isa {memOp = NopM, alu1Op = NopA, alu2Op = NopA, ctrlOp = Halt} 	@exit
+mem[564..999]: 	( 00 )
 ---

--- a/test/golden/vliw-iv/factorial_input_5.vliw-iv.result
+++ b/test/golden/vliw-iv/factorial_input_5.vliw-iv.result
@@ -3,87 +3,87 @@
 0 0 0 0
 144:	Isa {memOp = NopM, alu1Op = Lui {luiRd = T0, luiK = 0}, alu2Op = NopA, ctrlOp = NopC}	@_start
 0 0 0 0
-155:	Isa {memOp = NopM, alu1Op = Addi {addiRd = T0, addiRs1 = T0, addiK = 0}, alu2Op = NopA, ctrlOp = NopC}	
+158:	Isa {memOp = NopM, alu1Op = Addi {addiRd = T0, addiRs1 = T0, addiK = 0}, alu2Op = NopA, ctrlOp = NopC}	
 0 0 0 0
-166:	Isa {memOp = Lw {lwRd = T0, lwOffsetRs1 = MemRef {mrOffset = 0, mrReg = T0}}, alu1Op = NopA, alu2Op = NopA, ctrlOp = NopC}	
+172:	Isa {memOp = Lw {lwRd = T0, lwOffsetRs1 = MemRef {mrOffset = 0, mrReg = T0}}, alu1Op = NopA, alu2Op = NopA, ctrlOp = NopC}	
 128 0 0 0
-177:	Isa {memOp = Lw {lwRd = T1, lwOffsetRs1 = MemRef {mrOffset = 0, mrReg = T0}}, alu1Op = NopA, alu2Op = NopA, ctrlOp = NopC}	
+186:	Isa {memOp = Lw {lwRd = T1, lwOffsetRs1 = MemRef {mrOffset = 0, mrReg = T0}}, alu1Op = NopA, alu2Op = NopA, ctrlOp = NopC}	
 128 5 0 0
-188:	Isa {memOp = NopM, alu1Op = NopA, alu2Op = NopA, ctrlOp = Bgt {bgtRs1 = Zero, bgtRs2 = T1, bgtK = 165}}	
+200:	Isa {memOp = NopM, alu1Op = NopA, alu2Op = NopA, ctrlOp = Bgt {bgtRs1 = Zero, bgtRs2 = T1, bgtK = 210}}	
 128 5 0 0
-199:	Isa {memOp = NopM, alu1Op = Addi {addiRd = T2, addiRs1 = Zero, addiK = 1}, alu2Op = NopA, ctrlOp = NopC}	@factorial_begin
+214:	Isa {memOp = NopM, alu1Op = Addi {addiRd = T2, addiRs1 = Zero, addiK = 1}, alu2Op = NopA, ctrlOp = NopC}	@factorial_begin
 128 5 1 0
-210:	Isa {memOp = NopM, alu1Op = NopA, alu2Op = NopA, ctrlOp = Beqz {beqzRs1 = T1, beqzK = 209}}	@factorial_while
+228:	Isa {memOp = NopM, alu1Op = NopA, alu2Op = NopA, ctrlOp = Beqz {beqzRs1 = T1, beqzK = 266}}	@factorial_while
 128 5 1 0
-221:	Isa {memOp = NopM, alu1Op = Mulh {mulhRd = T3, mulhRs1 = T2, mulhRs2 = T1}, alu2Op = NopA, ctrlOp = NopC}	
+242:	Isa {memOp = NopM, alu1Op = Mulh {mulhRd = T3, mulhRs1 = T2, mulhRs2 = T1}, alu2Op = NopA, ctrlOp = NopC}	
 128 5 1 0
-232:	Isa {memOp = NopM, alu1Op = NopA, alu2Op = NopA, ctrlOp = Bnez {bnezRs1 = T3, bnezK = 44}}	
+256:	Isa {memOp = NopM, alu1Op = NopA, alu2Op = NopA, ctrlOp = Bnez {bnezRs1 = T3, bnezK = 56}}	
 128 5 1 0
-243:	Isa {memOp = NopM, alu1Op = Mul {mulRd = T2, mulRs1 = T2, mulRs2 = T1}, alu2Op = NopA, ctrlOp = NopC}	
+270:	Isa {memOp = NopM, alu1Op = Mul {mulRd = T2, mulRs1 = T2, mulRs2 = T1}, alu2Op = NopA, ctrlOp = NopC}	
 128 5 5 0
-254:	Isa {memOp = NopM, alu1Op = Addi {addiRd = T1, addiRs1 = T1, addiK = -1}, alu2Op = NopA, ctrlOp = NopC}	
+284:	Isa {memOp = NopM, alu1Op = Addi {addiRd = T1, addiRs1 = T1, addiK = -1}, alu2Op = NopA, ctrlOp = NopC}	
 128 4 5 0
-265:	Isa {memOp = NopM, alu1Op = NopA, alu2Op = NopA, ctrlOp = J {jK = -55}}	
+298:	Isa {memOp = NopM, alu1Op = NopA, alu2Op = NopA, ctrlOp = J {jK = -70}}	
 128 4 5 0
-210:	Isa {memOp = NopM, alu1Op = NopA, alu2Op = NopA, ctrlOp = Beqz {beqzRs1 = T1, beqzK = 209}}	@factorial_while
+228:	Isa {memOp = NopM, alu1Op = NopA, alu2Op = NopA, ctrlOp = Beqz {beqzRs1 = T1, beqzK = 266}}	@factorial_while
 128 4 5 0
-221:	Isa {memOp = NopM, alu1Op = Mulh {mulhRd = T3, mulhRs1 = T2, mulhRs2 = T1}, alu2Op = NopA, ctrlOp = NopC}	
+242:	Isa {memOp = NopM, alu1Op = Mulh {mulhRd = T3, mulhRs1 = T2, mulhRs2 = T1}, alu2Op = NopA, ctrlOp = NopC}	
 128 4 5 0
-232:	Isa {memOp = NopM, alu1Op = NopA, alu2Op = NopA, ctrlOp = Bnez {bnezRs1 = T3, bnezK = 44}}	
+256:	Isa {memOp = NopM, alu1Op = NopA, alu2Op = NopA, ctrlOp = Bnez {bnezRs1 = T3, bnezK = 56}}	
 128 4 5 0
-243:	Isa {memOp = NopM, alu1Op = Mul {mulRd = T2, mulRs1 = T2, mulRs2 = T1}, alu2Op = NopA, ctrlOp = NopC}	
+270:	Isa {memOp = NopM, alu1Op = Mul {mulRd = T2, mulRs1 = T2, mulRs2 = T1}, alu2Op = NopA, ctrlOp = NopC}	
 128 4 20 0
-254:	Isa {memOp = NopM, alu1Op = Addi {addiRd = T1, addiRs1 = T1, addiK = -1}, alu2Op = NopA, ctrlOp = NopC}	
+284:	Isa {memOp = NopM, alu1Op = Addi {addiRd = T1, addiRs1 = T1, addiK = -1}, alu2Op = NopA, ctrlOp = NopC}	
 128 3 20 0
-265:	Isa {memOp = NopM, alu1Op = NopA, alu2Op = NopA, ctrlOp = J {jK = -55}}	
+298:	Isa {memOp = NopM, alu1Op = NopA, alu2Op = NopA, ctrlOp = J {jK = -70}}	
 128 3 20 0
-210:	Isa {memOp = NopM, alu1Op = NopA, alu2Op = NopA, ctrlOp = Beqz {beqzRs1 = T1, beqzK = 209}}	@factorial_while
+228:	Isa {memOp = NopM, alu1Op = NopA, alu2Op = NopA, ctrlOp = Beqz {beqzRs1 = T1, beqzK = 266}}	@factorial_while
 128 3 20 0
-221:	Isa {memOp = NopM, alu1Op = Mulh {mulhRd = T3, mulhRs1 = T2, mulhRs2 = T1}, alu2Op = NopA, ctrlOp = NopC}	
+242:	Isa {memOp = NopM, alu1Op = Mulh {mulhRd = T3, mulhRs1 = T2, mulhRs2 = T1}, alu2Op = NopA, ctrlOp = NopC}	
 128 3 20 0
-232:	Isa {memOp = NopM, alu1Op = NopA, alu2Op = NopA, ctrlOp = Bnez {bnezRs1 = T3, bnezK = 44}}	
+256:	Isa {memOp = NopM, alu1Op = NopA, alu2Op = NopA, ctrlOp = Bnez {bnezRs1 = T3, bnezK = 56}}	
 128 3 20 0
-243:	Isa {memOp = NopM, alu1Op = Mul {mulRd = T2, mulRs1 = T2, mulRs2 = T1}, alu2Op = NopA, ctrlOp = NopC}	
+270:	Isa {memOp = NopM, alu1Op = Mul {mulRd = T2, mulRs1 = T2, mulRs2 = T1}, alu2Op = NopA, ctrlOp = NopC}	
 128 3 60 0
-254:	Isa {memOp = NopM, alu1Op = Addi {addiRd = T1, addiRs1 = T1, addiK = -1}, alu2Op = NopA, ctrlOp = NopC}	
+284:	Isa {memOp = NopM, alu1Op = Addi {addiRd = T1, addiRs1 = T1, addiK = -1}, alu2Op = NopA, ctrlOp = NopC}	
 128 2 60 0
-265:	Isa {memOp = NopM, alu1Op = NopA, alu2Op = NopA, ctrlOp = J {jK = -55}}	
+298:	Isa {memOp = NopM, alu1Op = NopA, alu2Op = NopA, ctrlOp = J {jK = -70}}	
 128 2 60 0
-210:	Isa {memOp = NopM, alu1Op = NopA, alu2Op = NopA, ctrlOp = Beqz {beqzRs1 = T1, beqzK = 209}}	@factorial_while
+228:	Isa {memOp = NopM, alu1Op = NopA, alu2Op = NopA, ctrlOp = Beqz {beqzRs1 = T1, beqzK = 266}}	@factorial_while
 128 2 60 0
-221:	Isa {memOp = NopM, alu1Op = Mulh {mulhRd = T3, mulhRs1 = T2, mulhRs2 = T1}, alu2Op = NopA, ctrlOp = NopC}	
+242:	Isa {memOp = NopM, alu1Op = Mulh {mulhRd = T3, mulhRs1 = T2, mulhRs2 = T1}, alu2Op = NopA, ctrlOp = NopC}	
 128 2 60 0
-232:	Isa {memOp = NopM, alu1Op = NopA, alu2Op = NopA, ctrlOp = Bnez {bnezRs1 = T3, bnezK = 44}}	
+256:	Isa {memOp = NopM, alu1Op = NopA, alu2Op = NopA, ctrlOp = Bnez {bnezRs1 = T3, bnezK = 56}}	
 128 2 60 0
-243:	Isa {memOp = NopM, alu1Op = Mul {mulRd = T2, mulRs1 = T2, mulRs2 = T1}, alu2Op = NopA, ctrlOp = NopC}	
+270:	Isa {memOp = NopM, alu1Op = Mul {mulRd = T2, mulRs1 = T2, mulRs2 = T1}, alu2Op = NopA, ctrlOp = NopC}	
 128 2 120 0
-254:	Isa {memOp = NopM, alu1Op = Addi {addiRd = T1, addiRs1 = T1, addiK = -1}, alu2Op = NopA, ctrlOp = NopC}	
+284:	Isa {memOp = NopM, alu1Op = Addi {addiRd = T1, addiRs1 = T1, addiK = -1}, alu2Op = NopA, ctrlOp = NopC}	
 128 1 120 0
-265:	Isa {memOp = NopM, alu1Op = NopA, alu2Op = NopA, ctrlOp = J {jK = -55}}	
+298:	Isa {memOp = NopM, alu1Op = NopA, alu2Op = NopA, ctrlOp = J {jK = -70}}	
 128 1 120 0
-210:	Isa {memOp = NopM, alu1Op = NopA, alu2Op = NopA, ctrlOp = Beqz {beqzRs1 = T1, beqzK = 209}}	@factorial_while
+228:	Isa {memOp = NopM, alu1Op = NopA, alu2Op = NopA, ctrlOp = Beqz {beqzRs1 = T1, beqzK = 266}}	@factorial_while
 128 1 120 0
-221:	Isa {memOp = NopM, alu1Op = Mulh {mulhRd = T3, mulhRs1 = T2, mulhRs2 = T1}, alu2Op = NopA, ctrlOp = NopC}	
+242:	Isa {memOp = NopM, alu1Op = Mulh {mulhRd = T3, mulhRs1 = T2, mulhRs2 = T1}, alu2Op = NopA, ctrlOp = NopC}	
 128 1 120 0
-232:	Isa {memOp = NopM, alu1Op = NopA, alu2Op = NopA, ctrlOp = Bnez {bnezRs1 = T3, bnezK = 44}}	
+256:	Isa {memOp = NopM, alu1Op = NopA, alu2Op = NopA, ctrlOp = Bnez {bnezRs1 = T3, bnezK = 56}}	
 128 1 120 0
-243:	Isa {memOp = NopM, alu1Op = Mul {mulRd = T2, mulRs1 = T2, mulRs2 = T1}, alu2Op = NopA, ctrlOp = NopC}	
+270:	Isa {memOp = NopM, alu1Op = Mul {mulRd = T2, mulRs1 = T2, mulRs2 = T1}, alu2Op = NopA, ctrlOp = NopC}	
 128 1 120 0
-254:	Isa {memOp = NopM, alu1Op = Addi {addiRd = T1, addiRs1 = T1, addiK = -1}, alu2Op = NopA, ctrlOp = NopC}	
+284:	Isa {memOp = NopM, alu1Op = Addi {addiRd = T1, addiRs1 = T1, addiK = -1}, alu2Op = NopA, ctrlOp = NopC}	
 128 0 120 0
-265:	Isa {memOp = NopM, alu1Op = NopA, alu2Op = NopA, ctrlOp = J {jK = -55}}	
+298:	Isa {memOp = NopM, alu1Op = NopA, alu2Op = NopA, ctrlOp = J {jK = -70}}	
 128 0 120 0
-210:	Isa {memOp = NopM, alu1Op = NopA, alu2Op = NopA, ctrlOp = Beqz {beqzRs1 = T1, beqzK = 209}}	@factorial_while
+228:	Isa {memOp = NopM, alu1Op = NopA, alu2Op = NopA, ctrlOp = Beqz {beqzRs1 = T1, beqzK = 266}}	@factorial_while
 128 0 120 0
-419:	Isa {memOp = NopM, alu1Op = Lui {luiRd = T0, luiK = 0}, alu2Op = NopA, ctrlOp = NopC}	@factorial_end
+494:	Isa {memOp = NopM, alu1Op = Lui {luiRd = T0, luiK = 0}, alu2Op = NopA, ctrlOp = NopC}	@factorial_end
 0 0 120 0
-430:	Isa {memOp = NopM, alu1Op = Addi {addiRd = T0, addiRs1 = T0, addiK = 4}, alu2Op = NopA, ctrlOp = NopC}	
+508:	Isa {memOp = NopM, alu1Op = Addi {addiRd = T0, addiRs1 = T0, addiK = 4}, alu2Op = NopA, ctrlOp = NopC}	
 4 0 120 0
-441:	Isa {memOp = Lw {lwRd = T0, lwOffsetRs1 = MemRef {mrOffset = 0, mrReg = T0}}, alu1Op = NopA, alu2Op = NopA, ctrlOp = NopC}	
+522:	Isa {memOp = Lw {lwRd = T0, lwOffsetRs1 = MemRef {mrOffset = 0, mrReg = T0}}, alu1Op = NopA, alu2Op = NopA, ctrlOp = NopC}	
 132 0 120 0
-452:	Isa {memOp = Sw {swRs2 = T2, swOffsetRs1 = MemRef {mrOffset = 0, mrReg = T0}}, alu1Op = NopA, alu2Op = NopA, ctrlOp = NopC}	
+536:	Isa {memOp = Sw {swRs2 = T2, swOffsetRs1 = MemRef {mrOffset = 0, mrReg = T0}}, alu1Op = NopA, alu2Op = NopA, ctrlOp = NopC}	
 132 0 120 0
-463:	Isa {memOp = NopM, alu1Op = NopA, alu2Op = NopA, ctrlOp = Halt}	@exit
+550:	Isa {memOp = NopM, alu1Op = NopA, alu2Op = NopA, ctrlOp = Halt}	@exit
 ---
 # result
 numio[0x80]: [] >>> []

--- a/test/golden/vliw-iv/factorial_input_5_fail_assert.vliw-iv.result
+++ b/test/golden/vliw-iv/factorial_input_5_fail_assert.vliw-iv.result
@@ -3,87 +3,87 @@
 0 0 0 0
 144:	Isa {memOp = NopM, alu1Op = Lui {luiRd = T0, luiK = 0}, alu2Op = NopA, ctrlOp = NopC}	@_start
 0 0 0 0
-155:	Isa {memOp = NopM, alu1Op = Addi {addiRd = T0, addiRs1 = T0, addiK = 0}, alu2Op = NopA, ctrlOp = NopC}	
+158:	Isa {memOp = NopM, alu1Op = Addi {addiRd = T0, addiRs1 = T0, addiK = 0}, alu2Op = NopA, ctrlOp = NopC}	
 0 0 0 0
-166:	Isa {memOp = Lw {lwRd = T0, lwOffsetRs1 = MemRef {mrOffset = 0, mrReg = T0}}, alu1Op = NopA, alu2Op = NopA, ctrlOp = NopC}	
+172:	Isa {memOp = Lw {lwRd = T0, lwOffsetRs1 = MemRef {mrOffset = 0, mrReg = T0}}, alu1Op = NopA, alu2Op = NopA, ctrlOp = NopC}	
 128 0 0 0
-177:	Isa {memOp = Lw {lwRd = T1, lwOffsetRs1 = MemRef {mrOffset = 0, mrReg = T0}}, alu1Op = NopA, alu2Op = NopA, ctrlOp = NopC}	
+186:	Isa {memOp = Lw {lwRd = T1, lwOffsetRs1 = MemRef {mrOffset = 0, mrReg = T0}}, alu1Op = NopA, alu2Op = NopA, ctrlOp = NopC}	
 128 5 0 0
-188:	Isa {memOp = NopM, alu1Op = NopA, alu2Op = NopA, ctrlOp = Bgt {bgtRs1 = Zero, bgtRs2 = T1, bgtK = 165}}	
+200:	Isa {memOp = NopM, alu1Op = NopA, alu2Op = NopA, ctrlOp = Bgt {bgtRs1 = Zero, bgtRs2 = T1, bgtK = 210}}	
 128 5 0 0
-199:	Isa {memOp = NopM, alu1Op = Addi {addiRd = T2, addiRs1 = Zero, addiK = 1}, alu2Op = NopA, ctrlOp = NopC}	@factorial_begin
+214:	Isa {memOp = NopM, alu1Op = Addi {addiRd = T2, addiRs1 = Zero, addiK = 1}, alu2Op = NopA, ctrlOp = NopC}	@factorial_begin
 128 5 1 0
-210:	Isa {memOp = NopM, alu1Op = NopA, alu2Op = NopA, ctrlOp = Beqz {beqzRs1 = T1, beqzK = 209}}	@factorial_while
+228:	Isa {memOp = NopM, alu1Op = NopA, alu2Op = NopA, ctrlOp = Beqz {beqzRs1 = T1, beqzK = 266}}	@factorial_while
 128 5 1 0
-221:	Isa {memOp = NopM, alu1Op = Mulh {mulhRd = T3, mulhRs1 = T2, mulhRs2 = T1}, alu2Op = NopA, ctrlOp = NopC}	
+242:	Isa {memOp = NopM, alu1Op = Mulh {mulhRd = T3, mulhRs1 = T2, mulhRs2 = T1}, alu2Op = NopA, ctrlOp = NopC}	
 128 5 1 0
-232:	Isa {memOp = NopM, alu1Op = NopA, alu2Op = NopA, ctrlOp = Bnez {bnezRs1 = T3, bnezK = 44}}	
+256:	Isa {memOp = NopM, alu1Op = NopA, alu2Op = NopA, ctrlOp = Bnez {bnezRs1 = T3, bnezK = 56}}	
 128 5 1 0
-243:	Isa {memOp = NopM, alu1Op = Mul {mulRd = T2, mulRs1 = T2, mulRs2 = T1}, alu2Op = NopA, ctrlOp = NopC}	
+270:	Isa {memOp = NopM, alu1Op = Mul {mulRd = T2, mulRs1 = T2, mulRs2 = T1}, alu2Op = NopA, ctrlOp = NopC}	
 128 5 5 0
-254:	Isa {memOp = NopM, alu1Op = Addi {addiRd = T1, addiRs1 = T1, addiK = -1}, alu2Op = NopA, ctrlOp = NopC}	
+284:	Isa {memOp = NopM, alu1Op = Addi {addiRd = T1, addiRs1 = T1, addiK = -1}, alu2Op = NopA, ctrlOp = NopC}	
 128 4 5 0
-265:	Isa {memOp = NopM, alu1Op = NopA, alu2Op = NopA, ctrlOp = J {jK = -55}}	
+298:	Isa {memOp = NopM, alu1Op = NopA, alu2Op = NopA, ctrlOp = J {jK = -70}}	
 128 4 5 0
-210:	Isa {memOp = NopM, alu1Op = NopA, alu2Op = NopA, ctrlOp = Beqz {beqzRs1 = T1, beqzK = 209}}	@factorial_while
+228:	Isa {memOp = NopM, alu1Op = NopA, alu2Op = NopA, ctrlOp = Beqz {beqzRs1 = T1, beqzK = 266}}	@factorial_while
 128 4 5 0
-221:	Isa {memOp = NopM, alu1Op = Mulh {mulhRd = T3, mulhRs1 = T2, mulhRs2 = T1}, alu2Op = NopA, ctrlOp = NopC}	
+242:	Isa {memOp = NopM, alu1Op = Mulh {mulhRd = T3, mulhRs1 = T2, mulhRs2 = T1}, alu2Op = NopA, ctrlOp = NopC}	
 128 4 5 0
-232:	Isa {memOp = NopM, alu1Op = NopA, alu2Op = NopA, ctrlOp = Bnez {bnezRs1 = T3, bnezK = 44}}	
+256:	Isa {memOp = NopM, alu1Op = NopA, alu2Op = NopA, ctrlOp = Bnez {bnezRs1 = T3, bnezK = 56}}	
 128 4 5 0
-243:	Isa {memOp = NopM, alu1Op = Mul {mulRd = T2, mulRs1 = T2, mulRs2 = T1}, alu2Op = NopA, ctrlOp = NopC}	
+270:	Isa {memOp = NopM, alu1Op = Mul {mulRd = T2, mulRs1 = T2, mulRs2 = T1}, alu2Op = NopA, ctrlOp = NopC}	
 128 4 20 0
-254:	Isa {memOp = NopM, alu1Op = Addi {addiRd = T1, addiRs1 = T1, addiK = -1}, alu2Op = NopA, ctrlOp = NopC}	
+284:	Isa {memOp = NopM, alu1Op = Addi {addiRd = T1, addiRs1 = T1, addiK = -1}, alu2Op = NopA, ctrlOp = NopC}	
 128 3 20 0
-265:	Isa {memOp = NopM, alu1Op = NopA, alu2Op = NopA, ctrlOp = J {jK = -55}}	
+298:	Isa {memOp = NopM, alu1Op = NopA, alu2Op = NopA, ctrlOp = J {jK = -70}}	
 128 3 20 0
-210:	Isa {memOp = NopM, alu1Op = NopA, alu2Op = NopA, ctrlOp = Beqz {beqzRs1 = T1, beqzK = 209}}	@factorial_while
+228:	Isa {memOp = NopM, alu1Op = NopA, alu2Op = NopA, ctrlOp = Beqz {beqzRs1 = T1, beqzK = 266}}	@factorial_while
 128 3 20 0
-221:	Isa {memOp = NopM, alu1Op = Mulh {mulhRd = T3, mulhRs1 = T2, mulhRs2 = T1}, alu2Op = NopA, ctrlOp = NopC}	
+242:	Isa {memOp = NopM, alu1Op = Mulh {mulhRd = T3, mulhRs1 = T2, mulhRs2 = T1}, alu2Op = NopA, ctrlOp = NopC}	
 128 3 20 0
-232:	Isa {memOp = NopM, alu1Op = NopA, alu2Op = NopA, ctrlOp = Bnez {bnezRs1 = T3, bnezK = 44}}	
+256:	Isa {memOp = NopM, alu1Op = NopA, alu2Op = NopA, ctrlOp = Bnez {bnezRs1 = T3, bnezK = 56}}	
 128 3 20 0
-243:	Isa {memOp = NopM, alu1Op = Mul {mulRd = T2, mulRs1 = T2, mulRs2 = T1}, alu2Op = NopA, ctrlOp = NopC}	
+270:	Isa {memOp = NopM, alu1Op = Mul {mulRd = T2, mulRs1 = T2, mulRs2 = T1}, alu2Op = NopA, ctrlOp = NopC}	
 128 3 60 0
-254:	Isa {memOp = NopM, alu1Op = Addi {addiRd = T1, addiRs1 = T1, addiK = -1}, alu2Op = NopA, ctrlOp = NopC}	
+284:	Isa {memOp = NopM, alu1Op = Addi {addiRd = T1, addiRs1 = T1, addiK = -1}, alu2Op = NopA, ctrlOp = NopC}	
 128 2 60 0
-265:	Isa {memOp = NopM, alu1Op = NopA, alu2Op = NopA, ctrlOp = J {jK = -55}}	
+298:	Isa {memOp = NopM, alu1Op = NopA, alu2Op = NopA, ctrlOp = J {jK = -70}}	
 128 2 60 0
-210:	Isa {memOp = NopM, alu1Op = NopA, alu2Op = NopA, ctrlOp = Beqz {beqzRs1 = T1, beqzK = 209}}	@factorial_while
+228:	Isa {memOp = NopM, alu1Op = NopA, alu2Op = NopA, ctrlOp = Beqz {beqzRs1 = T1, beqzK = 266}}	@factorial_while
 128 2 60 0
-221:	Isa {memOp = NopM, alu1Op = Mulh {mulhRd = T3, mulhRs1 = T2, mulhRs2 = T1}, alu2Op = NopA, ctrlOp = NopC}	
+242:	Isa {memOp = NopM, alu1Op = Mulh {mulhRd = T3, mulhRs1 = T2, mulhRs2 = T1}, alu2Op = NopA, ctrlOp = NopC}	
 128 2 60 0
-232:	Isa {memOp = NopM, alu1Op = NopA, alu2Op = NopA, ctrlOp = Bnez {bnezRs1 = T3, bnezK = 44}}	
+256:	Isa {memOp = NopM, alu1Op = NopA, alu2Op = NopA, ctrlOp = Bnez {bnezRs1 = T3, bnezK = 56}}	
 128 2 60 0
-243:	Isa {memOp = NopM, alu1Op = Mul {mulRd = T2, mulRs1 = T2, mulRs2 = T1}, alu2Op = NopA, ctrlOp = NopC}	
+270:	Isa {memOp = NopM, alu1Op = Mul {mulRd = T2, mulRs1 = T2, mulRs2 = T1}, alu2Op = NopA, ctrlOp = NopC}	
 128 2 120 0
-254:	Isa {memOp = NopM, alu1Op = Addi {addiRd = T1, addiRs1 = T1, addiK = -1}, alu2Op = NopA, ctrlOp = NopC}	
+284:	Isa {memOp = NopM, alu1Op = Addi {addiRd = T1, addiRs1 = T1, addiK = -1}, alu2Op = NopA, ctrlOp = NopC}	
 128 1 120 0
-265:	Isa {memOp = NopM, alu1Op = NopA, alu2Op = NopA, ctrlOp = J {jK = -55}}	
+298:	Isa {memOp = NopM, alu1Op = NopA, alu2Op = NopA, ctrlOp = J {jK = -70}}	
 128 1 120 0
-210:	Isa {memOp = NopM, alu1Op = NopA, alu2Op = NopA, ctrlOp = Beqz {beqzRs1 = T1, beqzK = 209}}	@factorial_while
+228:	Isa {memOp = NopM, alu1Op = NopA, alu2Op = NopA, ctrlOp = Beqz {beqzRs1 = T1, beqzK = 266}}	@factorial_while
 128 1 120 0
-221:	Isa {memOp = NopM, alu1Op = Mulh {mulhRd = T3, mulhRs1 = T2, mulhRs2 = T1}, alu2Op = NopA, ctrlOp = NopC}	
+242:	Isa {memOp = NopM, alu1Op = Mulh {mulhRd = T3, mulhRs1 = T2, mulhRs2 = T1}, alu2Op = NopA, ctrlOp = NopC}	
 128 1 120 0
-232:	Isa {memOp = NopM, alu1Op = NopA, alu2Op = NopA, ctrlOp = Bnez {bnezRs1 = T3, bnezK = 44}}	
+256:	Isa {memOp = NopM, alu1Op = NopA, alu2Op = NopA, ctrlOp = Bnez {bnezRs1 = T3, bnezK = 56}}	
 128 1 120 0
-243:	Isa {memOp = NopM, alu1Op = Mul {mulRd = T2, mulRs1 = T2, mulRs2 = T1}, alu2Op = NopA, ctrlOp = NopC}	
+270:	Isa {memOp = NopM, alu1Op = Mul {mulRd = T2, mulRs1 = T2, mulRs2 = T1}, alu2Op = NopA, ctrlOp = NopC}	
 128 1 120 0
-254:	Isa {memOp = NopM, alu1Op = Addi {addiRd = T1, addiRs1 = T1, addiK = -1}, alu2Op = NopA, ctrlOp = NopC}	
+284:	Isa {memOp = NopM, alu1Op = Addi {addiRd = T1, addiRs1 = T1, addiK = -1}, alu2Op = NopA, ctrlOp = NopC}	
 128 0 120 0
-265:	Isa {memOp = NopM, alu1Op = NopA, alu2Op = NopA, ctrlOp = J {jK = -55}}	
+298:	Isa {memOp = NopM, alu1Op = NopA, alu2Op = NopA, ctrlOp = J {jK = -70}}	
 128 0 120 0
-210:	Isa {memOp = NopM, alu1Op = NopA, alu2Op = NopA, ctrlOp = Beqz {beqzRs1 = T1, beqzK = 209}}	@factorial_while
+228:	Isa {memOp = NopM, alu1Op = NopA, alu2Op = NopA, ctrlOp = Beqz {beqzRs1 = T1, beqzK = 266}}	@factorial_while
 128 0 120 0
-419:	Isa {memOp = NopM, alu1Op = Lui {luiRd = T0, luiK = 0}, alu2Op = NopA, ctrlOp = NopC}	@factorial_end
+494:	Isa {memOp = NopM, alu1Op = Lui {luiRd = T0, luiK = 0}, alu2Op = NopA, ctrlOp = NopC}	@factorial_end
 0 0 120 0
-430:	Isa {memOp = NopM, alu1Op = Addi {addiRd = T0, addiRs1 = T0, addiK = 4}, alu2Op = NopA, ctrlOp = NopC}	
+508:	Isa {memOp = NopM, alu1Op = Addi {addiRd = T0, addiRs1 = T0, addiK = 4}, alu2Op = NopA, ctrlOp = NopC}	
 4 0 120 0
-441:	Isa {memOp = Lw {lwRd = T0, lwOffsetRs1 = MemRef {mrOffset = 0, mrReg = T0}}, alu1Op = NopA, alu2Op = NopA, ctrlOp = NopC}	
+522:	Isa {memOp = Lw {lwRd = T0, lwOffsetRs1 = MemRef {mrOffset = 0, mrReg = T0}}, alu1Op = NopA, alu2Op = NopA, ctrlOp = NopC}	
 132 0 120 0
-452:	Isa {memOp = Sw {swRs2 = T2, swOffsetRs1 = MemRef {mrOffset = 0, mrReg = T0}}, alu1Op = NopA, alu2Op = NopA, ctrlOp = NopC}	
+536:	Isa {memOp = Sw {swRs2 = T2, swOffsetRs1 = MemRef {mrOffset = 0, mrReg = T0}}, alu1Op = NopA, alu2Op = NopA, ctrlOp = NopC}	
 132 0 120 0
-463:	Isa {memOp = NopM, alu1Op = NopA, alu2Op = NopA, ctrlOp = Halt}	@exit
+550:	Isa {memOp = NopM, alu1Op = NopA, alu2Op = NopA, ctrlOp = Halt}	@exit
 ---
 # result
 numio[0x80]: [] >>> []

--- a/test/golden/vliw-iv/factorial_input_7.vliw-iv.result
+++ b/test/golden/vliw-iv/factorial_input_7.vliw-iv.result
@@ -3,111 +3,111 @@
 0 0 0 0
 144:	Isa {memOp = NopM, alu1Op = Lui {luiRd = T0, luiK = 0}, alu2Op = NopA, ctrlOp = NopC}	@_start
 0 0 0 0
-155:	Isa {memOp = NopM, alu1Op = Addi {addiRd = T0, addiRs1 = T0, addiK = 0}, alu2Op = NopA, ctrlOp = NopC}	
+158:	Isa {memOp = NopM, alu1Op = Addi {addiRd = T0, addiRs1 = T0, addiK = 0}, alu2Op = NopA, ctrlOp = NopC}	
 0 0 0 0
-166:	Isa {memOp = Lw {lwRd = T0, lwOffsetRs1 = MemRef {mrOffset = 0, mrReg = T0}}, alu1Op = NopA, alu2Op = NopA, ctrlOp = NopC}	
+172:	Isa {memOp = Lw {lwRd = T0, lwOffsetRs1 = MemRef {mrOffset = 0, mrReg = T0}}, alu1Op = NopA, alu2Op = NopA, ctrlOp = NopC}	
 128 0 0 0
-177:	Isa {memOp = Lw {lwRd = T1, lwOffsetRs1 = MemRef {mrOffset = 0, mrReg = T0}}, alu1Op = NopA, alu2Op = NopA, ctrlOp = NopC}	
+186:	Isa {memOp = Lw {lwRd = T1, lwOffsetRs1 = MemRef {mrOffset = 0, mrReg = T0}}, alu1Op = NopA, alu2Op = NopA, ctrlOp = NopC}	
 128 7 0 0
-188:	Isa {memOp = NopM, alu1Op = NopA, alu2Op = NopA, ctrlOp = Bgt {bgtRs1 = Zero, bgtRs2 = T1, bgtK = 165}}	
+200:	Isa {memOp = NopM, alu1Op = NopA, alu2Op = NopA, ctrlOp = Bgt {bgtRs1 = Zero, bgtRs2 = T1, bgtK = 210}}	
 128 7 0 0
-199:	Isa {memOp = NopM, alu1Op = Addi {addiRd = T2, addiRs1 = Zero, addiK = 1}, alu2Op = NopA, ctrlOp = NopC}	@factorial_begin
+214:	Isa {memOp = NopM, alu1Op = Addi {addiRd = T2, addiRs1 = Zero, addiK = 1}, alu2Op = NopA, ctrlOp = NopC}	@factorial_begin
 128 7 1 0
-210:	Isa {memOp = NopM, alu1Op = NopA, alu2Op = NopA, ctrlOp = Beqz {beqzRs1 = T1, beqzK = 209}}	@factorial_while
+228:	Isa {memOp = NopM, alu1Op = NopA, alu2Op = NopA, ctrlOp = Beqz {beqzRs1 = T1, beqzK = 266}}	@factorial_while
 128 7 1 0
-221:	Isa {memOp = NopM, alu1Op = Mulh {mulhRd = T3, mulhRs1 = T2, mulhRs2 = T1}, alu2Op = NopA, ctrlOp = NopC}	
+242:	Isa {memOp = NopM, alu1Op = Mulh {mulhRd = T3, mulhRs1 = T2, mulhRs2 = T1}, alu2Op = NopA, ctrlOp = NopC}	
 128 7 1 0
-232:	Isa {memOp = NopM, alu1Op = NopA, alu2Op = NopA, ctrlOp = Bnez {bnezRs1 = T3, bnezK = 44}}	
+256:	Isa {memOp = NopM, alu1Op = NopA, alu2Op = NopA, ctrlOp = Bnez {bnezRs1 = T3, bnezK = 56}}	
 128 7 1 0
-243:	Isa {memOp = NopM, alu1Op = Mul {mulRd = T2, mulRs1 = T2, mulRs2 = T1}, alu2Op = NopA, ctrlOp = NopC}	
+270:	Isa {memOp = NopM, alu1Op = Mul {mulRd = T2, mulRs1 = T2, mulRs2 = T1}, alu2Op = NopA, ctrlOp = NopC}	
 128 7 7 0
-254:	Isa {memOp = NopM, alu1Op = Addi {addiRd = T1, addiRs1 = T1, addiK = -1}, alu2Op = NopA, ctrlOp = NopC}	
+284:	Isa {memOp = NopM, alu1Op = Addi {addiRd = T1, addiRs1 = T1, addiK = -1}, alu2Op = NopA, ctrlOp = NopC}	
 128 6 7 0
-265:	Isa {memOp = NopM, alu1Op = NopA, alu2Op = NopA, ctrlOp = J {jK = -55}}	
+298:	Isa {memOp = NopM, alu1Op = NopA, alu2Op = NopA, ctrlOp = J {jK = -70}}	
 128 6 7 0
-210:	Isa {memOp = NopM, alu1Op = NopA, alu2Op = NopA, ctrlOp = Beqz {beqzRs1 = T1, beqzK = 209}}	@factorial_while
+228:	Isa {memOp = NopM, alu1Op = NopA, alu2Op = NopA, ctrlOp = Beqz {beqzRs1 = T1, beqzK = 266}}	@factorial_while
 128 6 7 0
-221:	Isa {memOp = NopM, alu1Op = Mulh {mulhRd = T3, mulhRs1 = T2, mulhRs2 = T1}, alu2Op = NopA, ctrlOp = NopC}	
+242:	Isa {memOp = NopM, alu1Op = Mulh {mulhRd = T3, mulhRs1 = T2, mulhRs2 = T1}, alu2Op = NopA, ctrlOp = NopC}	
 128 6 7 0
-232:	Isa {memOp = NopM, alu1Op = NopA, alu2Op = NopA, ctrlOp = Bnez {bnezRs1 = T3, bnezK = 44}}	
+256:	Isa {memOp = NopM, alu1Op = NopA, alu2Op = NopA, ctrlOp = Bnez {bnezRs1 = T3, bnezK = 56}}	
 128 6 7 0
-243:	Isa {memOp = NopM, alu1Op = Mul {mulRd = T2, mulRs1 = T2, mulRs2 = T1}, alu2Op = NopA, ctrlOp = NopC}	
+270:	Isa {memOp = NopM, alu1Op = Mul {mulRd = T2, mulRs1 = T2, mulRs2 = T1}, alu2Op = NopA, ctrlOp = NopC}	
 128 6 42 0
-254:	Isa {memOp = NopM, alu1Op = Addi {addiRd = T1, addiRs1 = T1, addiK = -1}, alu2Op = NopA, ctrlOp = NopC}	
+284:	Isa {memOp = NopM, alu1Op = Addi {addiRd = T1, addiRs1 = T1, addiK = -1}, alu2Op = NopA, ctrlOp = NopC}	
 128 5 42 0
-265:	Isa {memOp = NopM, alu1Op = NopA, alu2Op = NopA, ctrlOp = J {jK = -55}}	
+298:	Isa {memOp = NopM, alu1Op = NopA, alu2Op = NopA, ctrlOp = J {jK = -70}}	
 128 5 42 0
-210:	Isa {memOp = NopM, alu1Op = NopA, alu2Op = NopA, ctrlOp = Beqz {beqzRs1 = T1, beqzK = 209}}	@factorial_while
+228:	Isa {memOp = NopM, alu1Op = NopA, alu2Op = NopA, ctrlOp = Beqz {beqzRs1 = T1, beqzK = 266}}	@factorial_while
 128 5 42 0
-221:	Isa {memOp = NopM, alu1Op = Mulh {mulhRd = T3, mulhRs1 = T2, mulhRs2 = T1}, alu2Op = NopA, ctrlOp = NopC}	
+242:	Isa {memOp = NopM, alu1Op = Mulh {mulhRd = T3, mulhRs1 = T2, mulhRs2 = T1}, alu2Op = NopA, ctrlOp = NopC}	
 128 5 42 0
-232:	Isa {memOp = NopM, alu1Op = NopA, alu2Op = NopA, ctrlOp = Bnez {bnezRs1 = T3, bnezK = 44}}	
+256:	Isa {memOp = NopM, alu1Op = NopA, alu2Op = NopA, ctrlOp = Bnez {bnezRs1 = T3, bnezK = 56}}	
 128 5 42 0
-243:	Isa {memOp = NopM, alu1Op = Mul {mulRd = T2, mulRs1 = T2, mulRs2 = T1}, alu2Op = NopA, ctrlOp = NopC}	
+270:	Isa {memOp = NopM, alu1Op = Mul {mulRd = T2, mulRs1 = T2, mulRs2 = T1}, alu2Op = NopA, ctrlOp = NopC}	
 128 5 210 0
-254:	Isa {memOp = NopM, alu1Op = Addi {addiRd = T1, addiRs1 = T1, addiK = -1}, alu2Op = NopA, ctrlOp = NopC}	
+284:	Isa {memOp = NopM, alu1Op = Addi {addiRd = T1, addiRs1 = T1, addiK = -1}, alu2Op = NopA, ctrlOp = NopC}	
 128 4 210 0
-265:	Isa {memOp = NopM, alu1Op = NopA, alu2Op = NopA, ctrlOp = J {jK = -55}}	
+298:	Isa {memOp = NopM, alu1Op = NopA, alu2Op = NopA, ctrlOp = J {jK = -70}}	
 128 4 210 0
-210:	Isa {memOp = NopM, alu1Op = NopA, alu2Op = NopA, ctrlOp = Beqz {beqzRs1 = T1, beqzK = 209}}	@factorial_while
+228:	Isa {memOp = NopM, alu1Op = NopA, alu2Op = NopA, ctrlOp = Beqz {beqzRs1 = T1, beqzK = 266}}	@factorial_while
 128 4 210 0
-221:	Isa {memOp = NopM, alu1Op = Mulh {mulhRd = T3, mulhRs1 = T2, mulhRs2 = T1}, alu2Op = NopA, ctrlOp = NopC}	
+242:	Isa {memOp = NopM, alu1Op = Mulh {mulhRd = T3, mulhRs1 = T2, mulhRs2 = T1}, alu2Op = NopA, ctrlOp = NopC}	
 128 4 210 0
-232:	Isa {memOp = NopM, alu1Op = NopA, alu2Op = NopA, ctrlOp = Bnez {bnezRs1 = T3, bnezK = 44}}	
+256:	Isa {memOp = NopM, alu1Op = NopA, alu2Op = NopA, ctrlOp = Bnez {bnezRs1 = T3, bnezK = 56}}	
 128 4 210 0
-243:	Isa {memOp = NopM, alu1Op = Mul {mulRd = T2, mulRs1 = T2, mulRs2 = T1}, alu2Op = NopA, ctrlOp = NopC}	
+270:	Isa {memOp = NopM, alu1Op = Mul {mulRd = T2, mulRs1 = T2, mulRs2 = T1}, alu2Op = NopA, ctrlOp = NopC}	
 128 4 840 0
-254:	Isa {memOp = NopM, alu1Op = Addi {addiRd = T1, addiRs1 = T1, addiK = -1}, alu2Op = NopA, ctrlOp = NopC}	
+284:	Isa {memOp = NopM, alu1Op = Addi {addiRd = T1, addiRs1 = T1, addiK = -1}, alu2Op = NopA, ctrlOp = NopC}	
 128 3 840 0
-265:	Isa {memOp = NopM, alu1Op = NopA, alu2Op = NopA, ctrlOp = J {jK = -55}}	
+298:	Isa {memOp = NopM, alu1Op = NopA, alu2Op = NopA, ctrlOp = J {jK = -70}}	
 128 3 840 0
-210:	Isa {memOp = NopM, alu1Op = NopA, alu2Op = NopA, ctrlOp = Beqz {beqzRs1 = T1, beqzK = 209}}	@factorial_while
+228:	Isa {memOp = NopM, alu1Op = NopA, alu2Op = NopA, ctrlOp = Beqz {beqzRs1 = T1, beqzK = 266}}	@factorial_while
 128 3 840 0
-221:	Isa {memOp = NopM, alu1Op = Mulh {mulhRd = T3, mulhRs1 = T2, mulhRs2 = T1}, alu2Op = NopA, ctrlOp = NopC}	
+242:	Isa {memOp = NopM, alu1Op = Mulh {mulhRd = T3, mulhRs1 = T2, mulhRs2 = T1}, alu2Op = NopA, ctrlOp = NopC}	
 128 3 840 0
-232:	Isa {memOp = NopM, alu1Op = NopA, alu2Op = NopA, ctrlOp = Bnez {bnezRs1 = T3, bnezK = 44}}	
+256:	Isa {memOp = NopM, alu1Op = NopA, alu2Op = NopA, ctrlOp = Bnez {bnezRs1 = T3, bnezK = 56}}	
 128 3 840 0
-243:	Isa {memOp = NopM, alu1Op = Mul {mulRd = T2, mulRs1 = T2, mulRs2 = T1}, alu2Op = NopA, ctrlOp = NopC}	
+270:	Isa {memOp = NopM, alu1Op = Mul {mulRd = T2, mulRs1 = T2, mulRs2 = T1}, alu2Op = NopA, ctrlOp = NopC}	
 128 3 2520 0
-254:	Isa {memOp = NopM, alu1Op = Addi {addiRd = T1, addiRs1 = T1, addiK = -1}, alu2Op = NopA, ctrlOp = NopC}	
+284:	Isa {memOp = NopM, alu1Op = Addi {addiRd = T1, addiRs1 = T1, addiK = -1}, alu2Op = NopA, ctrlOp = NopC}	
 128 2 2520 0
-265:	Isa {memOp = NopM, alu1Op = NopA, alu2Op = NopA, ctrlOp = J {jK = -55}}	
+298:	Isa {memOp = NopM, alu1Op = NopA, alu2Op = NopA, ctrlOp = J {jK = -70}}	
 128 2 2520 0
-210:	Isa {memOp = NopM, alu1Op = NopA, alu2Op = NopA, ctrlOp = Beqz {beqzRs1 = T1, beqzK = 209}}	@factorial_while
+228:	Isa {memOp = NopM, alu1Op = NopA, alu2Op = NopA, ctrlOp = Beqz {beqzRs1 = T1, beqzK = 266}}	@factorial_while
 128 2 2520 0
-221:	Isa {memOp = NopM, alu1Op = Mulh {mulhRd = T3, mulhRs1 = T2, mulhRs2 = T1}, alu2Op = NopA, ctrlOp = NopC}	
+242:	Isa {memOp = NopM, alu1Op = Mulh {mulhRd = T3, mulhRs1 = T2, mulhRs2 = T1}, alu2Op = NopA, ctrlOp = NopC}	
 128 2 2520 0
-232:	Isa {memOp = NopM, alu1Op = NopA, alu2Op = NopA, ctrlOp = Bnez {bnezRs1 = T3, bnezK = 44}}	
+256:	Isa {memOp = NopM, alu1Op = NopA, alu2Op = NopA, ctrlOp = Bnez {bnezRs1 = T3, bnezK = 56}}	
 128 2 2520 0
-243:	Isa {memOp = NopM, alu1Op = Mul {mulRd = T2, mulRs1 = T2, mulRs2 = T1}, alu2Op = NopA, ctrlOp = NopC}	
+270:	Isa {memOp = NopM, alu1Op = Mul {mulRd = T2, mulRs1 = T2, mulRs2 = T1}, alu2Op = NopA, ctrlOp = NopC}	
 128 2 5040 0
-254:	Isa {memOp = NopM, alu1Op = Addi {addiRd = T1, addiRs1 = T1, addiK = -1}, alu2Op = NopA, ctrlOp = NopC}	
+284:	Isa {memOp = NopM, alu1Op = Addi {addiRd = T1, addiRs1 = T1, addiK = -1}, alu2Op = NopA, ctrlOp = NopC}	
 128 1 5040 0
-265:	Isa {memOp = NopM, alu1Op = NopA, alu2Op = NopA, ctrlOp = J {jK = -55}}	
+298:	Isa {memOp = NopM, alu1Op = NopA, alu2Op = NopA, ctrlOp = J {jK = -70}}	
 128 1 5040 0
-210:	Isa {memOp = NopM, alu1Op = NopA, alu2Op = NopA, ctrlOp = Beqz {beqzRs1 = T1, beqzK = 209}}	@factorial_while
+228:	Isa {memOp = NopM, alu1Op = NopA, alu2Op = NopA, ctrlOp = Beqz {beqzRs1 = T1, beqzK = 266}}	@factorial_while
 128 1 5040 0
-221:	Isa {memOp = NopM, alu1Op = Mulh {mulhRd = T3, mulhRs1 = T2, mulhRs2 = T1}, alu2Op = NopA, ctrlOp = NopC}	
+242:	Isa {memOp = NopM, alu1Op = Mulh {mulhRd = T3, mulhRs1 = T2, mulhRs2 = T1}, alu2Op = NopA, ctrlOp = NopC}	
 128 1 5040 0
-232:	Isa {memOp = NopM, alu1Op = NopA, alu2Op = NopA, ctrlOp = Bnez {bnezRs1 = T3, bnezK = 44}}	
+256:	Isa {memOp = NopM, alu1Op = NopA, alu2Op = NopA, ctrlOp = Bnez {bnezRs1 = T3, bnezK = 56}}	
 128 1 5040 0
-243:	Isa {memOp = NopM, alu1Op = Mul {mulRd = T2, mulRs1 = T2, mulRs2 = T1}, alu2Op = NopA, ctrlOp = NopC}	
+270:	Isa {memOp = NopM, alu1Op = Mul {mulRd = T2, mulRs1 = T2, mulRs2 = T1}, alu2Op = NopA, ctrlOp = NopC}	
 128 1 5040 0
-254:	Isa {memOp = NopM, alu1Op = Addi {addiRd = T1, addiRs1 = T1, addiK = -1}, alu2Op = NopA, ctrlOp = NopC}	
+284:	Isa {memOp = NopM, alu1Op = Addi {addiRd = T1, addiRs1 = T1, addiK = -1}, alu2Op = NopA, ctrlOp = NopC}	
 128 0 5040 0
-265:	Isa {memOp = NopM, alu1Op = NopA, alu2Op = NopA, ctrlOp = J {jK = -55}}	
+298:	Isa {memOp = NopM, alu1Op = NopA, alu2Op = NopA, ctrlOp = J {jK = -70}}	
 128 0 5040 0
-210:	Isa {memOp = NopM, alu1Op = NopA, alu2Op = NopA, ctrlOp = Beqz {beqzRs1 = T1, beqzK = 209}}	@factorial_while
+228:	Isa {memOp = NopM, alu1Op = NopA, alu2Op = NopA, ctrlOp = Beqz {beqzRs1 = T1, beqzK = 266}}	@factorial_while
 128 0 5040 0
-419:	Isa {memOp = NopM, alu1Op = Lui {luiRd = T0, luiK = 0}, alu2Op = NopA, ctrlOp = NopC}	@factorial_end
+494:	Isa {memOp = NopM, alu1Op = Lui {luiRd = T0, luiK = 0}, alu2Op = NopA, ctrlOp = NopC}	@factorial_end
 0 0 5040 0
-430:	Isa {memOp = NopM, alu1Op = Addi {addiRd = T0, addiRs1 = T0, addiK = 4}, alu2Op = NopA, ctrlOp = NopC}	
+508:	Isa {memOp = NopM, alu1Op = Addi {addiRd = T0, addiRs1 = T0, addiK = 4}, alu2Op = NopA, ctrlOp = NopC}	
 4 0 5040 0
-441:	Isa {memOp = Lw {lwRd = T0, lwOffsetRs1 = MemRef {mrOffset = 0, mrReg = T0}}, alu1Op = NopA, alu2Op = NopA, ctrlOp = NopC}	
+522:	Isa {memOp = Lw {lwRd = T0, lwOffsetRs1 = MemRef {mrOffset = 0, mrReg = T0}}, alu1Op = NopA, alu2Op = NopA, ctrlOp = NopC}	
 132 0 5040 0
-452:	Isa {memOp = Sw {swRs2 = T2, swOffsetRs1 = MemRef {mrOffset = 0, mrReg = T0}}, alu1Op = NopA, alu2Op = NopA, ctrlOp = NopC}	
+536:	Isa {memOp = Sw {swRs2 = T2, swOffsetRs1 = MemRef {mrOffset = 0, mrReg = T0}}, alu1Op = NopA, alu2Op = NopA, ctrlOp = NopC}	
 132 0 5040 0
-463:	Isa {memOp = NopM, alu1Op = NopA, alu2Op = NopA, ctrlOp = Halt}	@exit
+550:	Isa {memOp = NopM, alu1Op = NopA, alu2Op = NopA, ctrlOp = Halt}	@exit
 ---
 # result
 numio[0x80]: [] >>> []

--- a/test/golden/vliw-iv/factorial_rec_input_5.vliw-iv.result
+++ b/test/golden/vliw-iv/factorial_rec_input_5.vliw-iv.result
@@ -1,92 +1,92 @@
 ---
 # step-by-step
-[0, 0]       531@_start:	Isa {memOp = NopM, alu1Op = Lui {luiRd = T0, luiK = 0}, alu2Op = NopA, ctrlOp = NopC}
-[0, 0]       542:	Isa {memOp = NopM, alu1Op = Addi {addiRd = T0, addiRs1 = T0, addiK = 0}, alu2Op = NopA, ctrlOp = NopC}
-[0, 0]       553:	Isa {memOp = Lw {lwRd = T0, lwOffsetRs1 = MemRef {mrOffset = 0, mrReg = T0}}, alu1Op = NopA, alu2Op = NopA, ctrlOp = NopC}
-[0, 128]       564:	Isa {memOp = Lw {lwRd = A0, lwOffsetRs1 = MemRef {mrOffset = 0, mrReg = T0}}, alu1Op = NopA, alu2Op = NopA, ctrlOp = NopC}
-[5, 128]       575:	Isa {memOp = NopM, alu1Op = Addi {addiRd = A1, addiRs1 = Zero, addiK = 0}, alu2Op = NopA, ctrlOp = NopC}
-[5, 128]       586:	Isa {memOp = NopM, alu1Op = Lui {luiRd = Sp, luiK = 0}, alu2Op = NopA, ctrlOp = NopC}
-[5, 128]       597:	Isa {memOp = NopM, alu1Op = Addi {addiRd = Sp, addiRs1 = Sp, addiK = 1298}, alu2Op = NopA, ctrlOp = NopC}
-[5, 128]       608:	Isa {memOp = NopM, alu1Op = NopA, alu2Op = NopA, ctrlOp = Jal {jalRd = Ra, jalK = -352}}
+[0, 0]       606@_start:	Isa {memOp = NopM, alu1Op = Lui {luiRd = T0, luiK = 0}, alu2Op = NopA, ctrlOp = NopC}
+[0, 0]       620:	Isa {memOp = NopM, alu1Op = Addi {addiRd = T0, addiRs1 = T0, addiK = 0}, alu2Op = NopA, ctrlOp = NopC}
+[0, 0]       634:	Isa {memOp = Lw {lwRd = T0, lwOffsetRs1 = MemRef {mrOffset = 0, mrReg = T0}}, alu1Op = NopA, alu2Op = NopA, ctrlOp = NopC}
+[0, 128]       648:	Isa {memOp = Lw {lwRd = A0, lwOffsetRs1 = MemRef {mrOffset = 0, mrReg = T0}}, alu1Op = NopA, alu2Op = NopA, ctrlOp = NopC}
+[5, 128]       662:	Isa {memOp = NopM, alu1Op = Addi {addiRd = A1, addiRs1 = Zero, addiK = 0}, alu2Op = NopA, ctrlOp = NopC}
+[5, 128]       676:	Isa {memOp = NopM, alu1Op = Lui {luiRd = Sp, luiK = 0}, alu2Op = NopA, ctrlOp = NopC}
+[5, 128]       690:	Isa {memOp = NopM, alu1Op = Addi {addiRd = Sp, addiRs1 = Sp, addiK = 1298}, alu2Op = NopA, ctrlOp = NopC}
+[5, 128]       704:	Isa {memOp = NopM, alu1Op = NopA, alu2Op = NopA, ctrlOp = Jal {jalRd = Ra, jalK = -448}}
 [5, 128]       256@factorial:	Isa {memOp = NopM, alu1Op = Addi {addiRd = T0, addiRs1 = Zero, addiK = -1}, alu2Op = NopA, ctrlOp = NopC}
-[5, -1]       267:	Isa {memOp = NopM, alu1Op = NopA, alu2Op = NopA, ctrlOp = Ble {bleRs1 = A0, bleRs2 = T0, bleK = 198}}
-[5, -1]       278:	Isa {memOp = NopM, alu1Op = Addi {addiRd = T0, addiRs1 = Zero, addiK = 1}, alu2Op = NopA, ctrlOp = NopC}
-[5, 1]       289:	Isa {memOp = NopM, alu1Op = NopA, alu2Op = NopA, ctrlOp = Ble {bleRs1 = A0, bleRs2 = T0, bleK = 154}}
-[5, 1]       300:	Isa {memOp = NopM, alu1Op = Addi {addiRd = Sp, addiRs1 = Sp, addiK = -8}, alu2Op = NopA, ctrlOp = NopC}
-[5, 1]       311:	Isa {memOp = Sw {swRs2 = Ra, swOffsetRs1 = MemRef {mrOffset = 4, mrReg = Sp}}, alu1Op = NopA, alu2Op = NopA, ctrlOp = NopC}
-[5, 1]       322:	Isa {memOp = Sw {swRs2 = A0, swOffsetRs1 = MemRef {mrOffset = 0, mrReg = Sp}}, alu1Op = NopA, alu2Op = NopA, ctrlOp = NopC}
-[5, 1]       333:	Isa {memOp = NopM, alu1Op = Addi {addiRd = A0, addiRs1 = A0, addiK = -1}, alu2Op = NopA, ctrlOp = NopC}
-[4, 1]       344:	Isa {memOp = NopM, alu1Op = NopA, alu2Op = NopA, ctrlOp = Jal {jalRd = Ra, jalK = -88}}
+[5, -1]       270:	Isa {memOp = NopM, alu1Op = NopA, alu2Op = NopA, ctrlOp = Ble {bleRs1 = A0, bleRs2 = T0, bleK = 252}}
+[5, -1]       284:	Isa {memOp = NopM, alu1Op = Addi {addiRd = T0, addiRs1 = Zero, addiK = 1}, alu2Op = NopA, ctrlOp = NopC}
+[5, 1]       298:	Isa {memOp = NopM, alu1Op = NopA, alu2Op = NopA, ctrlOp = Ble {bleRs1 = A0, bleRs2 = T0, bleK = 196}}
+[5, 1]       312:	Isa {memOp = NopM, alu1Op = Addi {addiRd = Sp, addiRs1 = Sp, addiK = -8}, alu2Op = NopA, ctrlOp = NopC}
+[5, 1]       326:	Isa {memOp = Sw {swRs2 = Ra, swOffsetRs1 = MemRef {mrOffset = 4, mrReg = Sp}}, alu1Op = NopA, alu2Op = NopA, ctrlOp = NopC}
+[5, 1]       340:	Isa {memOp = Sw {swRs2 = A0, swOffsetRs1 = MemRef {mrOffset = 0, mrReg = Sp}}, alu1Op = NopA, alu2Op = NopA, ctrlOp = NopC}
+[5, 1]       354:	Isa {memOp = NopM, alu1Op = Addi {addiRd = A0, addiRs1 = A0, addiK = -1}, alu2Op = NopA, ctrlOp = NopC}
+[4, 1]       368:	Isa {memOp = NopM, alu1Op = NopA, alu2Op = NopA, ctrlOp = Jal {jalRd = Ra, jalK = -112}}
 [4, 1]       256@factorial:	Isa {memOp = NopM, alu1Op = Addi {addiRd = T0, addiRs1 = Zero, addiK = -1}, alu2Op = NopA, ctrlOp = NopC}
-[4, -1]       267:	Isa {memOp = NopM, alu1Op = NopA, alu2Op = NopA, ctrlOp = Ble {bleRs1 = A0, bleRs2 = T0, bleK = 198}}
-[4, -1]       278:	Isa {memOp = NopM, alu1Op = Addi {addiRd = T0, addiRs1 = Zero, addiK = 1}, alu2Op = NopA, ctrlOp = NopC}
-[4, 1]       289:	Isa {memOp = NopM, alu1Op = NopA, alu2Op = NopA, ctrlOp = Ble {bleRs1 = A0, bleRs2 = T0, bleK = 154}}
-[4, 1]       300:	Isa {memOp = NopM, alu1Op = Addi {addiRd = Sp, addiRs1 = Sp, addiK = -8}, alu2Op = NopA, ctrlOp = NopC}
-[4, 1]       311:	Isa {memOp = Sw {swRs2 = Ra, swOffsetRs1 = MemRef {mrOffset = 4, mrReg = Sp}}, alu1Op = NopA, alu2Op = NopA, ctrlOp = NopC}
-[4, 1]       322:	Isa {memOp = Sw {swRs2 = A0, swOffsetRs1 = MemRef {mrOffset = 0, mrReg = Sp}}, alu1Op = NopA, alu2Op = NopA, ctrlOp = NopC}
-[4, 1]       333:	Isa {memOp = NopM, alu1Op = Addi {addiRd = A0, addiRs1 = A0, addiK = -1}, alu2Op = NopA, ctrlOp = NopC}
-[3, 1]       344:	Isa {memOp = NopM, alu1Op = NopA, alu2Op = NopA, ctrlOp = Jal {jalRd = Ra, jalK = -88}}
+[4, -1]       270:	Isa {memOp = NopM, alu1Op = NopA, alu2Op = NopA, ctrlOp = Ble {bleRs1 = A0, bleRs2 = T0, bleK = 252}}
+[4, -1]       284:	Isa {memOp = NopM, alu1Op = Addi {addiRd = T0, addiRs1 = Zero, addiK = 1}, alu2Op = NopA, ctrlOp = NopC}
+[4, 1]       298:	Isa {memOp = NopM, alu1Op = NopA, alu2Op = NopA, ctrlOp = Ble {bleRs1 = A0, bleRs2 = T0, bleK = 196}}
+[4, 1]       312:	Isa {memOp = NopM, alu1Op = Addi {addiRd = Sp, addiRs1 = Sp, addiK = -8}, alu2Op = NopA, ctrlOp = NopC}
+[4, 1]       326:	Isa {memOp = Sw {swRs2 = Ra, swOffsetRs1 = MemRef {mrOffset = 4, mrReg = Sp}}, alu1Op = NopA, alu2Op = NopA, ctrlOp = NopC}
+[4, 1]       340:	Isa {memOp = Sw {swRs2 = A0, swOffsetRs1 = MemRef {mrOffset = 0, mrReg = Sp}}, alu1Op = NopA, alu2Op = NopA, ctrlOp = NopC}
+[4, 1]       354:	Isa {memOp = NopM, alu1Op = Addi {addiRd = A0, addiRs1 = A0, addiK = -1}, alu2Op = NopA, ctrlOp = NopC}
+[3, 1]       368:	Isa {memOp = NopM, alu1Op = NopA, alu2Op = NopA, ctrlOp = Jal {jalRd = Ra, jalK = -112}}
 [3, 1]       256@factorial:	Isa {memOp = NopM, alu1Op = Addi {addiRd = T0, addiRs1 = Zero, addiK = -1}, alu2Op = NopA, ctrlOp = NopC}
-[3, -1]       267:	Isa {memOp = NopM, alu1Op = NopA, alu2Op = NopA, ctrlOp = Ble {bleRs1 = A0, bleRs2 = T0, bleK = 198}}
-[3, -1]       278:	Isa {memOp = NopM, alu1Op = Addi {addiRd = T0, addiRs1 = Zero, addiK = 1}, alu2Op = NopA, ctrlOp = NopC}
-[3, 1]       289:	Isa {memOp = NopM, alu1Op = NopA, alu2Op = NopA, ctrlOp = Ble {bleRs1 = A0, bleRs2 = T0, bleK = 154}}
-[3, 1]       300:	Isa {memOp = NopM, alu1Op = Addi {addiRd = Sp, addiRs1 = Sp, addiK = -8}, alu2Op = NopA, ctrlOp = NopC}
-[3, 1]       311:	Isa {memOp = Sw {swRs2 = Ra, swOffsetRs1 = MemRef {mrOffset = 4, mrReg = Sp}}, alu1Op = NopA, alu2Op = NopA, ctrlOp = NopC}
-[3, 1]       322:	Isa {memOp = Sw {swRs2 = A0, swOffsetRs1 = MemRef {mrOffset = 0, mrReg = Sp}}, alu1Op = NopA, alu2Op = NopA, ctrlOp = NopC}
-[3, 1]       333:	Isa {memOp = NopM, alu1Op = Addi {addiRd = A0, addiRs1 = A0, addiK = -1}, alu2Op = NopA, ctrlOp = NopC}
-[2, 1]       344:	Isa {memOp = NopM, alu1Op = NopA, alu2Op = NopA, ctrlOp = Jal {jalRd = Ra, jalK = -88}}
+[3, -1]       270:	Isa {memOp = NopM, alu1Op = NopA, alu2Op = NopA, ctrlOp = Ble {bleRs1 = A0, bleRs2 = T0, bleK = 252}}
+[3, -1]       284:	Isa {memOp = NopM, alu1Op = Addi {addiRd = T0, addiRs1 = Zero, addiK = 1}, alu2Op = NopA, ctrlOp = NopC}
+[3, 1]       298:	Isa {memOp = NopM, alu1Op = NopA, alu2Op = NopA, ctrlOp = Ble {bleRs1 = A0, bleRs2 = T0, bleK = 196}}
+[3, 1]       312:	Isa {memOp = NopM, alu1Op = Addi {addiRd = Sp, addiRs1 = Sp, addiK = -8}, alu2Op = NopA, ctrlOp = NopC}
+[3, 1]       326:	Isa {memOp = Sw {swRs2 = Ra, swOffsetRs1 = MemRef {mrOffset = 4, mrReg = Sp}}, alu1Op = NopA, alu2Op = NopA, ctrlOp = NopC}
+[3, 1]       340:	Isa {memOp = Sw {swRs2 = A0, swOffsetRs1 = MemRef {mrOffset = 0, mrReg = Sp}}, alu1Op = NopA, alu2Op = NopA, ctrlOp = NopC}
+[3, 1]       354:	Isa {memOp = NopM, alu1Op = Addi {addiRd = A0, addiRs1 = A0, addiK = -1}, alu2Op = NopA, ctrlOp = NopC}
+[2, 1]       368:	Isa {memOp = NopM, alu1Op = NopA, alu2Op = NopA, ctrlOp = Jal {jalRd = Ra, jalK = -112}}
 [2, 1]       256@factorial:	Isa {memOp = NopM, alu1Op = Addi {addiRd = T0, addiRs1 = Zero, addiK = -1}, alu2Op = NopA, ctrlOp = NopC}
-[2, -1]       267:	Isa {memOp = NopM, alu1Op = NopA, alu2Op = NopA, ctrlOp = Ble {bleRs1 = A0, bleRs2 = T0, bleK = 198}}
-[2, -1]       278:	Isa {memOp = NopM, alu1Op = Addi {addiRd = T0, addiRs1 = Zero, addiK = 1}, alu2Op = NopA, ctrlOp = NopC}
-[2, 1]       289:	Isa {memOp = NopM, alu1Op = NopA, alu2Op = NopA, ctrlOp = Ble {bleRs1 = A0, bleRs2 = T0, bleK = 154}}
-[2, 1]       300:	Isa {memOp = NopM, alu1Op = Addi {addiRd = Sp, addiRs1 = Sp, addiK = -8}, alu2Op = NopA, ctrlOp = NopC}
-[2, 1]       311:	Isa {memOp = Sw {swRs2 = Ra, swOffsetRs1 = MemRef {mrOffset = 4, mrReg = Sp}}, alu1Op = NopA, alu2Op = NopA, ctrlOp = NopC}
-[2, 1]       322:	Isa {memOp = Sw {swRs2 = A0, swOffsetRs1 = MemRef {mrOffset = 0, mrReg = Sp}}, alu1Op = NopA, alu2Op = NopA, ctrlOp = NopC}
-[2, 1]       333:	Isa {memOp = NopM, alu1Op = Addi {addiRd = A0, addiRs1 = A0, addiK = -1}, alu2Op = NopA, ctrlOp = NopC}
-[1, 1]       344:	Isa {memOp = NopM, alu1Op = NopA, alu2Op = NopA, ctrlOp = Jal {jalRd = Ra, jalK = -88}}
+[2, -1]       270:	Isa {memOp = NopM, alu1Op = NopA, alu2Op = NopA, ctrlOp = Ble {bleRs1 = A0, bleRs2 = T0, bleK = 252}}
+[2, -1]       284:	Isa {memOp = NopM, alu1Op = Addi {addiRd = T0, addiRs1 = Zero, addiK = 1}, alu2Op = NopA, ctrlOp = NopC}
+[2, 1]       298:	Isa {memOp = NopM, alu1Op = NopA, alu2Op = NopA, ctrlOp = Ble {bleRs1 = A0, bleRs2 = T0, bleK = 196}}
+[2, 1]       312:	Isa {memOp = NopM, alu1Op = Addi {addiRd = Sp, addiRs1 = Sp, addiK = -8}, alu2Op = NopA, ctrlOp = NopC}
+[2, 1]       326:	Isa {memOp = Sw {swRs2 = Ra, swOffsetRs1 = MemRef {mrOffset = 4, mrReg = Sp}}, alu1Op = NopA, alu2Op = NopA, ctrlOp = NopC}
+[2, 1]       340:	Isa {memOp = Sw {swRs2 = A0, swOffsetRs1 = MemRef {mrOffset = 0, mrReg = Sp}}, alu1Op = NopA, alu2Op = NopA, ctrlOp = NopC}
+[2, 1]       354:	Isa {memOp = NopM, alu1Op = Addi {addiRd = A0, addiRs1 = A0, addiK = -1}, alu2Op = NopA, ctrlOp = NopC}
+[1, 1]       368:	Isa {memOp = NopM, alu1Op = NopA, alu2Op = NopA, ctrlOp = Jal {jalRd = Ra, jalK = -112}}
 [1, 1]       256@factorial:	Isa {memOp = NopM, alu1Op = Addi {addiRd = T0, addiRs1 = Zero, addiK = -1}, alu2Op = NopA, ctrlOp = NopC}
-[1, -1]       267:	Isa {memOp = NopM, alu1Op = NopA, alu2Op = NopA, ctrlOp = Ble {bleRs1 = A0, bleRs2 = T0, bleK = 198}}
-[1, -1]       278:	Isa {memOp = NopM, alu1Op = Addi {addiRd = T0, addiRs1 = Zero, addiK = 1}, alu2Op = NopA, ctrlOp = NopC}
-[1, 1]       289:	Isa {memOp = NopM, alu1Op = NopA, alu2Op = NopA, ctrlOp = Ble {bleRs1 = A0, bleRs2 = T0, bleK = 154}}
-[1, 1]       443@factorial_return_one:	Isa {memOp = NopM, alu1Op = Addi {addiRd = A0, addiRs1 = Zero, addiK = 1}, alu2Op = NopA, ctrlOp = NopC}
-[1, 1]       454:	Isa {memOp = NopM, alu1Op = NopA, alu2Op = NopA, ctrlOp = Jr {jrRs = Ra}}
-[1, 1]       355:	Isa {memOp = Lw {lwRd = T1, lwOffsetRs1 = MemRef {mrOffset = 0, mrReg = Sp}}, alu1Op = NopA, alu2Op = NopA, ctrlOp = NopC}
-[1, 1]       366:	Isa {memOp = Lw {lwRd = Ra, lwOffsetRs1 = MemRef {mrOffset = 4, mrReg = Sp}}, alu1Op = NopA, alu2Op = NopA, ctrlOp = NopC}
-[1, 1]       377:	Isa {memOp = NopM, alu1Op = Addi {addiRd = Sp, addiRs1 = Sp, addiK = 8}, alu2Op = NopA, ctrlOp = NopC}
-[1, 1]       388:	Isa {memOp = NopM, alu1Op = NopA, alu2Op = NopA, ctrlOp = Bgt {bgtRs1 = A1, bgtRs2 = Zero, bgtK = 99}}
-[1, 1]       399:	Isa {memOp = NopM, alu1Op = Mulh {mulhRd = T3, mulhRs1 = A0, mulhRs2 = T1}, alu2Op = NopA, ctrlOp = NopC}
-[1, 1]       410:	Isa {memOp = NopM, alu1Op = NopA, alu2Op = NopA, ctrlOp = Bnez {bnezRs1 = T3, bnezK = 77}}
-[1, 1]       421:	Isa {memOp = NopM, alu1Op = Mul {mulRd = A0, mulRs1 = A0, mulRs2 = T1}, alu2Op = NopA, ctrlOp = NopC}
-[2, 1]       432:	Isa {memOp = NopM, alu1Op = NopA, alu2Op = NopA, ctrlOp = Jr {jrRs = Ra}}
-[2, 1]       355:	Isa {memOp = Lw {lwRd = T1, lwOffsetRs1 = MemRef {mrOffset = 0, mrReg = Sp}}, alu1Op = NopA, alu2Op = NopA, ctrlOp = NopC}
-[2, 1]       366:	Isa {memOp = Lw {lwRd = Ra, lwOffsetRs1 = MemRef {mrOffset = 4, mrReg = Sp}}, alu1Op = NopA, alu2Op = NopA, ctrlOp = NopC}
-[2, 1]       377:	Isa {memOp = NopM, alu1Op = Addi {addiRd = Sp, addiRs1 = Sp, addiK = 8}, alu2Op = NopA, ctrlOp = NopC}
-[2, 1]       388:	Isa {memOp = NopM, alu1Op = NopA, alu2Op = NopA, ctrlOp = Bgt {bgtRs1 = A1, bgtRs2 = Zero, bgtK = 99}}
-[2, 1]       399:	Isa {memOp = NopM, alu1Op = Mulh {mulhRd = T3, mulhRs1 = A0, mulhRs2 = T1}, alu2Op = NopA, ctrlOp = NopC}
-[2, 1]       410:	Isa {memOp = NopM, alu1Op = NopA, alu2Op = NopA, ctrlOp = Bnez {bnezRs1 = T3, bnezK = 77}}
-[2, 1]       421:	Isa {memOp = NopM, alu1Op = Mul {mulRd = A0, mulRs1 = A0, mulRs2 = T1}, alu2Op = NopA, ctrlOp = NopC}
-[6, 1]       432:	Isa {memOp = NopM, alu1Op = NopA, alu2Op = NopA, ctrlOp = Jr {jrRs = Ra}}
-[6, 1]       355:	Isa {memOp = Lw {lwRd = T1, lwOffsetRs1 = MemRef {mrOffset = 0, mrReg = Sp}}, alu1Op = NopA, alu2Op = NopA, ctrlOp = NopC}
-[6, 1]       366:	Isa {memOp = Lw {lwRd = Ra, lwOffsetRs1 = MemRef {mrOffset = 4, mrReg = Sp}}, alu1Op = NopA, alu2Op = NopA, ctrlOp = NopC}
-[6, 1]       377:	Isa {memOp = NopM, alu1Op = Addi {addiRd = Sp, addiRs1 = Sp, addiK = 8}, alu2Op = NopA, ctrlOp = NopC}
-[6, 1]       388:	Isa {memOp = NopM, alu1Op = NopA, alu2Op = NopA, ctrlOp = Bgt {bgtRs1 = A1, bgtRs2 = Zero, bgtK = 99}}
-[6, 1]       399:	Isa {memOp = NopM, alu1Op = Mulh {mulhRd = T3, mulhRs1 = A0, mulhRs2 = T1}, alu2Op = NopA, ctrlOp = NopC}
-[6, 1]       410:	Isa {memOp = NopM, alu1Op = NopA, alu2Op = NopA, ctrlOp = Bnez {bnezRs1 = T3, bnezK = 77}}
-[6, 1]       421:	Isa {memOp = NopM, alu1Op = Mul {mulRd = A0, mulRs1 = A0, mulRs2 = T1}, alu2Op = NopA, ctrlOp = NopC}
-[24, 1]       432:	Isa {memOp = NopM, alu1Op = NopA, alu2Op = NopA, ctrlOp = Jr {jrRs = Ra}}
-[24, 1]       355:	Isa {memOp = Lw {lwRd = T1, lwOffsetRs1 = MemRef {mrOffset = 0, mrReg = Sp}}, alu1Op = NopA, alu2Op = NopA, ctrlOp = NopC}
-[24, 1]       366:	Isa {memOp = Lw {lwRd = Ra, lwOffsetRs1 = MemRef {mrOffset = 4, mrReg = Sp}}, alu1Op = NopA, alu2Op = NopA, ctrlOp = NopC}
-[24, 1]       377:	Isa {memOp = NopM, alu1Op = Addi {addiRd = Sp, addiRs1 = Sp, addiK = 8}, alu2Op = NopA, ctrlOp = NopC}
-[24, 1]       388:	Isa {memOp = NopM, alu1Op = NopA, alu2Op = NopA, ctrlOp = Bgt {bgtRs1 = A1, bgtRs2 = Zero, bgtK = 99}}
-[24, 1]       399:	Isa {memOp = NopM, alu1Op = Mulh {mulhRd = T3, mulhRs1 = A0, mulhRs2 = T1}, alu2Op = NopA, ctrlOp = NopC}
-[24, 1]       410:	Isa {memOp = NopM, alu1Op = NopA, alu2Op = NopA, ctrlOp = Bnez {bnezRs1 = T3, bnezK = 77}}
-[24, 1]       421:	Isa {memOp = NopM, alu1Op = Mul {mulRd = A0, mulRs1 = A0, mulRs2 = T1}, alu2Op = NopA, ctrlOp = NopC}
-[120, 1]       432:	Isa {memOp = NopM, alu1Op = NopA, alu2Op = NopA, ctrlOp = Jr {jrRs = Ra}}
-[120, 1]       619:	Isa {memOp = NopM, alu1Op = Lui {luiRd = T0, luiK = 0}, alu2Op = NopA, ctrlOp = NopC}
-[120, 0]       630:	Isa {memOp = NopM, alu1Op = Addi {addiRd = T0, addiRs1 = T0, addiK = 4}, alu2Op = NopA, ctrlOp = NopC}
-[120, 4]       641:	Isa {memOp = Lw {lwRd = T0, lwOffsetRs1 = MemRef {mrOffset = 0, mrReg = T0}}, alu1Op = NopA, alu2Op = NopA, ctrlOp = NopC}
-[120, 132]       652:	Isa {memOp = Sw {swRs2 = A0, swOffsetRs1 = MemRef {mrOffset = 0, mrReg = T0}}, alu1Op = NopA, alu2Op = NopA, ctrlOp = NopC}
-[120, 132]       663:	Isa {memOp = NopM, alu1Op = NopA, alu2Op = NopA, ctrlOp = Halt}
+[1, -1]       270:	Isa {memOp = NopM, alu1Op = NopA, alu2Op = NopA, ctrlOp = Ble {bleRs1 = A0, bleRs2 = T0, bleK = 252}}
+[1, -1]       284:	Isa {memOp = NopM, alu1Op = Addi {addiRd = T0, addiRs1 = Zero, addiK = 1}, alu2Op = NopA, ctrlOp = NopC}
+[1, 1]       298:	Isa {memOp = NopM, alu1Op = NopA, alu2Op = NopA, ctrlOp = Ble {bleRs1 = A0, bleRs2 = T0, bleK = 196}}
+[1, 1]       494@factorial_return_one:	Isa {memOp = NopM, alu1Op = Addi {addiRd = A0, addiRs1 = Zero, addiK = 1}, alu2Op = NopA, ctrlOp = NopC}
+[1, 1]       508:	Isa {memOp = NopM, alu1Op = NopA, alu2Op = NopA, ctrlOp = Jr {jrRs = Ra}}
+[1, 1]       382:	Isa {memOp = Lw {lwRd = T1, lwOffsetRs1 = MemRef {mrOffset = 0, mrReg = Sp}}, alu1Op = NopA, alu2Op = NopA, ctrlOp = NopC}
+[1, 1]       396:	Isa {memOp = Lw {lwRd = Ra, lwOffsetRs1 = MemRef {mrOffset = 4, mrReg = Sp}}, alu1Op = NopA, alu2Op = NopA, ctrlOp = NopC}
+[1, 1]       410:	Isa {memOp = NopM, alu1Op = Addi {addiRd = Sp, addiRs1 = Sp, addiK = 8}, alu2Op = NopA, ctrlOp = NopC}
+[1, 1]       424:	Isa {memOp = NopM, alu1Op = NopA, alu2Op = NopA, ctrlOp = Bgt {bgtRs1 = A1, bgtRs2 = Zero, bgtK = 126}}
+[1, 1]       438:	Isa {memOp = NopM, alu1Op = Mulh {mulhRd = T3, mulhRs1 = A0, mulhRs2 = T1}, alu2Op = NopA, ctrlOp = NopC}
+[1, 1]       452:	Isa {memOp = NopM, alu1Op = NopA, alu2Op = NopA, ctrlOp = Bnez {bnezRs1 = T3, bnezK = 98}}
+[1, 1]       466:	Isa {memOp = NopM, alu1Op = Mul {mulRd = A0, mulRs1 = A0, mulRs2 = T1}, alu2Op = NopA, ctrlOp = NopC}
+[2, 1]       480:	Isa {memOp = NopM, alu1Op = NopA, alu2Op = NopA, ctrlOp = Jr {jrRs = Ra}}
+[2, 1]       382:	Isa {memOp = Lw {lwRd = T1, lwOffsetRs1 = MemRef {mrOffset = 0, mrReg = Sp}}, alu1Op = NopA, alu2Op = NopA, ctrlOp = NopC}
+[2, 1]       396:	Isa {memOp = Lw {lwRd = Ra, lwOffsetRs1 = MemRef {mrOffset = 4, mrReg = Sp}}, alu1Op = NopA, alu2Op = NopA, ctrlOp = NopC}
+[2, 1]       410:	Isa {memOp = NopM, alu1Op = Addi {addiRd = Sp, addiRs1 = Sp, addiK = 8}, alu2Op = NopA, ctrlOp = NopC}
+[2, 1]       424:	Isa {memOp = NopM, alu1Op = NopA, alu2Op = NopA, ctrlOp = Bgt {bgtRs1 = A1, bgtRs2 = Zero, bgtK = 126}}
+[2, 1]       438:	Isa {memOp = NopM, alu1Op = Mulh {mulhRd = T3, mulhRs1 = A0, mulhRs2 = T1}, alu2Op = NopA, ctrlOp = NopC}
+[2, 1]       452:	Isa {memOp = NopM, alu1Op = NopA, alu2Op = NopA, ctrlOp = Bnez {bnezRs1 = T3, bnezK = 98}}
+[2, 1]       466:	Isa {memOp = NopM, alu1Op = Mul {mulRd = A0, mulRs1 = A0, mulRs2 = T1}, alu2Op = NopA, ctrlOp = NopC}
+[6, 1]       480:	Isa {memOp = NopM, alu1Op = NopA, alu2Op = NopA, ctrlOp = Jr {jrRs = Ra}}
+[6, 1]       382:	Isa {memOp = Lw {lwRd = T1, lwOffsetRs1 = MemRef {mrOffset = 0, mrReg = Sp}}, alu1Op = NopA, alu2Op = NopA, ctrlOp = NopC}
+[6, 1]       396:	Isa {memOp = Lw {lwRd = Ra, lwOffsetRs1 = MemRef {mrOffset = 4, mrReg = Sp}}, alu1Op = NopA, alu2Op = NopA, ctrlOp = NopC}
+[6, 1]       410:	Isa {memOp = NopM, alu1Op = Addi {addiRd = Sp, addiRs1 = Sp, addiK = 8}, alu2Op = NopA, ctrlOp = NopC}
+[6, 1]       424:	Isa {memOp = NopM, alu1Op = NopA, alu2Op = NopA, ctrlOp = Bgt {bgtRs1 = A1, bgtRs2 = Zero, bgtK = 126}}
+[6, 1]       438:	Isa {memOp = NopM, alu1Op = Mulh {mulhRd = T3, mulhRs1 = A0, mulhRs2 = T1}, alu2Op = NopA, ctrlOp = NopC}
+[6, 1]       452:	Isa {memOp = NopM, alu1Op = NopA, alu2Op = NopA, ctrlOp = Bnez {bnezRs1 = T3, bnezK = 98}}
+[6, 1]       466:	Isa {memOp = NopM, alu1Op = Mul {mulRd = A0, mulRs1 = A0, mulRs2 = T1}, alu2Op = NopA, ctrlOp = NopC}
+[24, 1]       480:	Isa {memOp = NopM, alu1Op = NopA, alu2Op = NopA, ctrlOp = Jr {jrRs = Ra}}
+[24, 1]       382:	Isa {memOp = Lw {lwRd = T1, lwOffsetRs1 = MemRef {mrOffset = 0, mrReg = Sp}}, alu1Op = NopA, alu2Op = NopA, ctrlOp = NopC}
+[24, 1]       396:	Isa {memOp = Lw {lwRd = Ra, lwOffsetRs1 = MemRef {mrOffset = 4, mrReg = Sp}}, alu1Op = NopA, alu2Op = NopA, ctrlOp = NopC}
+[24, 1]       410:	Isa {memOp = NopM, alu1Op = Addi {addiRd = Sp, addiRs1 = Sp, addiK = 8}, alu2Op = NopA, ctrlOp = NopC}
+[24, 1]       424:	Isa {memOp = NopM, alu1Op = NopA, alu2Op = NopA, ctrlOp = Bgt {bgtRs1 = A1, bgtRs2 = Zero, bgtK = 126}}
+[24, 1]       438:	Isa {memOp = NopM, alu1Op = Mulh {mulhRd = T3, mulhRs1 = A0, mulhRs2 = T1}, alu2Op = NopA, ctrlOp = NopC}
+[24, 1]       452:	Isa {memOp = NopM, alu1Op = NopA, alu2Op = NopA, ctrlOp = Bnez {bnezRs1 = T3, bnezK = 98}}
+[24, 1]       466:	Isa {memOp = NopM, alu1Op = Mul {mulRd = A0, mulRs1 = A0, mulRs2 = T1}, alu2Op = NopA, ctrlOp = NopC}
+[120, 1]       480:	Isa {memOp = NopM, alu1Op = NopA, alu2Op = NopA, ctrlOp = Jr {jrRs = Ra}}
+[120, 1]       718:	Isa {memOp = NopM, alu1Op = Lui {luiRd = T0, luiK = 0}, alu2Op = NopA, ctrlOp = NopC}
+[120, 0]       732:	Isa {memOp = NopM, alu1Op = Addi {addiRd = T0, addiRs1 = T0, addiK = 4}, alu2Op = NopA, ctrlOp = NopC}
+[120, 4]       746:	Isa {memOp = Lw {lwRd = T0, lwOffsetRs1 = MemRef {mrOffset = 0, mrReg = T0}}, alu1Op = NopA, alu2Op = NopA, ctrlOp = NopC}
+[120, 132]       760:	Isa {memOp = Sw {swRs2 = A0, swOffsetRs1 = MemRef {mrOffset = 0, mrReg = T0}}, alu1Op = NopA, alu2Op = NopA, ctrlOp = NopC}
+[120, 132]       774:	Isa {memOp = NopM, alu1Op = NopA, alu2Op = NopA, ctrlOp = Halt}
 ---
 # result
 numio[0x80]: [] >>> []

--- a/test/golden/vliw-iv/hello.s.vliw-iv.result
+++ b/test/golden/vliw-iv/hello.s.vliw-iv.result
@@ -1,16 +1,16 @@
 0:	buf
 17:	output_addr
 256:	_start
-289:	while
-311:	end
+298:	while
+326:	end
 ---
 mem[0..16]: 	1f 48 65 6c 6c 6f 0a 00 57 6f 72 6c 64 21 00 00 00	@"buf"
 mem[17..255]: 	84 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00	@"output_addr"
-mem[256..266]: 	Isa {memOp = NopM, alu1Op = Lui {luiRd = T0, luiK = 0}, alu2Op = NopA, ctrlOp = NopC} 	@_start
-mem[267..277]: 	Isa {memOp = NopM, alu1Op = Addi {addiRd = T0, addiRs1 = T0, addiK = 17}, alu2Op = NopA, ctrlOp = NopC}
-mem[278..288]: 	Isa {memOp = Lw {lwRd = T0, lwOffsetRs1 = MemRef {mrOffset = 0, mrReg = T0}}, alu1Op = Addi {addiRd = T1, addiRs1 = T1, addiK = 0}, alu2Op = Addi {addiRd = T3, addiRs1 = Zero, addiK = 14}, ctrlOp = NopC}
-mem[289..299]: 	Isa {memOp = Lw {lwRd = T2, lwOffsetRs1 = MemRef {mrOffset = 0, mrReg = T1}}, alu1Op = Addi {addiRd = T4, addiRs1 = T3, addiK = -1}, alu2Op = NopA, ctrlOp = Beqz {beqzRs1 = T3, beqzK = 22}} 	@while
-mem[300..310]: 	Isa {memOp = Sb {sbRs2 = T2, sbOffsetRs1 = MemRef {mrOffset = 0, mrReg = T0}}, alu1Op = Mv {mvRd = T3, mvRs = T4}, alu2Op = Addi {addiRd = T1, addiRs1 = T1, addiK = 1}, ctrlOp = J {jK = -11}}
-mem[311..321]: 	Isa {memOp = NopM, alu1Op = NopA, alu2Op = NopA, ctrlOp = Halt} 	@end
-mem[322..999]: 	( 00 )
+mem[256..269]: 	Isa {memOp = NopM, alu1Op = Lui {luiRd = T0, luiK = 0}, alu2Op = NopA, ctrlOp = NopC} 	@_start
+mem[270..283]: 	Isa {memOp = NopM, alu1Op = Addi {addiRd = T0, addiRs1 = T0, addiK = 17}, alu2Op = NopA, ctrlOp = NopC}
+mem[284..297]: 	Isa {memOp = Lw {lwRd = T0, lwOffsetRs1 = MemRef {mrOffset = 0, mrReg = T0}}, alu1Op = Addi {addiRd = T1, addiRs1 = T1, addiK = 0}, alu2Op = Addi {addiRd = T3, addiRs1 = Zero, addiK = 14}, ctrlOp = NopC}
+mem[298..311]: 	Isa {memOp = Lw {lwRd = T2, lwOffsetRs1 = MemRef {mrOffset = 0, mrReg = T1}}, alu1Op = Addi {addiRd = T4, addiRs1 = T3, addiK = -1}, alu2Op = NopA, ctrlOp = Beqz {beqzRs1 = T3, beqzK = 28}} 	@while
+mem[312..325]: 	Isa {memOp = Sb {sbRs2 = T2, sbOffsetRs1 = MemRef {mrOffset = 0, mrReg = T0}}, alu1Op = Mv {mvRd = T3, mvRs = T4}, alu2Op = Addi {addiRd = T1, addiRs1 = T1, addiK = 1}, ctrlOp = J {jK = -14}}
+mem[326..339]: 	Isa {memOp = NopM, alu1Op = NopA, alu2Op = NopA, ctrlOp = Halt} 	@end
+mem[340..999]: 	( 00 )
 ---

--- a/test/golden/vliw-iv/lui_addi.s.vliw-iv.result
+++ b/test/golden/vliw-iv/lui_addi.s.vliw-iv.result
@@ -1,9 +1,9 @@
 0:	_start
 ---
-mem[0..10]: 	Isa {memOp = NopM, alu1Op = Lui {luiRd = T1, luiK = 74565}, alu2Op = NopA, ctrlOp = NopC} 	@_start
-mem[11..21]: 	Isa {memOp = NopM, alu1Op = Addi {addiRd = T1, addiRs1 = T1, addiK = 1656}, alu2Op = NopA, ctrlOp = NopC}
-mem[22..32]: 	Isa {memOp = NopM, alu1Op = Lui {luiRd = T2, luiK = 74565}, alu2Op = NopA, ctrlOp = NopC}
-mem[33..43]: 	Isa {memOp = NopM, alu1Op = Addi {addiRd = T2, addiRs1 = T2, addiK = 1656}, alu2Op = NopA, ctrlOp = NopC}
-mem[44..54]: 	Isa {memOp = NopM, alu1Op = NopA, alu2Op = NopA, ctrlOp = Halt}
-mem[55..999]: 	( 00 )
+mem[0..13]: 	Isa {memOp = NopM, alu1Op = Lui {luiRd = T1, luiK = 74565}, alu2Op = NopA, ctrlOp = NopC} 	@_start
+mem[14..27]: 	Isa {memOp = NopM, alu1Op = Addi {addiRd = T1, addiRs1 = T1, addiK = 1656}, alu2Op = NopA, ctrlOp = NopC}
+mem[28..41]: 	Isa {memOp = NopM, alu1Op = Lui {luiRd = T2, luiK = 74565}, alu2Op = NopA, ctrlOp = NopC}
+mem[42..55]: 	Isa {memOp = NopM, alu1Op = Addi {addiRd = T2, addiRs1 = T2, addiK = 1656}, alu2Op = NopA, ctrlOp = NopC}
+mem[56..69]: 	Isa {memOp = NopM, alu1Op = NopA, alu2Op = NopA, ctrlOp = Halt}
+mem[70..999]: 	( 00 )
 ---

--- a/test/golden/vliw-iv/lui_addi.vliw-iv.result
+++ b/test/golden/vliw-iv/lui_addi.vliw-iv.result
@@ -1,10 +1,10 @@
 ---
 # Step-by-step
 0:	Isa {memOp = NopM, alu1Op = Lui {luiRd = T1, luiK = 74565}, alu2Op = NopA, ctrlOp = NopC}	0x00000000 0x00000000 0x00000000 0x00000000 @_start
-11:	Isa {memOp = NopM, alu1Op = Addi {addiRd = T1, addiRs1 = T1, addiK = 1656}, alu2Op = NopA, ctrlOp = NopC}	0x00000000 0x12345000 0x00000000 0x00000000 
-22:	Isa {memOp = NopM, alu1Op = Lui {luiRd = T2, luiK = 74565}, alu2Op = NopA, ctrlOp = NopC}	0x00000000 0x12345678 0x00000000 0x00000000 
-33:	Isa {memOp = NopM, alu1Op = Addi {addiRd = T2, addiRs1 = T2, addiK = 1656}, alu2Op = NopA, ctrlOp = NopC}	0x00000000 0x12345678 0x12345000 0x00000000 
-44:	Isa {memOp = NopM, alu1Op = NopA, alu2Op = NopA, ctrlOp = Halt}	0x00000000 0x12345678 0x12345678 0x00000000
+14:	Isa {memOp = NopM, alu1Op = Addi {addiRd = T1, addiRs1 = T1, addiK = 1656}, alu2Op = NopA, ctrlOp = NopC}	0x00000000 0x12345000 0x00000000 0x00000000 
+28:	Isa {memOp = NopM, alu1Op = Lui {luiRd = T2, luiK = 74565}, alu2Op = NopA, ctrlOp = NopC}	0x00000000 0x12345678 0x00000000 0x00000000 
+42:	Isa {memOp = NopM, alu1Op = Addi {addiRd = T2, addiRs1 = T2, addiK = 1656}, alu2Op = NopA, ctrlOp = NopC}	0x00000000 0x12345678 0x12345000 0x00000000 
+56:	Isa {memOp = NopM, alu1Op = NopA, alu2Op = NopA, ctrlOp = Halt}	0x00000000 0x12345678 0x12345678 0x00000000
 ---
 # Result
 4: 	InstructionPart

--- a/test/golden/vliw-iv/sb.vliw-iv.result
+++ b/test/golden/vliw-iv/sb.vliw-iv.result
@@ -1,12 +1,12 @@
 ---
 # Step-by-step
 256:	Isa {memOp = NopM, alu1Op = Lui {luiRd = T0, luiK = 0}, alu2Op = NopA, ctrlOp = NopC}	@_start buf_ptr=t0=0x00000000 char=t1=0x00000000
-267:	Isa {memOp = NopM, alu1Op = Addi {addiRd = T0, addiRs1 = T0, addiK = 0}, alu2Op = NopA, ctrlOp = NopC}	 buf_ptr=t0=0x00000000 char=t1=0x00000000
-278:	Isa {memOp = NopM, alu1Op = Lui {luiRd = T1, luiK = 0}, alu2Op = NopA, ctrlOp = NopC}	 buf_ptr=t0=0x00000000 char=t1=0x00000000
-289:	Isa {memOp = NopM, alu1Op = Addi {addiRd = T1, addiRs1 = T1, addiK = 4}, alu2Op = NopA, ctrlOp = NopC}	 buf_ptr=t0=0x00000000 char=t1=0x00000000
-300:	Isa {memOp = Lw {lwRd = T1, lwOffsetRs1 = MemRef {mrOffset = 0, mrReg = T1}}, alu1Op = NopA, alu2Op = NopA, ctrlOp = NopC}	 buf_ptr=t0=0x00000000 char=t1=0x00000004
-311:	Isa {memOp = Sb {sbRs2 = T1, sbOffsetRs1 = MemRef {mrOffset = 0, mrReg = T0}}, alu1Op = NopA, alu2Op = NopA, ctrlOp = NopC}	 buf_ptr=t0=0x00000000 char=t1=0x000000ff
-322:	Isa {memOp = NopM, alu1Op = NopA, alu2Op = NopA, ctrlOp = Halt}	 buf_ptr=t0=0x00000000 char=t1=0x000000ff
+270:	Isa {memOp = NopM, alu1Op = Addi {addiRd = T0, addiRs1 = T0, addiK = 0}, alu2Op = NopA, ctrlOp = NopC}	 buf_ptr=t0=0x00000000 char=t1=0x00000000
+284:	Isa {memOp = NopM, alu1Op = Lui {luiRd = T1, luiK = 0}, alu2Op = NopA, ctrlOp = NopC}	 buf_ptr=t0=0x00000000 char=t1=0x00000000
+298:	Isa {memOp = NopM, alu1Op = Addi {addiRd = T1, addiRs1 = T1, addiK = 4}, alu2Op = NopA, ctrlOp = NopC}	 buf_ptr=t0=0x00000000 char=t1=0x00000000
+312:	Isa {memOp = Lw {lwRd = T1, lwOffsetRs1 = MemRef {mrOffset = 0, mrReg = T1}}, alu1Op = NopA, alu2Op = NopA, ctrlOp = NopC}	 buf_ptr=t0=0x00000000 char=t1=0x00000004
+326:	Isa {memOp = Sb {sbRs2 = T1, sbOffsetRs1 = MemRef {mrOffset = 0, mrReg = T0}}, alu1Op = NopA, alu2Op = NopA, ctrlOp = NopC}	 buf_ptr=t0=0x00000000 char=t1=0x000000ff
+340:	Isa {memOp = NopM, alu1Op = NopA, alu2Op = NopA, ctrlOp = Halt}	 buf_ptr=t0=0x00000000 char=t1=0x000000ff
 ---
 # Check results
 mem[0..5]: 	ff 32 33 34 ff 00

--- a/wrench.cabal
+++ b/wrench.cabal
@@ -34,6 +34,7 @@ library
       Wrench.Machine
       Wrench.Machine.Memory
       Wrench.Machine.Types
+      Wrench.Machine.Word
       Wrench.Misc
       Wrench.Report
       Wrench.Translator
@@ -108,6 +109,7 @@ executable wrench
       Wrench.Machine
       Wrench.Machine.Memory
       Wrench.Machine.Types
+      Wrench.Machine.Word
       Wrench.Misc
       Wrench.Report
       Wrench.Translator


### PR DESCRIPTION
#163

## Problem
The documented VLIW-IV bundle format was internally inconsistent: "11 bytes (90-bit)" doesn't add up (11 B = 88 bits), and the per-slot fields (ALU 20-bit, etc.) were too small to actually hold their operands (`lui`/`addi`/branches overflowed). The simulator stored abstract operations and never honored the encoding, so the field widths were fiction.

## Changes
**New 112-bit / 14-byte bundle** — `[ALU1:32][ALU2:32][MEM:24][CTRL:24]`:
- Opcodes sized per slot (ALU 5, CTRL 4, MEM 3); every instruction's opcode + operands now fit its field.
- `byteSize` 11 → 14, with matching PC stride and `jal` return-address updates.

**Silent field truncation** — every immediate/offset is now reduced to its documented field width and sign-extended (addi/slti 17, mem 11, branches 10, beqz/bnez/jal 15, j 20); `lui` keeps its low 20 bits. `%hi`/`%lo` values still fit unchanged. No example program's behavior changed (all existing goldens held without `--accept`); added unit tests covering truncation.

**Refactor** — extracted the shared machine-word helpers (`signBitAnd`, `fitSigned`, `lShiftR`/`lShiftL`, `Ext`/`addExt`/`subExt`/`mulExt`) into a new `Wrench.Machine.Word` module. The module docs spell out the distinction between `signBitAnd` (sign-preserving truncation, used by RISC-V/Acc32 for unsigned low-bit immediates) and `fitSigned` (signed-field truncation, VLIW-IV).

## Docs
`docs/vliw-iv.md` updated with the new format, per-slot widths, and the truncation semantics.

## Tests
All 562 tests pass; vliw-iv golden results regenerated for the new bundle stride.