### PR TITLE
Add pre-commit hooks for linting and fromatting

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,52 @@
+repos:
+  - repo: local
+    hooks:
+      # Lint
+      - id: lint-hs
+        name: Haskell linter
+        language: system
+        entry: bash -c 'make lint-hs FILES="$@"' --
+        types: [haskell]
+
+      - id: lint-py
+        name: Python linter
+        language: system
+        entry: bash -c 'make lint-py FILES="$@"' --
+        types: [python]
+
+      - id: typecheck-py
+        name: Python linter (typecheck)
+        language: system
+        entry: bash -c 'make typecheck-py FILES="$@"' --
+        types: [python]
+
+      - id: lint-html
+        name: HTML linter
+        language: system
+        entry: bash -c 'make lint-html FILES="$@"' --
+        types: [css, javascript, html]
+
+      # Format check
+      - id: format-check-hs
+        name: Haskell formatter
+        language: system
+        entry: bash -c 'make format-check-hs FILES="$@"' --
+        types: [haskell]
+
+      - id: format-check-py
+        name: Python formatter
+        language: system
+        entry: bash -c 'make format-check-py FILES="$@"' --
+        types: [python]
+
+      - id: format-check-html
+        name: HTML formatter
+        language: system
+        entry: bash -c 'make format-check-html FILES="$@"' --
+        types: [css, javascript, html]
+
+      - id: format-check-md
+        name: Markdown formatter
+        language: system
+        entry: bash -c 'make format-check-md FILES="$@"' --
+        types: [markdown]

--- a/Makefile
+++ b/Makefile
@@ -125,7 +125,7 @@ format-yaml:
 format-check: format-check-hs format-check-asm format-check-py format-check-html format-check-md
 
 format-check-hs:
-	fourmolu -m check $(HS_SRC_DIR)
+	fourmolu -m check $(if $(FILES),$(FILES),$(HS_SRC_DIR))
 
 format-check-asm: build-fmt
 	stack exec wrench-fmt -- --check --isa risc-iv-32 -v example/risc-iv-32/*.s test/golden/risc-iv-32/*.s
@@ -135,29 +135,29 @@ format-check-asm: build-fmt
 	stack exec wrench-fmt -- --check --isa vliw-iv    -v example/vliw-iv/*.s    test/golden/vliw-iv/*.s
 
 format-check-py:
-	ruff format --check script
+	ruff format --check $(if $(FILES),$(FILES),script)
 
 format-check-html:
-	npx @biomejs/biome format static/
+	npx @biomejs/biome format $(if $(FILES),$(FILES),static/)
 
 format-check-md:
-	markdownlint . .rules -c .markdownlint.yaml
+	markdownlint $(if $(FILES),$(FILES),. .rules) -c .markdownlint.yaml
 
 # Lint – check
 
 lint: lint-hs lint-py lint-html typecheck-py
 
 lint-hs:
-	hlint $(HS_SRC_DIR)
+	hlint $(if $(FILES),$(FILES),$(HS_SRC_DIR))
 
 lint-py:
-	ruff check script
+	ruff check $(if $(FILES),$(FILES),script)
 
 typecheck-py:
-	pyright
+	pyright $(FILES)
 
 lint-html:
-	npx @biomejs/biome lint static/
+	npx @biomejs/biome lint $(if $(FILES),$(FILES),static/)
 
 # Lint – fix
 

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@
         format-check format-check-hs format-check-asm format-check-py format-check-html format-check-md \
         lint lint-hs lint-py lint-html typecheck-py \
         lint-fix lint-fix-hs lint-fix-py \
+		setup-hooks \
         generate generate-variants generate-stack-deps \
         run-server \
         docker-build docker-push-builder docker-push-edge \
@@ -197,6 +198,9 @@ docker-run-server: docker-build
 	docker run -it --rm $(IMAGE_NAME) wrench-serv
 
 # Meta
+
+setup-hooks:
+	pre-commit install
 
 fix: lint-fix format generate test-accept test-examples test-server
 


### PR DESCRIPTION
## Why we should add it
The pre-commit hook automatically runs make for linting and formatting, so it doesn't need to be remembered or run manually.

This catches issues before they are pushed and reduces unnecessary force-pushes caused by fixing formatting or linting afterwards.

## What it looks like
Before every commit, all changed files are passed to the pre-commit hooks, and you will see something like this:
```text
Haskell linter.......................................(no files to check)Skipped
Python linter........................................(no files to check)Skipped
Python linter (typecheck)............................(no files to check)Skipped
HTML linter..............................................................Passed
Haskell formatter....................................(no files to check)Skipped
Python formatter.....................................(no files to check)Skipped
HTML formatter...........................................................Passed
Markdown formatter...................................(no files to check)Skipped
```

## How to install
1. Install the [pre-commit](https://pre-commit.com/) framework:
```bash
pip install pre-commit
```

2. Install the hooks:
```bash
pre-commit install
```
or
```bash
make setup-hooks
```