### PR TITLE
fix typo: f18a -> f32a in ISA list in variants generator

### DIFF
--- a/script/variants.py
+++ b/script/variants.py
@@ -222,7 +222,7 @@ def gen_variants(cases):
         inf_shuffle(categories["Bitwise Operations"]),
         inf_shuffle(categories["Complex Tasks"]),
         inf_shuffle(categories["Mathematics"]),
-        inf_shuffle(["acc32", "f18a", "m68k", "risc-iv"]),
+        inf_shuffle(["acc32", "f32a", "m68k", "risc-iv"]),
         inf_shuffle(categories["VLIW"]),
     ):
         yield fun_shuffle(e)


### PR DESCRIPTION
Currently scheme column is filled with the value f18a instead of f32a.

<img width="1174" height="1374" alt="image" src="https://github.com/user-attachments/assets/2094af6e-4701-43c6-b45f-c9d169441dcd" />
